### PR TITLE
Restructure curriculum refs to use IDs instead of names

### DIFF
--- a/DESIGN/MIGRATION-GUIDE.md
+++ b/DESIGN/MIGRATION-GUIDE.md
@@ -1,8 +1,10 @@
-# Migration Guide: Stable Course IDs
+# Migration Guide: Stable Course IDs & Curriculum References
 
 ## Overview
 
-Every course now has a stable `id` field (kebab-case slug) that serves as its permanent identifier. The `name` field remains the human-readable display label and can be changed freely.
+Every course has a stable `id` field (kebab-case slug) that serves as its permanent identifier. The `name` field remains the human-readable display label and can be changed freely.
+
+Curriculum references now use IDs instead of names. This eliminates data duplication and ensures refs stay valid when courses are renamed.
 
 ## Rules
 
@@ -21,28 +23,70 @@ Every course now has a stable `id` field (kebab-case slug) that serves as its pe
 | File | Field | Notes |
 |---|---|---|
 | `courses.json` → courses[] | `id` | Primary definition |
-| `courses.json` → curricula[] → courses/groups | `id` on each courseRef | Links curriculum entries to courses |
+| `courses.json` → curricula[] → courses/groups | ID-based courseRef | Links curriculum entries to courses |
 | `outlines/manifest.json` | `id` on each entry | Links outline files to courses |
 | `courses.js` (generated) | `courseStatusMap` keyed by both `name` and `id` | Dual lookup |
+| `courses.js` (generated) | `curriculaData` with resolved refs | ID refs expanded to `{ name, id }` at build time |
 | `index.html` | `data-course-id` on nav items, `courseLookup` keyed by both | ID-first lookup with name fallback |
 | `status.html` | `membershipMap` keyed by `id` with name fallback | |
+
+## Curriculum course reference format
+
+Curriculum entries in `courses.json` reference courses using one of three formats:
+
+### Simple ref (most common)
+A plain ID string — used when no per-curriculum overrides are needed:
+```json
+"courses": ["linux-foundations", "comptia-network-plus"]
+```
+
+### Override ref
+An object with `id` plus per-curriculum overrides:
+```json
+"courses": [
+  { "id": "comptia-a-plus", "hoursOverride": 96 },
+  { "id": "java-language-fundamentals", "hoursOverride": 44, "note": "Reduced from 56h" }
+]
+```
+
+### Legacy name-only ref (deprecated)
+An object with `name` but no `id` — used for unresolved references that haven't been mapped to a course yet. These generate build warnings:
+```json
+"courses": [
+  { "name": "Network Fundamentals", "hoursOverride": 80 }
+]
+```
+
+### Build-time resolution
+The build process (`node build.js`) resolves ID refs into full objects in the generated `courses.js`. Simple string refs like `"linux-foundations"` become `{ "name": "Linux Foundations", "id": "linux-foundations" }`. This means the frontend always receives the same `{ name, id, hoursOverride?, note? }` shape regardless of which format is used in `courses.json`.
 
 ## How to rename a course
 
 1. Change the `name` field in `courses.json` (in the courses array)
-2. Update the `name` in any curricula courseRef entries (the `id` stays the same)
-3. Run `node build.js`
-4. The dashboard will show the new name everywhere
+2. Run `node build.js`
+3. The dashboard will show the new name everywhere
 
-You do **not** need to touch `outlines/manifest.json`, outline JSON files, or syllabus HTML files — they all reference by `id` or filename, not by display name.
+You do **not** need to update curriculum refs — they reference by ID, so renames propagate automatically at build time.
 
 ## How to add a new course
 
 1. Pick an ID: take the course name, lowercase it, replace spaces/special chars with hyphens
 2. Add the course to `courses.json` with the `id` as the first field
-3. If adding to a curriculum, include both `name` and `id` in the courseRef
+3. If adding to a curriculum, add the course ID as a string ref (or `{ "id": "...", "hoursOverride": N }` if overrides are needed)
 4. If creating an outline, add an entry to `outlines/manifest.json` with `file`, `course`, and `id`
 5. Run `node build.js`
