### PR TITLE
Update ITIL Foundations development status to Complete

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -411,11 +411,11 @@ const courseData = [
     "hours": 20,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": "itil-foundations",
     "outline": true,
-    "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep. Needs SCORM packaging.",
+    "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep.",
     "driveFolder": "https://drive.google.com/drive/folders/1aljEOFGVRecJDz1QsGRCNTjBs-i81esw",
     "deployRepo": "https://github.com/apprenti-org/itil-foundations-content",
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"

--- a/courses.json
+++ b/courses.json
@@ -409,11 +409,11 @@
       "hours": 20,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": "itil-foundations",
       "outline": true,
-      "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep. Needs SCORM packaging.",
+      "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep.",
       "driveFolder": "https://drive.google.com/drive/folders/1aljEOFGVRecJDz1QsGRCNTjBs-i81esw",
       "deployRepo": "https://github.com/apprenti-org/itil-foundations-content",
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"


### PR DESCRIPTION
## Summary
- Set `status.development` to `Complete` for ITIL Foundations (content fully deployed: 7 modules, 19 lessons, 126 PDFs, SCORM 1.2 packages)
- Removed "Needs SCORM packaging" from the note (now done)
- Regenerated `courses.js`

## Test plan
- [ ] Dashboard detail panel shows Development: Complete
- [ ] Syllabus link still works
- [ ] Outline still renders

Closes #32