### PR TITLE
Record SCORM packaging state in Data Literacy note

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-17T23:09:20",
+  "generated": "2026-04-17T23:58:10",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -207,7 +207,7 @@ const courseData = [
     },
     "syllabus": "data-literacy",
     "outline": "Course Outline: Data Fundamentals — Data Literacy",
-    "note": "7 modules, 24 lessons. Deployed to deploy/content (PDFs) and deploy/html. PLE manifest generated and integrated.",
+    "note": "7 modules, 24 lessons, 107 PDFs. Deploy repo: apprenti-org/data-literacy-deploy. PLE manifest integrated. Welcome interactive packaged as SCORM 1.2 (ready for Absorb upload).",
     "driveFolder": "https://drive.google.com/drive/folders/17-Ll0td-RhLRdvpzksoFHNX70AZX4ikQ"
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -205,7 +205,7 @@
       },
       "syllabus": "data-literacy",
       "outline": "Course Outline: Data Fundamentals \u2014 Data Literacy",
-      "note": "7 modules, 24 lessons. Deployed to deploy/content (PDFs) and deploy/html. PLE manifest generated and integrated.",
+      "note": "7 modules, 24 lessons, 107 PDFs. Deploy repo: apprenti-org/data-literacy-deploy. PLE manifest integrated. Welcome interactive packaged as SCORM 1.2 (ready for Absorb upload).",
       "driveFolder": "https://drive.google.com/drive/folders/17-Ll0td-RhLRdvpzksoFHNX70AZX4ikQ"
     },
     {


### PR DESCRIPTION
## Summary

- Updates the \`courses.json\` note for Data Literacy to reflect the current deploy state: deploy repo link, PDF count, and SCORM readiness
- Regenerates the auto-built bundles (\`courses.js\`, \`course-overview.json\`)

Closes apprenti-org/design-documentation#77.

## Diff (excluding regenerated bundles and timestamp)

\`\`\`
-  "note": "7 modules, 24 lessons. Deployed to deploy/content (PDFs) and deploy/html. PLE manifest generated and integrated.",
+  "note": "7 modules, 24 lessons, 107 PDFs. Deploy repo: apprenti-org/data-literacy-deploy. PLE manifest integrated. Welcome interactive packaged as SCORM 1.2 (ready for Absorb upload).",
\`\`\`

## Context

This completes Phase 4 of #77 (SCORM packaging for Data Literacy). Phases 1–2 already landed:

- design-documentation#77 Phase 1 — 14-point interactive review logged at \`courses/data-literacy/_REVIEW/interactive-review-log.md\`; welcome interactive updated so \`render()\` calls \`window.completeSCORM?.()\` at the finale slide
- design-documentation#78 — \`package.js --artifact\` flag added (merged)
- design-documentation#77 Phase 2 — \`scorm-intro-to-data-literacy.zip\` packaged and landed in apprenti-org/data-literacy-deploy (PR #1)

Phase 3 (Absorb upload + gating verification) happens out-of-band with LMS owner access. The note leaves "ready for Absorb upload" as the current state so the dashboard accurately describes what's shipped.

## Things to check

- [ ] Diff is limited to the Data Literacy note line and regenerated bundles
- [ ] Dashboard renders; Data Literacy detail panel reflects the new note
- [ ] No course-overview drift (the #53 fix means other courses' counts should be untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)