+
+## How to add a course to a curriculum
+
+Use the course's `id` field. For a simple ref with no overrides:
+```json
+"courses": ["existing-course", "new-course-id"]
+```
+
+For a ref with per-curriculum hour override:
+```json
+"courses": [{ "id": "new-course-id", "hoursOverride": 40 }]
+```
 
 ## Schema
 
@@ -51,11 +95,11 @@ The formal JSON Schema definition is at `data/schema.json`. It defines:
 - Required course fields: `id`, `name`, `status`
 - Status enum values: "Not Started", "Scoping", "In Progress", "Needs Review", "In Review", "Complete"
 - Curriculum structure: either `groups` (with nested courseRefs) or flat `courses` array
-- CourseRef: `name` (required), `id` (recommended), `hoursOverride` (optional)
+- CourseRef formats: plain ID string, `{ id, hoursOverride?, note? }`, or legacy `{ name, hoursOverride?, note? }`
 
 ## Known data issues
 
-The Cloud Operations Specialist curriculum references 6 courses by names that don't match any course in the courses array ("Network Fundamentals", "Linux Fundamentals", etc.). These entries don't have IDs because there's no matching course to link to. This should be resolved by either adding those courses or correcting the names.
+The Cloud Operations Specialist curriculum has 6 legacy name-only refs that don't match any course in the system ("Network Fundamentals", "Linux Fundamentals", "Database Technologies", "Security Fundamentals", "Python Programming", "Cloud Essentials"). These are pending curriculum review — once the correct courses are identified, they should be migrated to ID-based refs.
 
 ---
 

--- a/courses.js
+++ b/courses.js
@@ -854,8 +854,8 @@ const curriculaData = [
         "courses": [
           {
             "name": "Helpdesk Software Fundamentals",
-            "hoursOverride": 13,
-            "id": "helpdesk-software-fundamentals"
+            "id": "helpdesk-software-fundamentals",
+            "hoursOverride": 13
           }
         ]
       }
@@ -905,18 +905,18 @@ const curriculaData = [
     "courses": [
       {
         "name": "IT Fundamentals",
-        "hoursOverride": 80,
-        "id": "it-fundamentals"
+        "id": "it-fundamentals",
+        "hoursOverride": 80
       },
       {
         "name": "Networking Fundamentals",
-        "hoursOverride": 220,
-        "id": "networking-fundamentals"
+        "id": "networking-fundamentals",
+        "hoursOverride": 220
       },
       {
         "name": "Security and Cybersecurity Fundamentals",
-        "hoursOverride": 220,
-        "id": "security-and-cybersecurity-fundamentals"
+        "id": "security-and-cybersecurity-fundamentals",
+        "hoursOverride": 220
       }
     ]
   },
