### PR TITLE
Make generate-course-overview folder matcher deterministic (fix #53)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -276,8 +276,8 @@ var courseOverviewData = [
     "hours": 8,
     "outline": {
       "exists": true,
-      "modules": 1,
-      "lessons": 7
+      "modules": 2,
+      "lessons": 5
     },
     "syllabus": true,
     "source": {
@@ -546,8 +546,8 @@ var courseOverviewData = [
     "hours": 50,
     "outline": {
       "exists": true,
-      "modules": 5,
-      "lessons": 14
+      "modules": 8,
+      "lessons": 17
     },
     "syllabus": true,
     "source": {
@@ -997,7 +997,7 @@ var courseOverviewData = [
     "outline": {
       "exists": true,
       "modules": 1,
-      "lessons": 13
+      "lessons": 10
     },
     "syllabus": true,
     "source": {
@@ -1116,8 +1116,8 @@ var courseOverviewData = [
     "hours": 8,
     "outline": {
       "exists": true,
-      "modules": 2,
-      "lessons": 5
+      "modules": 1,
+      "lessons": 7
     },
     "syllabus": true,
     "source": {
@@ -1537,7 +1537,7 @@ var courseOverviewData = [
     "outline": {
       "exists": true,
       "modules": 1,
-      "lessons": 10
+      "lessons": 13
     },
     "syllabus": true,
     "source": {
@@ -1776,8 +1776,8 @@ var courseOverviewData = [
     "hours": 20,
     "outline": {
       "exists": true,
-      "modules": 8,
-      "lessons": 17
+      "modules": 5,
+      "lessons": 14
     },
     "syllabus": true,
     "source": {
@@ -1895,17 +1895,17 @@ var courseOverviewData = [
     "name": "Web Development with JavaScript",
     "hours": 40,
     "outline": {
-      "exists": false,
-      "modules": 0,
-      "lessons": 0
+      "exists": true,
+      "modules": 9,
+      "lessons": 18
     },
-    "syllabus": false,
+    "syllabus": true,
     "source": {
       "exists": true,
       "folder": "Course: Web Development with JavaScript",
       "modules": 1
     },
-    "coverage": null,
+    "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
       "lessons": 3,

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-17T15:32:00",
+  "generated": "2026-04-17T23:09:20",
   "courseCount": 64,
   "courses": [
     {
@@ -278,8 +278,8 @@
       "hours": 8,
       "outline": {
         "exists": true,
-        "modules": 1,
-        "lessons": 7
+        "modules": 2,
+        "lessons": 5
       },
       "syllabus": true,
       "source": {
@@ -548,8 +548,8 @@
       "hours": 50,
       "outline": {
         "exists": true,
-        "modules": 5,
-        "lessons": 14
+        "modules": 8,
+        "lessons": 17
       },
       "syllabus": true,
       "source": {
@@ -999,7 +999,7 @@
       "outline": {
         "exists": true,
         "modules": 1,
-        "lessons": 13
+        "lessons": 10
       },
       "syllabus": true,
       "source": {
@@ -1118,8 +1118,8 @@
       "hours": 8,
       "outline": {
         "exists": true,
-        "modules": 2,
-        "lessons": 5
+        "modules": 1,
+        "lessons": 7
       },
       "syllabus": true,
       "source": {
@@ -1539,7 +1539,7 @@
       "outline": {
         "exists": true,
         "modules": 1,
-        "lessons": 10
+        "lessons": 13
       },
       "syllabus": true,
       "source": {
@@ -1778,8 +1778,8 @@
       "hours": 20,
       "outline": {
         "exists": true,
-        "modules": 8,
-        "lessons": 17
+        "modules": 5,
+        "lessons": 14
       },
       "syllabus": true,
       "source": {
@@ -1897,17 +1897,17 @@
       "name": "Web Development with JavaScript",
       "hours": 40,
       "outline": {
-        "exists": false,
-        "modules": 0,
-        "lessons": 0
+        "exists": true,
+        "modules": 9,
+        "lessons": 18
       },
-      "syllabus": false,
+      "syllabus": true,
       "source": {
         "exists": true,
         "folder": "Course: Web Development with JavaScript",
         "modules": 1
       },
-      "coverage": null,
+      "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
         "lessons": 3,

--- a/scripts/generate-course-overview.py
+++ b/scripts/generate-course-overview.py
@@ -467,6 +467,59 @@ def parse_hours(text):
             pass
     return 0
 
+def match_folder_json_ids(folders, json_ids):
+    """Pair course-folder names with courses.json ids.
+
+    Deterministic: result depends only on input values, never on set-iteration
+    order or PYTHONHASHSEED. Addresses curriculum-tracking#53, where the prior
+    set-iteration + first-match approach produced different mappings across
+    runs for name families like the Coding Booster courses.
+
+    Scoring (higher = better):
+      1000  exact match (folder_id == json_id)
+       500  de-hyphenated substring match in either direction
+       100 * word_overlap_count  (only counted when overlap >= 2)
+         0  otherwise (treated as no match)
+
+    Assignment is greedy by descending score, with alphabetical tiebreakers;
+    each folder and each json_id is claimed at most once.
+
+    Returns (folder_to_json, json_to_folder) dicts.
+    """
+    json_set = set(json_ids)
+    candidates = []
+
+    for fid in folders:
+        f_words = set(fid.split('-'))
+        f_norm = fid.replace('-', '')
+        for jid in json_ids:
+            if fid == jid:
+                score = 1000
+            else:
+                j_norm = jid.replace('-', '')
+                if f_norm in j_norm or j_norm in f_norm:
+                    score = 500
+                else:
+                    j_words = set(jid.split('-'))
+                    overlap = len(f_words & j_words)
+                    score = 100 * overlap if overlap >= 2 else 0
+            if score > 0:
+                candidates.append((score, fid, jid))
+
+    # Highest score first; then alphabetical for deterministic tiebreaking.
+    candidates.sort(key=lambda c: (-c[0], c[1], c[2]))
+
+    folder_to_json = {}
+    json_to_folder = {}
+    for _score, fid, jid in candidates:
+        if fid in folder_to_json or jid in json_to_folder:
+            continue
+        folder_to_json[fid] = jid
+        json_to_folder[jid] = fid
+
+    return folder_to_json, json_to_folder
+
+
 def parse_outline(outline_path):
     """Simplified outline parser — returns module/lesson counts."""
     try:
@@ -842,35 +895,9 @@ def main():
             if os.path.isdir(p) and d not in ('.template', '.scorm-template'):
                 folders.add(d)
 
-    folder_to_json = {}
-    json_to_folder = {}
-
-    for fid in folders:
-        if fid in json_courses:
-            folder_to_json[fid] = fid
-            json_to_folder[fid] = fid
-
-    unmatched_folders = folders - set(folder_to_json.keys())
-    unmatched_json = set(json_courses.keys()) - set(json_to_folder.keys())
-
-    for fid in unmatched_folders:
-        f_norm = fid.replace('-', '')
-        best = None
-        for jid in unmatched_json:
-            j_norm = jid.replace('-', '')
-            if f_norm in j_norm or j_norm in f_norm:
-                best = jid
-                break
-            f_words = set(fid.split('-'))
-            j_words = set(jid.split('-'))
-            overlap = len(f_words & j_words)
-            if overlap >= max(2, min(len(f_words), len(j_words)) - 1):
-                best = jid
-                break
-        if best:
-            folder_to_json[fid] = best
-            json_to_folder[best] = fid
-            unmatched_json.discard(best)
+    folder_to_json, json_to_folder = match_folder_json_ids(
+        list(folders), list(json_courses.keys())
+    )
 
     overview = []
 

--- a/scripts/test_generate_course_overview.py
+++ b/scripts/test_generate_course_overview.py
@@ -189,5 +189,107 @@ class TestPhase1Scanner(unittest.TestCase):
             self.assertEqual(source_data['module_folders'], {})
 
 
+class TestFolderJsonMatching(unittest.TestCase):
+    """Tests for match_folder_json_ids — the folder↔courses.json id matcher.
+
+    These tests guard against the bug where the fuzzy matcher iterated over
+    Python sets (non-deterministic across hash seeds) and took the first
+    overlap-≥2 match rather than the best match. See curriculum-tracking#53.
+    """
+
+    def test_direct_matches_preserved(self):
+        folders = ['itil-foundations', 'data-literacy']
+        json_ids = ['itil-foundations', 'data-literacy']
+        f2j, j2f = gen_overview.match_folder_json_ids(folders, json_ids)
+        self.assertEqual(f2j, {'itil-foundations': 'itil-foundations',
+                               'data-literacy': 'data-literacy'})
+        self.assertEqual(j2f, {'itil-foundations': 'itil-foundations',
+                               'data-literacy': 'data-literacy'})
+
+    def test_coding_booster_family_maps_correctly(self):
+        """All 5 Coding Booster folders → their matching -intensive json ids."""
+        folders = [
+            'cpp-coding-booster',
+            'java-coding-booster',
+            'javascript-coding-booster',
+            'python-coding-booster',
+            'sql-coding-booster',
+        ]
+        json_ids = [
+            'c-plus-plus-coding-booster-intensive',
+            'java-coding-booster-intensive',
+            'javascript-coding-booster-intensive',
+            'python-coding-booster-intensive',
+            'sql-coding-booster-intensive',
+        ]
+        f2j, _ = gen_overview.match_folder_json_ids(folders, json_ids)
+        self.assertEqual(f2j['cpp-coding-booster'], 'c-plus-plus-coding-booster-intensive')
+        self.assertEqual(f2j['java-coding-booster'], 'java-coding-booster-intensive')
+        self.assertEqual(f2j['javascript-coding-booster'], 'javascript-coding-booster-intensive')
+        self.assertEqual(f2j['python-coding-booster'], 'python-coding-booster-intensive')
+        self.assertEqual(f2j['sql-coding-booster'], 'sql-coding-booster-intensive')
+
+    def test_data_fundamentals_family_maps_correctly(self):
+        """Collision case: folders sharing 'data', 'sql', or 'for' route correctly."""
+        folders = [
+            'sql-for-data',
+            'excel-for-data-analysts',
+            'sql-fundamentals-operations',
+        ]
+        json_ids = [
+            'data-fundamentals-sql-for-data',
+            'data-fundamentals-excel-for-data-analysts',
+            'sql-fundamentals-for-operations',
+        ]
+        f2j, _ = gen_overview.match_folder_json_ids(folders, json_ids)
+        self.assertEqual(f2j['sql-for-data'], 'data-fundamentals-sql-for-data')
+        self.assertEqual(f2j['excel-for-data-analysts'],
+                         'data-fundamentals-excel-for-data-analysts')
+        self.assertEqual(f2j['sql-fundamentals-operations'],
+                         'sql-fundamentals-for-operations')
+
+    def test_unrelated_folders_unmatched(self):
+        """Folders with no shared tokens beyond noise don't get force-matched."""
+        folders = ['astronomy-basics']
+        json_ids = ['cooking-101', 'history-of-rome']
+        f2j, _ = gen_overview.match_folder_json_ids(folders, json_ids)
+        self.assertNotIn('astronomy-basics', f2j)
+
+    def test_deterministic_under_input_permutation(self):
+        """Output must be identical regardless of input list order."""
+        folders_a = [
+            'cpp-coding-booster', 'java-coding-booster',
+            'javascript-coding-booster', 'python-coding-booster',
+            'sql-coding-booster',
+        ]
+        folders_b = list(reversed(folders_a))
+        json_ids_a = [
+            'c-plus-plus-coding-booster-intensive',
+            'java-coding-booster-intensive',
+            'javascript-coding-booster-intensive',
+            'python-coding-booster-intensive',
+            'sql-coding-booster-intensive',
+        ]
+        json_ids_b = list(reversed(json_ids_a))
+        result_a = gen_overview.match_folder_json_ids(folders_a, json_ids_a)
+        result_b = gen_overview.match_folder_json_ids(folders_b, json_ids_b)
+        self.assertEqual(result_a, result_b)
+
+    def test_prefers_substring_over_lower_overlap(self):
+        """A folder id that's a substring of a json id beats a word-overlap peer."""
+        # 'java-coding-booster' is a de-hyphenated substring of
+        # 'java-coding-booster-intensive' (higher score)
+        # but only shares {coding,booster} with 'python-coding-booster-intensive'
+        folders = ['java-coding-booster']
+        json_ids = ['python-coding-booster-intensive', 'java-coding-booster-intensive']
+        f2j, _ = gen_overview.match_folder_json_ids(folders, json_ids)
+        self.assertEqual(f2j['java-coding-booster'], 'java-coding-booster-intensive')
+
+    def test_handles_empty_inputs(self):
+        self.assertEqual(gen_overview.match_folder_json_ids([], []), ({}, {}))
+        self.assertEqual(gen_overview.match_folder_json_ids(['a'], []), ({}, {}))
+        self.assertEqual(gen_overview.match_folder_json_ids([], ['a']), ({}, {}))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Root cause of #53: `generate-course-overview.py`'s fuzzy-match fallback iterated over Python sets (non-deterministic across PYTHONHASHSEED) and took the **first** overlap-≥2 match rather than the **best**. For the Coding Booster family — which all share `{coding, booster}` = 2 words — any pair "matched" under the loose threshold.
- Replaces the inline logic with a pure function `match_folder_json_ids(folders, json_ids)` that scores every pair and assigns greedily by descending score with alphabetical tiebreaks. Output is now stable across PYTHONHASHSEED values.
- 7 course-overview rows now show their folders' actual outline counts (4 Coding Booster + 2 SQL/Data swap + 1 previously-unmatched JavaScript course).

Closes #53.

## Scoring algorithm

| Score | Condition |
|---|---|
| 1000 | `folder_id == json_id` (exact match) |
| 500 | de-hyphenated substring in either direction |
| 100 × N | word overlap of N hyphen-separated tokens (N ≥ 2) |
| 0 | otherwise (treated as no match) |

Greedy assignment: every (folder, json_id) pair is scored; pairs sorted descending by score with alphabetical tiebreaks; iterate and claim each folder/json_id at most once.

## Stability verification

```bash
for seed in 1 7 42 99 200; do
  PYTHONHASHSEED=$seed python3 scripts/generate-course-overview.py --base ... > out-$seed.txt
done
md5 out-*.txt
```

All 5 MD5s identical after the fix (were different before).

## Rows whose counts changed (all verified against `parse_outline()` on the matching folder's markdown)

| Course | Before | After | Folder (source) |
|---|---|---|---|
| c-plus-plus-coding-booster-intensive | 1m/7l | **2m/5l** | `cpp-coding-booster` |
| java-coding-booster-intensive | 1m/13l | **1m/10l** | `java-coding-booster` |
| javascript-coding-booster-intensive | 2m/5l | **1m/7l** | `javascript-coding-booster` |
| python-coding-booster-intensive | 1m/10l | **1m/13l** | `python-coding-booster` |
| data-fundamentals-sql-for-data | 5m/14l | **8m/17l** | `sql-for-data` (was swapped with sql-fundamentals) |
| sql-fundamentals-for-operations | 8m/17l | **5m/14l** | `sql-fundamentals-operations` (was swapped with sql-for-data) |
| web-development-with-javascript | exists:false, 0m/0l | **exists:true, 9m/18l** | `web-dev-javascript-react` (was missed by too-strict overlap ≥ min_len-1 threshold) |

## Tests

7 new unit tests in `scripts/test_generate_course_overview.py`:

- `test_direct_matches_preserved` — direct matches still short-circuit
- `test_coding_booster_family_maps_correctly` — all 5 CB folders → correct json ids
- `test_data_fundamentals_family_maps_correctly` — 3-way collision resolves correctly
- `test_unrelated_folders_unmatched` — truly unrelated folders don't get force-matched
- `test_deterministic_under_input_permutation` — reversed input produces same output
- `test_prefers_substring_over_lower_overlap` — scoring priority is honored
- `test_handles_empty_inputs` — edge cases

All 20 tests pass: `python3 -m unittest scripts.test_generate_course_overview`

## Things to check

- [ ] Dashboard renders without console errors
- [ ] The 4 Coding Booster courses show non-zero module/lesson counts in the status panel
- [ ] Data Fundamentals: SQL for Data and SQL Fundamentals for Operations no longer have swapped counts
- [ ] Web Development with JavaScript row now reads "outline exists" (was previously false)
- [ ] Unit tests pass locally: `python3 -m unittest scripts.test_generate_course_overview`
- [ ] Running `node build.js` twice in a row produces identical `course-overview.json` (no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)