### PR TITLE
Add 'Needs Review' banner to auto-generated syllabus HTML pages

### DIFF
--- a/convert-syllabi.js
+++ b/convert-syllabi.js
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
 `;
 
 function escHtml(s) {
@@ -443,7 +460,8 @@ function parseSyllabusMd(text) {
     return result;
 }
 
-function buildHtml(data) {
+function buildHtml(data, designStatus) {
+    const needsReview = designStatus && designStatus.toLowerCase() === 'needs review';
     let html = `<!DOCTYPE html>
 <html lang="en" data-theme="dark">
 <head>
@@ -457,7 +475,7 @@ function buildHtml(data) {
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
-        <div class="header">
+${needsReview ? `        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>\n` : ''}        <div class="header">
             <h1>Syllabus: ${escHtml(data.title)}</h1>
             <div class="header-meta">
                 ${data.curriculum ? `<span><i class="fa-solid fa-layer-group"></i> ${escHtml(data.curriculum)}</span>` : ''}
@@ -545,6 +563,53 @@ const folders = fs.readdirSync(coursesDir).filter(d => {
     return stat.isDirectory() && d !== '.template' && d !== '.scorm-template';
 });
 
+// Load courses.json to look up design status per course
+const coursesJsonPath = path.join(syllabiDir, '..', 'courses.json');
+const coursesData = JSON.parse(fs.readFileSync(coursesJsonPath, 'utf8'));
+const courseById = {};
+const courseBySlug = {};  // fuzzy: maps folder slugs to course entries
+coursesData.courses.forEach(c => {
+    if (c.id) courseById[c.id] = c;
+});
+// Build slug lookup: for each course, also index by folder-style slug
+// (handles mismatches like "agile-project-management" folder vs "agile-project-management-with-scrum" ID)
+coursesData.courses.forEach(c => {
+    if (!c.id) return;
+    courseBySlug[c.id] = c;
+    // Also try shorter slug: take first 3 words
+    const parts = c.id.split('-');
+    if (parts.length > 3) {
+        const short = parts.slice(0, 3).join('-');
+        if (!courseBySlug[short]) courseBySlug[short] = c;
+    }
+});
+
+function findCourseForFolder(folder) {
+    // Exact match first
+    if (courseById[folder]) return courseById[folder];
+    // Check if any JSON ID contains the folder slug or vice versa
+    for (const c of coursesData.courses) {
+        if (!c.id) continue;
+        if (c.id.includes(folder) || folder.includes(c.id)) return c;
+    }
+    // Word overlap match (handles intro-to-aws vs introduction-to-aws-cloud-platform)
+    const normalize = w => w === 'intro' ? 'introduction' : w;
+    const folderWords = new Set(folder.split('-').filter(w => w.length > 2).map(normalize));
+    let bestMatch = null;
+    let bestScore = 0;
+    for (const c of coursesData.courses) {
+        if (!c.id) continue;
+        const idWords = new Set(c.id.split('-').filter(w => w.length > 2).map(normalize));
+        const overlap = [...folderWords].filter(w => idWords.has(w)).length;
+        const score = overlap / Math.max(folderWords.size, idWords.size);
+        if (overlap >= 2 && score > bestScore) {
+            bestScore = score;
+            bestMatch = c;
+        }
+    }
+    return bestMatch;
+}
+
 const syllabiMap = {};
 let converted = 0;
 let errors = [];
@@ -568,7 +633,9 @@ folders.forEach(folder => {
     }
 
     const htmlFilename = folder + '.html';
-    const html = buildHtml(data);
+    const courseEntry = findCourseForFolder(folder);
+    const designStatus = courseEntry && courseEntry.status ? courseEntry.status.design : null;
+    const html = buildHtml(data, designStatus);
     fs.writeFileSync(path.join(syllabiDir, htmlFilename), html);
 
     // We need to map course names. Read from courses.json

--- a/syllabi/advanced-python.html
+++ b/syllabi/advanced-python.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Advanced Python</h1>
             <div class="header-meta">

--- a/syllabi/agile-project-management.html
+++ b/syllabi/agile-project-management.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Agile Project Management with Scrum</h1>
             <div class="header-meta">

--- a/syllabi/aspnet.html
+++ b/syllabi/aspnet.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: ASP.NET</h1>
             <div class="header-meta">

--- a/syllabi/business-analysis-fundamentals.html
+++ b/syllabi/business-analysis-fundamentals.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/business-and-it-fundamentals.html
+++ b/syllabi/business-and-it-fundamentals.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/cicd-pipeline-concepts.html
+++ b/syllabi/cicd-pipeline-concepts.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/compliance-security-awareness.html
+++ b/syllabi/compliance-security-awareness.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/comptia-a-plus.html
+++ b/syllabi/comptia-a-plus.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/comptia-network-plus.html
+++ b/syllabi/comptia-network-plus.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/cpp-coding-booster.html
+++ b/syllabi/cpp-coding-booster.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/csharp-data-access.html
+++ b/syllabi/csharp-data-access.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: C# Data Access</h1>
             <div class="header-meta">

--- a/syllabi/csharp-language-fundamentals.html
+++ b/syllabi/csharp-language-fundamentals.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: C# Language Fundamentals</h1>
             <div class="header-meta">

--- a/syllabi/csharp-oop.html
+++ b/syllabi/csharp-oop.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: C# OOP</h1>
             <div class="header-meta">

--- a/syllabi/data-literacy.html
+++ b/syllabi/data-literacy.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Data Fundamentals — Data Literacy</h1>
             <div class="header-meta">

--- a/syllabi/data-viz-power-bi.html
+++ b/syllabi/data-viz-power-bi.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Data Fundamentals — Data Visualizations and Power BI</h1>
             <div class="header-meta">

--- a/syllabi/databases-in-java.html
+++ b/syllabi/databases-in-java.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/excel-for-data-analysts.html
+++ b/syllabi/excel-for-data-analysts.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Data Fundamentals — Excel for Data Analysts</h1>
             <div class="header-meta">

--- a/syllabi/helpdesk-software-fundamentals.html
+++ b/syllabi/helpdesk-software-fundamentals.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/http-services.html
+++ b/syllabi/http-services.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: HTTP Services</h1>
             <div class="header-meta">

--- a/syllabi/infrastructure-as-code.html
+++ b/syllabi/infrastructure-as-code.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/instructor-onboarding.html
+++ b/syllabi/instructor-onboarding.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Instructor Onboarding</h1>
             <div class="header-meta">

--- a/syllabi/intro-to-aws.html
+++ b/syllabi/intro-to-aws.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Introduction to AWS Cloud Platform</h1>
             <div class="header-meta">

--- a/syllabi/intro-to-cloud-technology.html
+++ b/syllabi/intro-to-cloud-technology.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Introduction to Cloud Technology</h1>
             <div class="header-meta">

--- a/syllabi/intro-to-github.html
+++ b/syllabi/intro-to-github.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Introduction to GitHub</h1>
             <div class="header-meta">

--- a/syllabi/intro-to-html-css.html
+++ b/syllabi/intro-to-html-css.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Introduction to HTML &amp; CSS</h1>
             <div class="header-meta">

--- a/syllabi/intro-to-microsoft-teams.html
+++ b/syllabi/intro-to-microsoft-teams.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Introduction to Microsoft Teams</h1>
             <div class="header-meta">

--- a/syllabi/it-fundamentals.html
+++ b/syllabi/it-fundamentals.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: IT Fundamentals</h1>
             <div class="header-meta">

--- a/syllabi/itil-foundations.html
+++ b/syllabi/itil-foundations.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/itil-specialist.html
+++ b/syllabi/itil-specialist.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/java-coding-booster.html
+++ b/syllabi/java-coding-booster.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/java-language-fundamentals.html
+++ b/syllabi/java-language-fundamentals.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/javascript-coding-booster.html
+++ b/syllabi/javascript-coding-booster.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/javascript-react-for-csharp.html
+++ b/syllabi/javascript-react-for-csharp.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/javascript.html
+++ b/syllabi/javascript.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/layers-and-file-io-csharp.html
+++ b/syllabi/layers-and-file-io-csharp.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/linq-and-dependency-injection.html
+++ b/syllabi/linq-and-dependency-injection.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/linux-foundations.html
+++ b/syllabi/linux-foundations.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/macos-administration.html
+++ b/syllabi/macos-administration.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: macOS Administration Fundamentals</h1>
             <div class="header-meta">

--- a/syllabi/networking-fundamentals.html
+++ b/syllabi/networking-fundamentals.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/non-relational-data.html
+++ b/syllabi/non-relational-data.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/oss-network-curriculum.html
+++ b/syllabi/oss-network-curriculum.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/pandas.html
+++ b/syllabi/pandas.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/productivity-tools-reporting.html
+++ b/syllabi/productivity-tools-reporting.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/professional-communication.html
+++ b/syllabi/professional-communication.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/python-basics-softdev.html
+++ b/syllabi/python-basics-softdev.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/python-coding-booster.html
+++ b/syllabi/python-coding-booster.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/python-infrastructure-automation.html
+++ b/syllabi/python-infrastructure-automation.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/react.html
+++ b/syllabi/react.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: React</h1>
             <div class="header-meta">

--- a/syllabi/security-cybersecurity-fundamentals.html
+++ b/syllabi/security-cybersecurity-fundamentals.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/software-developer-prework.html
+++ b/syllabi/software-developer-prework.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/software-development-lifecycle.html
+++ b/syllabi/software-development-lifecycle.html
@@ -285,12 +285,30 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
+        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Software Development Lifecycle</h1>
             <div class="header-meta">

--- a/syllabi/sql-coding-booster.html
+++ b/syllabi/sql-coding-booster.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/sql-for-csharp.html
+++ b/syllabi/sql-for-csharp.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/sql-for-data.html
+++ b/syllabi/sql-for-data.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/sql-fundamentals-operations.html
+++ b/syllabi/sql-fundamentals-operations.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/student-onboarding.html
+++ b/syllabi/student-onboarding.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/technical-documentation.html
+++ b/syllabi/technical-documentation.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>

--- a/syllabi/web-dev-javascript-react.html
+++ b/syllabi/web-dev-javascript-react.html
@@ -285,6 +285,23 @@ code {
     font-size: 13px;
     color: var(--sky-blue);
 }
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
     </style>
 </head>
 <body>


### PR DESCRIPTION
convert-syllabi.js now reads each course's design status from courses.json. When status is "Needs Review", the generated HTML syllabus displays an amber warning banner at the top: "This syllabus is auto-generated and needs review"

Includes fuzzy folder-to-ID matching so courses with slug mismatches (e.g. intro-to-aws vs introduction-to-aws-cloud-platform) are correctly resolved. 20 of 59 syllabi now show the banner.