@@ -1007,8 +1007,8 @@ const curriculaData = [
         "courses": [
           {
             "name": "CompTIA A+",
-            "hoursOverride": 96,
-            "id": "comptia-a-plus"
+            "id": "comptia-a-plus",
+            "hoursOverride": 96
           },
           {
             "name": "ITIL Foundations",
@@ -1035,9 +1035,9 @@ const curriculaData = [
           },
           {
             "name": "Java Language Fundamentals",
+            "id": "java-language-fundamentals",
             "hoursOverride": 44,
-            "note": "Reduced from 56h for this deployment",
-            "id": "java-language-fundamentals"
+            "note": "Reduced from 56h for this deployment"
           },
           {
             "name": "Web Development with JavaScript",

--- a/courses.json
+++ b/courses.json
@@ -841,10 +841,7 @@
           "name": "Foundational IT & Operations",
           "hours": 120,
           "courses": [
-            {
-              "name": "CompTIA A+",
-              "id": "comptia-a-plus"
-            }
+            "comptia-a-plus"
           ]
         },
         {
@@ -852,9 +849,8 @@
           "hours": 42,
           "courses": [
             {
-              "name": "Helpdesk Software Fundamentals",
-              "hoursOverride": 13,
-              "id": "helpdesk-software-fundamentals"
+              "id": "helpdesk-software-fundamentals",
+              "hoursOverride": 13
             }
           ]
         }
@@ -868,10 +864,7 @@
           "name": "Network Fundamentals",
           "hoursOverride": 80
         },
-        {
-          "name": "Introduction to GitHub",
-          "id": "introduction-to-github"
-        },
+        "introduction-to-github",
         {
           "name": "Linux Fundamentals",
           "hoursOverride": 72
@@ -892,10 +885,7 @@
           "name": "Cloud Essentials",
           "hoursOverride": 80
         },
-        {
-          "name": "Introduction to AWS Cloud Platform",
-          "id": "introduction-to-aws-cloud-platform"
-        }
+        "introduction-to-aws-cloud-platform"
       ]
     },
     {
@@ -903,82 +893,40 @@
       "syllabus": "https://docs.google.com/document/d/14-ByDX4VgO6S3azaJ9IbUsvJYKr99_7TOzygszBJWSc",
       "courses": [
         {
-          "name": "IT Fundamentals",
-          "hoursOverride": 80,
-          "id": "it-fundamentals"
+          "id": "it-fundamentals",
+          "hoursOverride": 80
         },
         {
-          "name": "Networking Fundamentals",
-          "hoursOverride": 220,
-          "id": "networking-fundamentals"
+          "id": "networking-fundamentals",
+          "hoursOverride": 220
         },
         {
-          "name": "Security and Cybersecurity Fundamentals",
-          "hoursOverride": 220,
-          "id": "security-and-cybersecurity-fundamentals"
+          "id": "security-and-cybersecurity-fundamentals",
+          "hoursOverride": 220
         }
       ]
     },
     {
       "name": "IT Business Analyst",
       "courses": [
-        {
-          "name": "Linux Foundations",
-          "id": "linux-foundations"
-        },
-        {
-          "name": "Python Basics (for Software Dev)",
-          "id": "python-basics-for-software-dev"
-        },
-        {
-          "name": "Advanced Python",
-          "id": "advanced-python"
-        },
-        {
-          "name": "Agile Project Management with Scrum",
-          "id": "agile-project-management-with-scrum"
-        },
-        {
-          "name": "Python for Infrastructure Automation",
-          "id": "python-for-infrastructure-automation"
-        }
+        "linux-foundations",
+        "python-basics-for-software-dev",
+        "advanced-python",
+        "agile-project-management-with-scrum",
+        "python-for-infrastructure-automation"
       ]
     },
     {
       "name": "IT Support Professional",
       "courses": [
-        {
-          "name": "CompTIA A+",
-          "id": "comptia-a-plus"
-        },
-        {
-          "name": "CompTIA Network+",
-          "id": "comptia-network-plus"
-        },
-        {
-          "name": "Microsoft 365 Fundamentals",
-          "id": "microsoft-365-fundamentals"
-        },
-        {
-          "name": "Microsoft 365 Endpoint Administrator",
-          "id": "microsoft-365-endpoint-administrator"
-        },
-        {
-          "name": "macOS Administration Fundamentals",
-          "id": "macos-administration-fundamentals"
-        },
-        {
-          "name": "Cloud Fundamentals",
-          "id": "cloud-fundamentals"
-        },
-        {
-          "name": "Troubleshooting/Supporting in an Enterprise Environment",
-          "id": "troubleshooting-supporting-in-an-enterprise-environment"
-        },
-        {
-          "name": "Helpdesk Software Fundamentals",
-          "id": "helpdesk-software-fundamentals"
-        }
+        "comptia-a-plus",
+        "comptia-network-plus",
+        "microsoft-365-fundamentals",
+        "microsoft-365-endpoint-administrator",
+        "macos-administration-fundamentals",
+        "cloud-fundamentals",
+        "troubleshooting-supporting-in-an-enterprise-environment",
+        "helpdesk-software-fundamentals"
       ]
     },
     {
@@ -989,14 +937,8 @@
           "hours": 176,
           "note": "RTI Area 1",
           "courses": [
-            {
-              "name": "Linux Foundations",
-              "id": "linux-foundations"
-            },
-            {
-              "name": "CompTIA Network+",
-              "id": "comptia-network-plus"
-            }
+            "linux-foundations",
+            "comptia-network-plus"
           ]
         },
         {
@@ -1005,18 +947,11 @@
           "note": "RTI Area 2",
           "courses": [
             {
-              "name": "CompTIA A+",
-              "hoursOverride": 96,
-              "id": "comptia-a-plus"
+              "id": "comptia-a-plus",
+              "hoursOverride": 96
             },
-            {
-              "name": "ITIL Foundations",
-              "id": "itil-foundations"
-            },
-            {
-              "name": "ITIL Specialist 4",
-              "id": "itil-specialist-4"
-            }
+            "itil-foundations",
+            "itil-specialist-4"
           ]
         },
         {
@@ -1024,40 +959,18 @@
           "hours": 236,
           "note": "RTI Area 3",
           "courses": [
+            "python-basics-for-software-dev",
+            "python-for-infrastructure-automation",
             {
-              "name": "Python Basics (for Software Dev)",
-              "id": "python-basics-for-software-dev"
-            },
-            {
-              "name": "Python for Infrastructure Automation",
-              "id": "python-for-infrastructure-automation"
-            },
-            {
-              "name": "Java Language Fundamentals",
+              "id": "java-language-fundamentals",
               "hoursOverride": 44,
-              "note": "Reduced from 56h for this deployment",
-              "id": "java-language-fundamentals"
+              "note": "Reduced from 56h for this deployment"
             },
-            {
-              "name": "Web Development with JavaScript",
-              "id": "web-development-with-javascript"
-            },
-            {
-              "name": "SQL Fundamentals for Operations",
-              "id": "sql-fundamentals-for-operations"
-            },
-            {
-              "name": "CI/CD Pipeline Concepts",
-              "id": "ci-cd-pipeline-concepts"
-            },
-            {
-              "name": "Infrastructure as Code Fundamentals",
-              "id": "infrastructure-as-code-fundamentals"
-            },
-            {
-              "name": "AI Foundations",
-              "id": "ai-foundations"
-            }
+            "web-development-with-javascript",
+            "sql-fundamentals-for-operations",
+            "ci-cd-pipeline-concepts",
+            "infrastructure-as-code-fundamentals",
+            "ai-foundations"
           ]
         },
         {
@@ -1065,22 +978,10 @@
           "hours": 16,
           "note": "RTI Area 4",
           "courses": [
-            {
-              "name": "Compliance and Security Awareness",
-              "id": "compliance-and-security-awareness"
-            },
-            {
-              "name": "Technical Documentation",
-              "id": "technical-documentation"
-            },
-            {
-              "name": "Productivity Tools for Technical Reporting",
-              "id": "productivity-tools-for-technical-reporting"
-            },
-            {
-              "name": "Professional Communication",
-              "id": "professional-communication"
-            }
+            "compliance-and-security-awareness",
+            "technical-documentation",
+            "productivity-tools-for-technical-reporting",
+            "professional-communication"
           ]
         }
       ]
