### PR TITLE
Add Productivity Tools for Technical Reporting tracking entry (#40)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -277,7 +277,7 @@ var courseOverviewData = [
     "outline": {
       "exists": true,
       "modules": 1,
-      "lessons": 7
+      "lessons": 10
     },
     "syllabus": true,
     "source": {
@@ -516,8 +516,8 @@ var courseOverviewData = [
     "hours": 50,
     "outline": {
       "exists": true,
-      "modules": 8,
-      "lessons": 17
+      "modules": 7,
+      "lessons": 14
     },
     "syllabus": true,
     "source": {
@@ -525,8 +525,8 @@ var courseOverviewData = [
       "folder": "Course: Excel for Data Analysts",
       "modules": 10
     },
-    "coverage": 0,
-    "lessonsWithContent": 0,
+    "coverage": 14,
+    "lessonsWithContent": 2,
     "assets": {
       "lessons": 30,
       "slides": 25,
@@ -545,17 +545,17 @@ var courseOverviewData = [
     "name": "Data Fundamentals — SQL for Data",
     "hours": 50,
     "outline": {
-      "exists": false,
-      "modules": 0,
-      "lessons": 0
+      "exists": true,
+      "modules": 5,
+      "lessons": 14
     },
-    "syllabus": false,
+    "syllabus": true,
     "source": {
       "exists": true,
       "folder": "Course: SQL for Data",
       "modules": 8
     },
-    "coverage": null,
+    "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
       "lessons": 33,
@@ -997,7 +997,7 @@ var courseOverviewData = [
     "outline": {
       "exists": true,
       "modules": 1,
-      "lessons": 10
+      "lessons": 7
     },
     "syllabus": true,
     "source": {
@@ -1441,13 +1441,13 @@ var courseOverviewData = [
     "totalAssets": 30
   },
   {
-    "id": "productivity-tools-for-technical-reporting",
+    "id": "productivity-tools-reporting",
     "name": "Productivity Tools for Technical Reporting",
     "hours": 4,
     "outline": {
       "exists": true,
-      "modules": 3,
-      "lessons": 5
+      "modules": 2,
+      "lessons": 4
     },
     "syllabus": true,
     "source": {
@@ -1776,8 +1776,8 @@ var courseOverviewData = [
     "hours": 20,
     "outline": {
       "exists": true,
-      "modules": 5,
-      "lessons": 14
+      "modules": 8,
+      "lessons": 17
     },
     "syllabus": true,
     "source": {

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-13T21:20:52",
+  "generated": "2026-04-14T13:01:25",
   "courseCount": 64,
   "courses": [
     {
@@ -279,7 +279,7 @@
       "outline": {
         "exists": true,
         "modules": 1,
-        "lessons": 7
+        "lessons": 10
       },
       "syllabus": true,
       "source": {
@@ -518,8 +518,8 @@
       "hours": 50,
       "outline": {
         "exists": true,
-        "modules": 8,
-        "lessons": 17
+        "modules": 7,
+        "lessons": 14
       },
       "syllabus": true,
       "source": {
@@ -527,8 +527,8 @@
         "folder": "Course: Excel for Data Analysts",
         "modules": 10
       },
-      "coverage": 0,
-      "lessonsWithContent": 0,
+      "coverage": 14,
+      "lessonsWithContent": 2,
       "assets": {
         "lessons": 30,
         "slides": 25,
@@ -547,17 +547,17 @@
       "name": "Data Fundamentals \u2014 SQL for Data",
       "hours": 50,
       "outline": {
-        "exists": false,
-        "modules": 0,
-        "lessons": 0
+        "exists": true,
+        "modules": 5,
+        "lessons": 14
       },
-      "syllabus": false,
+      "syllabus": true,
       "source": {
         "exists": true,
         "folder": "Course: SQL for Data",
         "modules": 8
       },
-      "coverage": null,
+      "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
         "lessons": 33,
@@ -999,7 +999,7 @@
       "outline": {
         "exists": true,
         "modules": 1,
-        "lessons": 10
+        "lessons": 7
       },
       "syllabus": true,
       "source": {
@@ -1443,13 +1443,13 @@
       "totalAssets": 30
     },
     {
-      "id": "productivity-tools-for-technical-reporting",
+      "id": "productivity-tools-reporting",
       "name": "Productivity Tools for Technical Reporting",
       "hours": 4,
       "outline": {
         "exists": true,
-        "modules": 3,
-        "lessons": 5
+        "modules": 2,
+        "lessons": 4
       },
       "syllabus": true,
       "source": {
@@ -1778,8 +1778,8 @@
       "hours": 20,
       "outline": {
         "exists": true,
-        "modules": 5,
-        "lessons": 14
+        "modules": 8,
+        "lessons": 17
       },
       "syllabus": true,
       "source": {

--- a/courses.js
+++ b/courses.js
@@ -629,17 +629,18 @@ const courseData = [
     "driveFolder": "https://drive.google.com/drive/folders/1rGEdXkwx1oq5ZgKL3EPXKtHRGOn-Da6y"
   },
   {
-    "id": "productivity-tools-for-technical-reporting",
+    "id": "productivity-tools-reporting",
     "name": "Productivity Tools for Technical Reporting",
     "hours": 4,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "In Progress"
     },
-    "syllabus": null,
-    "outline": null,
-    "note": "Net New",
-    "driveFolder": null
+    "syllabus": "productivity-tools-reporting",
+    "outline": true,
+    "note": "OSS Area 4 (S&PS). 4h, 2 modules, 4 lessons + integrated capstone. Excel and PowerPoint for technical reporting. Design complete (apprenti-org/design-documentation#46, #48, #54). Content scaffolded (#57); Phase 3 horizontal production next.",
+    "driveFolder": null,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
   },
   {
     "id": "professional-communication",
@@ -1089,7 +1090,7 @@ const curriculaData = [
           },
           {
             "name": "Productivity Tools for Technical Reporting",
-            "id": "productivity-tools-for-technical-reporting"
+            "id": "productivity-tools-reporting"
           },
           {
             "name": "Professional Communication",

--- a/courses.json
+++ b/courses.json
@@ -627,17 +627,18 @@
       "driveFolder": "https://drive.google.com/drive/folders/1rGEdXkwx1oq5ZgKL3EPXKtHRGOn-Da6y"
     },
     {
-      "id": "productivity-tools-for-technical-reporting",
+      "id": "productivity-tools-reporting",
       "name": "Productivity Tools for Technical Reporting",
       "hours": 4,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "In Progress"
       },
-      "syllabus": null,
-      "outline": null,
-      "note": "Net New",
-      "driveFolder": null
+      "syllabus": "productivity-tools-reporting",
+      "outline": true,
+      "note": "OSS Area 4 (S&PS). 4h, 2 modules, 4 lessons + integrated capstone. Excel and PowerPoint for technical reporting. Design complete (apprenti-org/design-documentation#46, #48, #54). Content scaffolded (#57); Phase 3 horizontal production next.",
+      "driveFolder": null,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {
       "id": "professional-communication",
@@ -991,7 +992,7 @@
           "courses": [
             "compliance-and-security-awareness",
             "technical-documentation",
-            "productivity-tools-for-technical-reporting",
+            "productivity-tools-reporting",
             "professional-communication"
           ]
         }

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -205,6 +205,11 @@
     "id": "pandas"
   },
   {
+    "file": "productivity-tools-reporting.json",
+    "course": "Productivity Tools for Technical Reporting",
+    "id": "productivity-tools-reporting"
+  },
+  {
     "file": "python-basics.json",
     "course": "Python Basics (for Software Dev)",
     "id": "python-basics-for-software-dev"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -8160,6 +8160,98 @@ const courseOutlines = {
       ]
     }
   },
+  "Productivity Tools for Technical Reporting": {
+    "course": "Productivity Tools for Technical Reporting",
+    "totalHours": 4,
+    "totalModules": 2,
+    "totalLessons": 4,
+    "modules": [
+      {
+        "name": "Excel for Technical Analysis and Reporting",
+        "hours": 2,
+        "lessons": [
+          {
+            "title": "Data Management and Analysis in Excel",
+            "hours": 1,
+            "topics": [
+              "Spreadsheet design and organization for technical data (naming conventions, worksheet structure, data ranges)",
+              "Data entry, validation, and cleanup (removing duplicates, handling missing values, data types)",
+              "Formulas and functions for technical metrics (SUM, AVERAGE, COUNTIF, SUMIF, IF, VLOOKUP/XLOOKUP)",
+              "Tables and structured references for maintainable spreadsheets",
+              "Sorting, filtering, and conditional formatting to surface anomalies",
+              "Common operational data sources: log exports, ticketing reports, monitoring CSVs",
+              "Clean a provided log-export CSV and produce a sortable incident table",
+              "Build a small KPI calculator (MTTR, uptime %, ticket volume by severity) from sample operations data"
+            ],
+            "objects": [
+              "Object: Lesson: Data Management and Analysis in Excel",
+              "Assessment: Quiz: Data Management and Analysis in Excel"
+            ]
+          },
+          {
+            "title": "Data Visualization and Operational Dashboards",
+            "hours": 1,
+            "topics": [
+              "Chart types and when to use them (column, bar, line, pie, scatter) — data visualization",
+              "Pivot tables and pivot charts for summarizing technical data",
+              "Building an operational dashboard: KPI tiles, trend lines, status indicators",
+              "Conditional formatting for visual health checks (heat maps, data bars, icon sets)",
+              "Exporting charts and dashboards for inclusion in presentations and documentation",
+              "Avoiding misleading visualizations (truncated axes, 3D distortion, chart-type mismatch)",
+              "Convert a flat KPI table into a pivot-driven dashboard with at least three visual elements",
+              "Critique a set of sample charts and justify one fix per chart"
+            ],
+            "objects": [
+              "Object: Lesson: Data Visualization and Operational Dashboards",
+              "Assessment: Quiz: Data Visualization and Operational Dashboards"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "PowerPoint for Technical Presentations",
+        "hours": 2,
+        "lessons": [
+          {
+            "title": "Presentation Design Principles",
+            "hours": 1,
+            "topics": [
+              "Structuring a technical presentation: problem → evidence → options → recommendation",
+              "Slide design best practices: consistent layout, hierarchy, readable typography, contrast",
+              "Using PowerPoint layouts, master slides, and themes for consistency",
+              "Creating technical diagrams: network topology, architecture blocks, flow diagrams, sequence steps",
+              "SmartArt and shape-based diagrams for process flows, runbook visualizations, and escalation paths",
+              "Embedding and formatting Excel charts/tables inside slides without losing fidelity",
+              "Rebuild a dense text-heavy slide into a structured, visual slide following design principles",
+              "Create a network/system diagram for a provided operational scenario using shapes or SmartArt"
+            ],
+            "objects": [
+              "Object: Lesson: Presentation Design Principles",
+              "Assessment: Quiz: Presentation Design Principles"
+            ]
+          },
+          {
+            "title": "Presenting Data and Recommendations",
+            "hours": 1,
+            "topics": [
+              "Telling a data story: framing findings around the audience's decision",
+              "Choosing the right chart for the message (comparison, trend, distribution, composition)",
+              "Annotating charts to direct attention (callouts, highlights, plain-language takeaways)",
+              "Preparing for different audiences: executive summary vs technical deep-dive",
+              "Handling Q&A: backing up claims with data, admitting limits, capturing follow-ups",
+              "Presenter tools: notes, rehearse-with-timing, and basic accessibility (alt text, contrast, reading order)",
+              "Deliver a 5-minute technical briefing (incident review or capacity report) using a provided dataset",
+              "Peer feedback on clarity, structure, and visual effectiveness"
+            ],
+            "objects": [
+              "Object: Lesson: Presenting Data and Recommendations",
+              "Assessment: Quiz: Presenting Data and Recommendations"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "Python Basics (for Software Dev)": {
     "course": "Python Basics (for Software Dev)",
     "totalHours": 48,

--- a/outlines/productivity-tools-reporting.json
+++ b/outlines/productivity-tools-reporting.json
@@ -1,0 +1,92 @@
+{
+  "course": "Productivity Tools for Technical Reporting",
+  "totalHours": 4,
+  "totalModules": 2,
+  "totalLessons": 4,
+  "modules": [
+    {
+      "name": "Excel for Technical Analysis and Reporting",
+      "hours": 2,
+      "lessons": [
+        {
+          "title": "Data Management and Analysis in Excel",
+          "hours": 1,
+          "topics": [
+            "Spreadsheet design and organization for technical data (naming conventions, worksheet structure, data ranges)",
+            "Data entry, validation, and cleanup (removing duplicates, handling missing values, data types)",
+            "Formulas and functions for technical metrics (SUM, AVERAGE, COUNTIF, SUMIF, IF, VLOOKUP/XLOOKUP)",
+            "Tables and structured references for maintainable spreadsheets",
+            "Sorting, filtering, and conditional formatting to surface anomalies",
+            "Common operational data sources: log exports, ticketing reports, monitoring CSVs",
+            "Clean a provided log-export CSV and produce a sortable incident table",
+            "Build a small KPI calculator (MTTR, uptime %, ticket volume by severity) from sample operations data"
+          ],
+          "objects": [
+            "Object: Lesson: Data Management and Analysis in Excel",
+            "Assessment: Quiz: Data Management and Analysis in Excel"
+          ]
+        },
+        {
+          "title": "Data Visualization and Operational Dashboards",
+          "hours": 1,
+          "topics": [
+            "Chart types and when to use them (column, bar, line, pie, scatter) — data visualization",
+            "Pivot tables and pivot charts for summarizing technical data",
+            "Building an operational dashboard: KPI tiles, trend lines, status indicators",
+            "Conditional formatting for visual health checks (heat maps, data bars, icon sets)",
+            "Exporting charts and dashboards for inclusion in presentations and documentation",
+            "Avoiding misleading visualizations (truncated axes, 3D distortion, chart-type mismatch)",
+            "Convert a flat KPI table into a pivot-driven dashboard with at least three visual elements",
+            "Critique a set of sample charts and justify one fix per chart"
+          ],
+          "objects": [
+            "Object: Lesson: Data Visualization and Operational Dashboards",
+            "Assessment: Quiz: Data Visualization and Operational Dashboards"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PowerPoint for Technical Presentations",
+      "hours": 2,
+      "lessons": [
+        {
+          "title": "Presentation Design Principles",
+          "hours": 1,
+          "topics": [
+            "Structuring a technical presentation: problem → evidence → options → recommendation",
+            "Slide design best practices: consistent layout, hierarchy, readable typography, contrast",
+            "Using PowerPoint layouts, master slides, and themes for consistency",
+            "Creating technical diagrams: network topology, architecture blocks, flow diagrams, sequence steps",
+            "SmartArt and shape-based diagrams for process flows, runbook visualizations, and escalation paths",
+            "Embedding and formatting Excel charts/tables inside slides without losing fidelity",
+            "Rebuild a dense text-heavy slide into a structured, visual slide following design principles",
+            "Create a network/system diagram for a provided operational scenario using shapes or SmartArt"
+          ],
+          "objects": [
+            "Object: Lesson: Presentation Design Principles",
+            "Assessment: Quiz: Presentation Design Principles"
+          ]
+        },
+        {
+          "title": "Presenting Data and Recommendations",
+          "hours": 1,
+          "topics": [
+            "Telling a data story: framing findings around the audience's decision",
+            "Choosing the right chart for the message (comparison, trend, distribution, composition)",
+            "Annotating charts to direct attention (callouts, highlights, plain-language takeaways)",
+            "Preparing for different audiences: executive summary vs technical deep-dive",
+            "Handling Q&A: backing up claims with data, admitting limits, capturing follow-ups",
+            "Presenter tools: notes, rehearse-with-timing, and basic accessibility (alt text, contrast, reading order)",
+            "Deliver a 5-minute technical briefing (incident review or capacity report) using a provided dataset",
+            "Peer feedback on clarity, structure, and visual effectiveness"
+          ],
+          "objects": [
+            "Object: Lesson: Presenting Data and Recommendations",
+            "Assessment: Quiz: Presenting Data and Recommendations"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Aligns the tracking entry slug with the rest of the repo (`productivity-tools-for-technical-reporting` → `productivity-tools-reporting`)
- Updates status from Not Started/Not Started → Complete/In Progress
- Adds outline JSON, manifest entry, and regenerates bundles

Downstream of [design-documentation#58](https://github.com/apprenti-org/design-documentation/pull/58) (content scaffolding for this course).

## Test plan
- [x] Course appears in dashboard with correct status (Design=Complete, Dev=In Progress)
- [x] Outline shows 2 modules / 4 lessons in detail panel
- [x] Syllabus link works
- [x] No regression to ITIL Foundations (still 100% coverage, 101 assets)
- [x] Build passes (`node build.js`) with no warnings introduced
- [ ] Localhost dashboard preview

Closes #40