### PR TITLE
Hide nullh for modules without hours data

### DIFF
--- a/js/dashboard/outline-renderer.js
+++ b/js/dashboard/outline-renderer.js
@@ -20,7 +20,7 @@ function renderOutline(outlineData) {
         html += '<div class="outline-module"><div class="module-header" data-module="' + i + '">' +
             '<i class="fa-solid fa-chevron-right module-chevron"></i>' +
             '<span class="module-name"><i class="fa-solid fa-cube" style="opacity:0.5;margin-right:4px;font-size:11px;"></i>Module ' + (i + 1) + ': ' + (mod.name || mod.title) + '</span>' +
-            '<span class="module-hours">' + mod.hours + 'h &middot; ' + mod.lessons.length + ' lessons</span></div>';
+            '<span class="module-hours">' + (mod.hours != null ? mod.hours + 'h &middot; ' : '') + mod.lessons.length + ' lessons</span></div>';
         html += '<div class="module-lessons">';
 
         if (mod.description) {
@@ -82,7 +82,7 @@ function renderOutline(outlineData) {
     if (outlineData.assessment) {
         html += '<div class="outline-assessment"><div class="assessment-title">' +
             '<i class="fa-solid fa-clipboard-check" style="margin-right:6px;"></i>' +
-            outlineData.assessment.title + ' (' + outlineData.assessment.hours + 'h)</div><div class="assessment-items">';
+            outlineData.assessment.title + (outlineData.assessment.hours != null ? ' (' + outlineData.assessment.hours + 'h)' : '') + '</div><div class="assessment-items">';
         outlineData.assessment.items.forEach(function(item) { html += '<div class="assessment-item">' + item + '</div>'; });
         html += '</div></div>';
     }


### PR DESCRIPTION
## Summary
`js/dashboard/outline-renderer.js` unconditionally appended `h` to `mod.hours` and `outlineData.assessment.hours`, producing `nullh` in the UI for courses (like Data Literacy) whose outline JSON uses `"hours": null` at the module level. Guard both sites the same way the lesson-hours renderer already does.

## Before / After
- Before: `Module 1: Introduction to Data ─ nullh · 4 lessons`
- After: `Module 1: Introduction to Data ─ 4 lessons`

## Test plan
- [ ] Reload dashboard, select Data Literacy — no more `nullh`
- [ ] Non-regression: ITIL Foundations and Linux Foundations still show `Nh · N lessons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)