@@ -1088,22 +989,10 @@
     {
       "name": "Software Development Java",
       "courses": [
-        {
-          "name": "Java Language Fundamentals",
-          "id": "java-language-fundamentals"
-        },
-        {
-          "name": "JavaScript",
-          "id": "javascript"
-        },
-        {
-          "name": "Web Development with JavaScript",
-          "id": "web-development-with-javascript"
-        },
-        {
-          "name": "Data Fundamentals — SQL for Data",
-          "id": "data-fundamentals-sql-for-data"
-        }
+        "java-language-fundamentals",
+        "javascript",
+        "web-development-with-javascript",
+        "data-fundamentals-sql-for-data"
       ]
     }
   ]

--- a/data/schema.json
+++ b/data/schema.json
@@ -108,28 +108,55 @@
     },
 
     "courseRef": {
-      "type": "object",
-      "required": ["name"],
-      "description": "Reference to a course within a curriculum. Uses name for display, id for stable linking.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Course display name"
-        },
-        "id": {
+      "description": "Reference to a course within a curriculum. Three formats: (1) plain ID string for simple refs, (2) object with 'id' + optional overrides, (3) legacy object with 'name' only (deprecated, for unresolved refs).",
+      "oneOf": [
+        {
           "type": "string",
           "pattern": "^[a-z0-9-]+$",
-          "description": "Stable course ID — matches course.id in courses array"
+          "description": "Simple ref — course ID string (most common)"
         },
-        "hoursOverride": {
-          "type": ["integer", "null"],
-          "description": "Per-deployment hour override for this curriculum"
+        {
+          "type": "object",
+          "required": ["id"],
+          "description": "Override ref — course ID with per-curriculum overrides",
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]+$",
+              "description": "Stable course ID"
+            },
+            "hoursOverride": {
+              "type": ["integer", "null"],
+              "description": "Per-curriculum hour override"
+            },
+            "note": {
+              "type": ["string", "null"],
+              "description": "Per-curriculum note"
+            }
+          },
+          "additionalProperties": false
         },
-        "note": {
-          "type": ["string", "null"],
-          "description": "Per-deployment note"
+        {
+          "type": "object",
+          "required": ["name"],
+          "description": "Legacy ref — name-only, no matching course ID (deprecated). Will generate build warnings.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Course display name (unresolved — no matching course in system)"
+            },
+            "hoursOverride": {
+              "type": ["integer", "null"],
+              "description": "Per-curriculum hour override"
+            },
+            "note": {
+              "type": ["string", "null"],
+              "description": "Per-curriculum note"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      ]
     }
   }
 }

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -17,11 +17,59 @@ const path = require('path');
  *   const curriculaData = [...];
  *   const courseStatusMap = {};
  *   courseData.forEach(c => { courseStatusMap[c.name] = c; });
+ *
+ * Curricula refs are resolved at build time: ID strings and { id } objects
+ * are expanded to { name, id, hoursOverride?, note? } so the frontend
+ * doesn't need to perform lookups on raw IDs.
  */
 function generateCourseBundle(data, config) {
+  // Build ID → course lookup for resolving refs
+  const courseById = {};
+  data.courses.forEach(c => { courseById[c.id] = c; });
+
+  // Deep-clone curricula and resolve course refs
+  const resolvedCurricula = JSON.parse(JSON.stringify(data.curricula));
+
+  resolvedCurricula.forEach(cur => {
+    function resolveRefs(refs) {
+      return refs.map(ref => {
+        // String ref → expand to { name, id }
+        if (typeof ref === 'string') {
+          const course = courseById[ref];
+          if (course) return { name: course.name, id: ref };
+          // Unresolved ID — keep as object so frontend can display something
+          return { name: ref, id: ref };
+        }
+
+        // Object ref with id → expand with name from master course
+        if (ref.id) {
+          const course = courseById[ref.id];
+          const resolved = { name: course ? course.name : ref.id, id: ref.id };
+          if (ref.hoursOverride !== undefined) resolved.hoursOverride = ref.hoursOverride;
+          if (ref.note !== undefined) resolved.note = ref.note;
+          return resolved;
+        }
+
+        // Legacy name-only ref — pass through as-is
+        return ref;
+      });
+    }
+
+    if (Array.isArray(cur.groups)) {
+      cur.groups.forEach(g => {
+        if (Array.isArray(g.courses)) {
+          g.courses = resolveRefs(g.courses);
+        }
+      });
+    }
+    if (Array.isArray(cur.courses)) {
+      cur.courses = resolveRefs(cur.courses);
+    }
+  });
+
   let js = '// Auto-generated from courses.json — do not edit directly\n';
   js += 'const courseData = ' + JSON.stringify(data.courses, null, 2) + ';\n\n';
-  js += 'const curriculaData = ' + JSON.stringify(data.curricula, null, 2) + ';\n\n';
+  js += 'const curriculaData = ' + JSON.stringify(resolvedCurricula, null, 2) + ';\n\n';
   js += 'const courseStatusMap = {};\n';
   js += 'courseData.forEach(c => {\n';
   js += '  courseStatusMap[c.name] = c;\n';

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -82,50 +82,64 @@ function validateSchema(data, config) {
 /**
  * Validate cross-references between curricula and courses
  * Ensures every course referenced in a curriculum actually exists
+ *
+ * Course refs support three formats:
+ *   - string: "course-id" (simple ID ref)
+ *   - object with id: { id: "course-id", hoursOverride: 80 } (override ref)
+ *   - object with name only: { name: "Course Name" } (legacy, deprecated)
  */
 function validateReferences(data, config) {
   const warnings = [];
+  const errors = [];
 
+  const courseIds = new Set(data.courses.map(c => c.id));
   const courseNames = new Set(data.courses.map(c => c.name));
 
   /**
-   * Extract course name from a reference — handles both formats:
-   *   string: "Course Name"
-   *   object: { name: "Course Name", hoursOverride: 80 }
+   * Validate a single course ref and return any issues
    */
-  function getCourseName(ref) {
-    if (typeof ref === 'string') return ref;
-    if (ref && typeof ref === 'object' && ref.name) return ref.name;
-    return null;
+  function validateRef(ref, currName) {
+    // String ref — must be a valid course ID
+    if (typeof ref === 'string') {
+      if (!courseIds.has(ref)) {
+        warnings.push(`curricula "${currName}": references unknown course ID "${ref}"`);
+      }
+      return;
+    }
+
+    // Object ref with id — preferred format
+    if (ref && typeof ref === 'object' && ref.id) {
+      if (!courseIds.has(ref.id)) {
+        warnings.push(`curricula "${currName}": references unknown course ID "${ref.id}"`);
+      }
+      return;
+    }
+
+    // Legacy object ref with name only (no id) — deprecated
+    if (ref && typeof ref === 'object' && ref.name) {
+      warnings.push(`curricula "${currName}": legacy name-only ref "${ref.name}" — should be migrated to ID ref`);
+      return;
+    }
+
+    // Invalid ref format
+    errors.push(`curricula "${currName}": contains invalid course reference: ${JSON.stringify(ref)}`);
   }
 
   data.curricula.forEach(curr => {
-    // Collect all course references from both formats
-    const courseRefs = [];
-
     if (Array.isArray(curr.groups)) {
       curr.groups.forEach(group => {
         if (Array.isArray(group.courses)) {
-          courseRefs.push(...group.courses);
+          group.courses.forEach(ref => validateRef(ref, curr.name));
         }
       });
     }
 
     if (Array.isArray(curr.courses)) {
-      courseRefs.push(...curr.courses);
+      curr.courses.forEach(ref => validateRef(ref, curr.name));
     }
-
-    courseRefs.forEach(ref => {
-      const name = getCourseName(ref);
-      if (!name) {
-        warnings.push(`curricula "${curr.name}": contains invalid course reference`);
-      } else if (!courseNames.has(name)) {
-        warnings.push(`curricula "${curr.name}": references unknown course "${name}"`);
-      }
-    });
   });
 
-  return { errors: [], warnings };
+  return { errors, warnings };
 }
 
 /**


### PR DESCRIPTION
Convert 41 curriculum course refs from { name, id } objects to ID-only format: plain strings for simple refs, { id, hoursOverride?, note? } for override refs. The name field is dropped from refs since it can be resolved from the course's master entry.

The build generator now resolves ID refs at build time, expanding them back to { name, id } objects in the generated courses.js. This means the frontend receives the same data shape and requires no changes.

Changes:
- courses.json: 41 refs converted to ID-only, 6 Cloud Ops legacy refs kept as-is (pending curriculum review)
- data/schema.json: courseRef now supports string | {id} | {name}
- lib/validators.js: validates new ref formats, warns on legacy refs
- lib/generators.js: resolves ID refs to { name, id } at build time
- DESIGN/MIGRATION-GUIDE.md: documents new ref format and resolution

Closes #11