### PR TITLE
Add Deployed and In LMS columns to status table (fix #44)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -28,7 +28,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 30
+    "totalAssets": 30,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "agile-project-management-with-scrum",
@@ -58,7 +63,12 @@ var courseOverviewData = [
       "modIntros": 4,
       "modRecaps": 8
     },
-    "totalAssets": 67
+    "totalAssets": 67,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "ai-foundations",
@@ -88,7 +98,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "aspnet",
@@ -118,7 +133,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 20
+    "totalAssets": 20,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "business-analysis-fundamentals",
@@ -148,7 +168,12 @@ var courseOverviewData = [
       "modIntros": 1,
       "modRecaps": 4
     },
-    "totalAssets": 176
+    "totalAssets": 176,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "business-and-it-fundamentals",
@@ -178,7 +203,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 9
     },
-    "totalAssets": 84
+    "totalAssets": 84,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "csharp-data-access",
@@ -208,7 +238,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 24
+    "totalAssets": 24,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "csharp-language-fundamentals",
@@ -238,7 +273,12 @@ var courseOverviewData = [
       "modIntros": 2,
       "modRecaps": 0
     },
-    "totalAssets": 49
+    "totalAssets": 49,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "csharp-oop",
@@ -268,7 +308,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 26
+    "totalAssets": 26,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "c-plus-plus-coding-booster-intensive",
@@ -298,7 +343,12 @@ var courseOverviewData = [
       "modIntros": 7,
       "modRecaps": 7
     },
-    "totalAssets": 59
+    "totalAssets": 59,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "ci-cd-pipeline-concepts",
@@ -328,7 +378,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "cloud-fundamentals",
@@ -358,7 +413,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "compliance-and-security-awareness",
@@ -388,7 +448,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 223
+    "totalAssets": 223,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "comptia-a-plus",
@@ -418,7 +483,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 86
+    "totalAssets": 86,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "comptia-network-plus",
@@ -448,7 +518,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "data-fundamentals-data-literacy",
@@ -478,7 +553,12 @@ var courseOverviewData = [
       "modIntros": 1,
       "modRecaps": 0
     },
-    "totalAssets": 98
+    "totalAssets": 98,
+    "deployment": {
+      "state": "Complete",
+      "expected": 1,
+      "actual": 1
+    }
   },
   {
     "id": "data-fundamentals-data-visualizations-and-power-bi",
@@ -508,7 +588,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 106
+    "totalAssets": 106,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "data-fundamentals-excel-for-data-analysts",
@@ -538,7 +623,12 @@ var courseOverviewData = [
       "modIntros": 3,
       "modRecaps": 0
     },
-    "totalAssets": 142
+    "totalAssets": 142,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "data-fundamentals-sql-for-data",
@@ -568,7 +658,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 142
+    "totalAssets": 142,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "databases-in-java",
@@ -598,7 +693,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 92
+    "totalAssets": 92,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "helpdesk-software-fundamentals",
@@ -628,7 +728,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "http-services",
@@ -658,7 +763,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "infrastructure-as-code-fundamentals",
@@ -688,7 +798,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "instructor-onboarding",
@@ -718,7 +833,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "introduction-to-advanced-concepts-in-java",
@@ -748,7 +868,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 44
+    "totalAssets": 44,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "introduction-to-aws-cloud-platform",
@@ -778,7 +903,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 133
+    "totalAssets": 133,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "introduction-to-cloud-technology",
@@ -808,7 +938,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 59
+    "totalAssets": 59,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "introduction-to-github",
@@ -838,7 +973,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 10
+    "totalAssets": 10,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "introduction-to-html-and-css",
@@ -868,7 +1008,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 45
+    "totalAssets": 45,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "introduction-to-microsoft-teams",
@@ -898,7 +1043,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "it-fundamentals",
@@ -928,7 +1078,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 81
+    "totalAssets": 81,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "itil-foundations",
@@ -958,7 +1113,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 101
+    "totalAssets": 101,
+    "deployment": {
+      "state": "Complete",
+      "expected": 19,
+      "actual": 19
+    }
   },
   {
     "id": "itil-specialist-4",
@@ -988,7 +1148,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "java-coding-booster-intensive",
@@ -1018,7 +1183,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 15
+    "totalAssets": 15,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "java-language-fundamentals",
@@ -1048,7 +1218,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 62
+    "totalAssets": 62,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "java-oop",
@@ -1078,7 +1253,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 132
+    "totalAssets": 132,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "javascript",
@@ -1108,7 +1288,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "javascript-coding-booster-intensive",
@@ -1138,7 +1323,12 @@ var courseOverviewData = [
       "modIntros": 1,
       "modRecaps": 0
     },
-    "totalAssets": 9
+    "totalAssets": 9,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "javascript-react-for-csharp",
@@ -1168,7 +1358,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 50
+    "totalAssets": 50,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "layers-and-file-i-o-for-csharp",
@@ -1198,7 +1393,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 34
+    "totalAssets": 34,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "linq-and-dependency-injection",
@@ -1228,7 +1428,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 26
+    "totalAssets": 26,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "linux-foundations",
@@ -1258,7 +1463,12 @@ var courseOverviewData = [
       "modIntros": 5,
       "modRecaps": 3
     },
-    "totalAssets": 74
+    "totalAssets": 74,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "macos-administration-fundamentals",
@@ -1288,7 +1498,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "microsoft-365-endpoint-administrator",
@@ -1318,7 +1533,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 41
+    "totalAssets": 41,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "microsoft-365-fundamentals",
@@ -1348,7 +1568,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 37
+    "totalAssets": 37,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "networking-fundamentals",
@@ -1378,7 +1603,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "non-relational-data",
@@ -1408,7 +1638,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 43
+    "totalAssets": 43,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "pandas",
@@ -1438,7 +1673,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 30
+    "totalAssets": 30,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "productivity-tools-reporting",
@@ -1468,7 +1708,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 29
+    "totalAssets": 29,
+    "deployment": {
+      "state": "Complete",
+      "expected": 4,
+      "actual": 4
+    }
   },
   {
     "id": "professional-communication",
@@ -1498,7 +1743,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "python-basics-for-software-dev",
@@ -1528,7 +1778,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 77
+    "totalAssets": 77,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "python-coding-booster-intensive",
@@ -1558,7 +1813,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 32
+    "totalAssets": 32,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "python-for-infrastructure-automation",
@@ -1588,7 +1848,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "react",
@@ -1618,7 +1883,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "security-and-cybersecurity-fundamentals",
@@ -1648,7 +1918,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 223
+    "totalAssets": 223,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "software-developer-pre-work",
@@ -1678,7 +1953,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "software-development-lifecycle",
@@ -1708,7 +1988,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "sql-coding-booster-intensive",
@@ -1738,7 +2023,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 8
+    "totalAssets": 8,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "sql-for-csharp",
@@ -1768,7 +2058,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 49
+    "totalAssets": 49,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "sql-fundamentals-for-operations",
@@ -1798,7 +2093,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 142
+    "totalAssets": 142,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "student-onboarding",
@@ -1828,7 +2128,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "technical-documentation",
@@ -1858,7 +2163,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "troubleshooting-supporting-in-an-enterprise-environment",
@@ -1888,7 +2198,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 70
+    "totalAssets": 70,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   },
   {
     "id": "web-development-with-javascript",
@@ -1918,7 +2233,12 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 15
+    "totalAssets": 15,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
   }
 ];
 

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-17T23:58:10",
+  "generated": "2026-04-18T00:07:29",
   "courseCount": 64,
   "courses": [
     {
@@ -30,7 +30,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 30
+      "totalAssets": 30,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "agile-project-management-with-scrum",
@@ -60,7 +65,12 @@
         "modIntros": 4,
         "modRecaps": 8
       },
-      "totalAssets": 67
+      "totalAssets": 67,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "ai-foundations",
@@ -90,7 +100,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "aspnet",
@@ -120,7 +135,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 20
+      "totalAssets": 20,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "business-analysis-fundamentals",
@@ -150,7 +170,12 @@
         "modIntros": 1,
         "modRecaps": 4
       },
-      "totalAssets": 176
+      "totalAssets": 176,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "business-and-it-fundamentals",
@@ -180,7 +205,12 @@
         "modIntros": 0,
         "modRecaps": 9
       },
-      "totalAssets": 84
+      "totalAssets": 84,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "csharp-data-access",
@@ -210,7 +240,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 24
+      "totalAssets": 24,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "csharp-language-fundamentals",
@@ -240,7 +275,12 @@
         "modIntros": 2,
         "modRecaps": 0
       },
-      "totalAssets": 49
+      "totalAssets": 49,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "csharp-oop",
@@ -270,7 +310,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 26
+      "totalAssets": 26,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "c-plus-plus-coding-booster-intensive",
@@ -300,7 +345,12 @@
         "modIntros": 7,
         "modRecaps": 7
       },
-      "totalAssets": 59
+      "totalAssets": 59,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "ci-cd-pipeline-concepts",
@@ -330,7 +380,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "cloud-fundamentals",
@@ -360,7 +415,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "compliance-and-security-awareness",
@@ -390,7 +450,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 223
+      "totalAssets": 223,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "comptia-a-plus",
@@ -420,7 +485,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 86
+      "totalAssets": 86,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "comptia-network-plus",
@@ -450,7 +520,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "data-fundamentals-data-literacy",
@@ -480,7 +555,12 @@
         "modIntros": 1,
         "modRecaps": 0
       },
-      "totalAssets": 98
+      "totalAssets": 98,
+      "deployment": {
+        "state": "Complete",
+        "expected": 1,
+        "actual": 1
+      }
     },
     {
       "id": "data-fundamentals-data-visualizations-and-power-bi",
@@ -510,7 +590,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 106
+      "totalAssets": 106,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "data-fundamentals-excel-for-data-analysts",
@@ -540,7 +625,12 @@
         "modIntros": 3,
         "modRecaps": 0
       },
-      "totalAssets": 142
+      "totalAssets": 142,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "data-fundamentals-sql-for-data",
@@ -570,7 +660,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 142
+      "totalAssets": 142,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "databases-in-java",
@@ -600,7 +695,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 92
+      "totalAssets": 92,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "helpdesk-software-fundamentals",
@@ -630,7 +730,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "http-services",
@@ -660,7 +765,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "infrastructure-as-code-fundamentals",
@@ -690,7 +800,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "instructor-onboarding",
@@ -720,7 +835,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "introduction-to-advanced-concepts-in-java",
@@ -750,7 +870,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 44
+      "totalAssets": 44,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "introduction-to-aws-cloud-platform",
@@ -780,7 +905,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 133
+      "totalAssets": 133,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "introduction-to-cloud-technology",
@@ -810,7 +940,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 59
+      "totalAssets": 59,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "introduction-to-github",
@@ -840,7 +975,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 10
+      "totalAssets": 10,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "introduction-to-html-and-css",
@@ -870,7 +1010,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 45
+      "totalAssets": 45,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "introduction-to-microsoft-teams",
@@ -900,7 +1045,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "it-fundamentals",
@@ -930,7 +1080,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 81
+      "totalAssets": 81,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "itil-foundations",
@@ -960,7 +1115,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 101
+      "totalAssets": 101,
+      "deployment": {
+        "state": "Complete",
+        "expected": 19,
+        "actual": 19
+      }
     },
     {
       "id": "itil-specialist-4",
@@ -990,7 +1150,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "java-coding-booster-intensive",
@@ -1020,7 +1185,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 15
+      "totalAssets": 15,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "java-language-fundamentals",
@@ -1050,7 +1220,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 62
+      "totalAssets": 62,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "java-oop",
@@ -1080,7 +1255,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 132
+      "totalAssets": 132,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "javascript",
@@ -1110,7 +1290,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "javascript-coding-booster-intensive",
@@ -1140,7 +1325,12 @@
         "modIntros": 1,
         "modRecaps": 0
       },
-      "totalAssets": 9
+      "totalAssets": 9,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "javascript-react-for-csharp",
@@ -1170,7 +1360,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 50
+      "totalAssets": 50,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "layers-and-file-i-o-for-csharp",
@@ -1200,7 +1395,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 34
+      "totalAssets": 34,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "linq-and-dependency-injection",
@@ -1230,7 +1430,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 26
+      "totalAssets": 26,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "linux-foundations",
@@ -1260,7 +1465,12 @@
         "modIntros": 5,
         "modRecaps": 3
       },
-      "totalAssets": 74
+      "totalAssets": 74,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "macos-administration-fundamentals",
@@ -1290,7 +1500,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "microsoft-365-endpoint-administrator",
@@ -1320,7 +1535,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 41
+      "totalAssets": 41,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "microsoft-365-fundamentals",
@@ -1350,7 +1570,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 37
+      "totalAssets": 37,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "networking-fundamentals",
@@ -1380,7 +1605,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "non-relational-data",
@@ -1410,7 +1640,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 43
+      "totalAssets": 43,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "pandas",
@@ -1440,7 +1675,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 30
+      "totalAssets": 30,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "productivity-tools-reporting",
@@ -1470,7 +1710,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 29
+      "totalAssets": 29,
+      "deployment": {
+        "state": "Complete",
+        "expected": 4,
+        "actual": 4
+      }
     },
     {
       "id": "professional-communication",
@@ -1500,7 +1745,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "python-basics-for-software-dev",
@@ -1530,7 +1780,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 77
+      "totalAssets": 77,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "python-coding-booster-intensive",
@@ -1560,7 +1815,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 32
+      "totalAssets": 32,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "python-for-infrastructure-automation",
@@ -1590,7 +1850,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "react",
@@ -1620,7 +1885,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "security-and-cybersecurity-fundamentals",
@@ -1650,7 +1920,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 223
+      "totalAssets": 223,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "software-developer-pre-work",
@@ -1680,7 +1955,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "software-development-lifecycle",
@@ -1710,7 +1990,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "sql-coding-booster-intensive",
@@ -1740,7 +2025,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 8
+      "totalAssets": 8,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "sql-for-csharp",
@@ -1770,7 +2060,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 49
+      "totalAssets": 49,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "sql-fundamentals-for-operations",
@@ -1800,7 +2095,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 142
+      "totalAssets": 142,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "student-onboarding",
@@ -1830,7 +2130,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "technical-documentation",
@@ -1860,7 +2165,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "troubleshooting-supporting-in-an-enterprise-environment",
@@ -1890,7 +2200,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 70
+      "totalAssets": 70,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     },
     {
       "id": "web-development-with-javascript",
@@ -1920,7 +2235,12 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 15
+      "totalAssets": 15,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
     }
   ]
 }

--- a/courses.js
+++ b/courses.js
@@ -418,7 +418,8 @@ const courseData = [
     "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep.",
     "driveFolder": "https://drive.google.com/drive/folders/1aljEOFGVRecJDz1QsGRCNTjBs-i81esw",
     "deployRepo": "https://github.com/apprenti-org/itil-foundations-content",
-    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+    "lms": "Complete"
   },
   {
     "id": "itil-specialist-4",

--- a/courses.json
+++ b/courses.json
@@ -416,7 +416,8 @@
       "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep.",
       "driveFolder": "https://drive.google.com/drive/folders/1aljEOFGVRecJDz1QsGRCNTjBs-i81esw",
       "deployRepo": "https://github.com/apprenti-org/itil-foundations-content",
-      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+      "lms": "Complete"
     },
     {
       "id": "itil-specialist-4",

--- a/js/shared/constants.js
+++ b/js/shared/constants.js
@@ -14,6 +14,21 @@ var STATUS_CLASSES = {
     'Complete': 'complete'
 };
 
+// Post-development state column classes (reuse existing pill colors).
+var DEPLOYMENT_CLASSES = {
+    'Complete': 'complete',
+    'Partial': 'in-progress',
+    'Not Packaged': 'scoping',
+    'Not Deployed': 'not-started'
+};
+
+var LMS_VALUES = ['Not Uploaded', 'Partial', 'Complete'];
+var LMS_CLASSES = {
+    'Not Uploaded': 'not-started',
+    'Partial': 'in-progress',
+    'Complete': 'complete'
+};
+
 // Syllabi map — course name → HTML filename in syllabi/
 // Add entries here as syllabi are rendered to HTML
 var syllabiMap = {

--- a/js/status/init.js
+++ b/js/status/init.js
@@ -30,6 +30,9 @@ var contentData = courseData.map(function(c) {
         lessonsWithContent: ov ? ov.lessonsWithContent : 0,
         totalAssets: ov ? ov.totalAssets : 0,
         assets: ov ? ov.assets : null,
+        // Post-development state
+        deployment: ov && ov.deployment ? ov.deployment : { state: 'Not Deployed', expected: 0, actual: 0 },
+        lms: c.lms || 'Not Uploaded',
         // Link data for doc icons
         driveFolder: c.driveFolder || '',
         syllabusUrl: (typeof syllabiMap !== 'undefined' && syllabiMap[c.name]) ? 'syllabi/' + syllabiMap[c.name] : '',

--- a/js/status/table.js
+++ b/js/status/table.js
@@ -37,6 +37,37 @@ function renderDocLink(exists, url, icon, titleYes, titleNo) {
 }
 
 /**
+ * Render the Deployed pill (auto-derived).
+ */
+function renderDeploymentPill(dep) {
+    var state = (dep && dep.state) || 'Not Deployed';
+    var cls = DEPLOYMENT_CLASSES[state] || 'not-started';
+    var label = state;
+    if (state === 'Partial' && dep && typeof dep.actual === 'number' && typeof dep.expected === 'number') {
+        label = 'Partial (' + dep.actual + '/' + dep.expected + ')';
+    }
+    return '<span class="status-pill status-' + cls + '" title="SCORM packages: ' +
+        (dep ? dep.actual + '/' + dep.expected : '0/0') +
+        '"><span class="status-dot dot-' + cls + '"></span>' + label + '</span>';
+}
+
+/**
+ * Render the In-LMS pill with a click-to-toggle dropdown.
+ */
+function renderLmsPill(value, idx) {
+    var v = value || 'Not Uploaded';
+    var cls = LMS_CLASSES[v] || 'not-started';
+    return '<span class="status-pill status-' + cls + '" onclick="toggleDropdown(event, ' + idx + ', \'lms\')">' +
+        '<span class="status-dot dot-' + cls + '"></span>' + v + '</span>' +
+        '<div class="status-dropdown" id="dd-lms-' + idx + '">' +
+        LMS_VALUES.map(function(s) {
+            return '<div class="status-option" onclick="setStatus(' + idx + ', \'lms\', \'' + s + '\')">' +
+                '<span class="status-dot dot-' + LMS_CLASSES[s] + '"></span> ' + s + '</div>';
+        }).join('') +
+        '</div>';
+}
+
+/**
  * Render document readiness icons (outline, syllabus, source)
  */
 function renderDocsIcons(item) {
@@ -86,6 +117,8 @@ function renderTable() {
             '<td class="asset-td">' + renderAssetCell(assets.slides) + '</td>' +
             '<td class="asset-td">' + renderAssetCell(assets.quizzes) + '</td>' +
             '<td class="asset-td">' + renderAssetCell(assets.activities) + '</td>' +
+            '<td class="status-cell">' + renderDeploymentPill(item.deployment) + '</td>' +
+            '<td class="status-cell">' + renderLmsPill(item.lms, realIdx) + '</td>' +
         '</tr>';
     }).join('');
 
@@ -113,6 +146,8 @@ function renderTable() {
             '<th><i class="fa-solid fa-tv"></i> Slides / SCORM</th>' +
             '<th><i class="fa-solid fa-circle-question"></i> Quizzes</th>' +
             '<th><i class="fa-solid fa-flask"></i> Activities</th>' +
+            '<th>Deployed</th>' +
+            '<th>In LMS</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
 }
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -53,6 +53,16 @@ function validateSchema(data, config) {
         errors.push(`courses[${i}] (${course.name}): missing "status.development"`);
       }
     }
+
+    // Optional lms field — tracks Absorb upload state (see #44).
+    if (course.lms !== undefined) {
+      const allowed = ['Not Uploaded', 'Partial', 'Complete'];
+      if (!allowed.includes(course.lms)) {
+        errors.push(
+          `courses[${i}] (${course.name}): "lms" must be one of ${allowed.join(', ')} (got "${course.lms}")`
+        );
+      }
+    }
   });
 
   // Validate each curriculum entry

--- a/scripts/generate-course-overview.py
+++ b/scripts/generate-course-overview.py
@@ -467,6 +467,64 @@ def parse_hours(text):
             pass
     return 0
 
+def compute_deployment_status(course_dir):
+    """Derive the Deployed pill state for a course.
+
+    Returns {state, expected, actual}:
+      expected = count of source interactives (both lesson-level
+                 modules/.../lessons/.../interactive.html and course-level
+                 interactives/*.html files)
+      actual   = count of packaged SCORM zips under deploy/content/**
+                 whose filenames start with 'scorm-' and end with '.zip'
+      state    = one of:
+        'Not Deployed'  — deploy/content/ missing
+        'Not Packaged'  — deploy/content/ exists, interactives exist, zero SCORMs
+        'Partial'       — 0 < actual < expected
+        'Complete'      — actual >= expected (includes expected=0 PDFs-only case)
+
+    curriculum-tracking#44.
+    """
+    deploy_content = os.path.join(course_dir, 'deploy', 'content')
+    deploy_exists = os.path.isdir(deploy_content)
+
+    expected = 0
+    modules_dir = os.path.join(course_dir, 'modules')
+    if os.path.isdir(modules_dir):
+        for mod in os.listdir(modules_dir):
+            lessons_dir = os.path.join(modules_dir, mod, 'lessons')
+            if not os.path.isdir(lessons_dir):
+                continue
+            for les in os.listdir(lessons_dir):
+                if os.path.isfile(os.path.join(lessons_dir, les, 'interactive.html')):
+                    expected += 1
+
+    course_interactives_dir = os.path.join(course_dir, 'interactives')
+    if os.path.isdir(course_interactives_dir):
+        for f in os.listdir(course_interactives_dir):
+            if f.lower().endswith('.html'):
+                expected += 1
+
+    actual = 0
+    if deploy_exists:
+        for root, _dirs, files in os.walk(deploy_content):
+            for f in files:
+                if f.startswith('scorm-') and f.lower().endswith('.zip'):
+                    actual += 1
+
+    if not deploy_exists:
+        state = 'Not Deployed'
+    elif expected == 0:
+        state = 'Complete'
+    elif actual == 0:
+        state = 'Not Packaged'
+    elif actual >= expected:
+        state = 'Complete'
+    else:
+        state = 'Partial'
+
+    return {'state': state, 'expected': expected, 'actual': actual}
+
+
 def match_folder_json_ids(folders, json_ids):
     """Pair course-folder names with courses.json ids.
 
@@ -940,6 +998,13 @@ def main():
         total_assets = sum(assets.values())
         source_modules = len([k for k in source_data['module_folders'] if k < 100])
 
+        course_folder_path = os.path.join(courses_dir, folder_id)
+        deployment = (
+            compute_deployment_status(course_folder_path)
+            if os.path.isdir(course_folder_path)
+            else {'state': 'Not Deployed', 'expected': 0, 'actual': 0}
+        )
+
         entry = {
             'id': cid,
             'name': name,
@@ -951,6 +1016,7 @@ def main():
             'lessonsWithContent': lessons_with_content,
             'assets': assets,
             'totalAssets': total_assets,
+            'deployment': deployment,
         }
 
         overview.append(entry)

--- a/scripts/test_generate_course_overview.py
+++ b/scripts/test_generate_course_overview.py
@@ -291,5 +291,113 @@ class TestFolderJsonMatching(unittest.TestCase):
         self.assertEqual(gen_overview.match_folder_json_ids([], ['a']), ({}, {}))
 
 
+class TestDeploymentStatus(unittest.TestCase):
+    """Tests for compute_deployment_status — counts source interactives and
+    packaged SCORMs to derive a Deployed pill state for the dashboard.
+
+    See curriculum-tracking#44.
+    """
+
+    def _make_course(self, tmp, slug, lessons_with_interactive=0, course_interactives=0, scorms=0):
+        """Build a minimal course folder tree in tmp and return its path."""
+        course_dir = os.path.join(tmp, 'courses', slug)
+        for i in range(lessons_with_interactive):
+            lesson_dir = os.path.join(course_dir, 'modules', f'01-m1', 'lessons', f'{i+1:02d}-l{i+1}')
+            os.makedirs(lesson_dir, exist_ok=True)
+            with open(os.path.join(lesson_dir, 'interactive.html'), 'w') as f:
+                f.write('<html></html>')
+        if course_interactives > 0:
+            ci_dir = os.path.join(course_dir, 'interactives')
+            os.makedirs(ci_dir, exist_ok=True)
+            for i in range(course_interactives):
+                with open(os.path.join(ci_dir, f'intro-{i}.html'), 'w') as f:
+                    f.write('<html></html>')
+        if scorms > 0:
+            deploy = os.path.join(course_dir, 'deploy', 'content')
+            os.makedirs(deploy, exist_ok=True)
+            for i in range(scorms):
+                with open(os.path.join(deploy, f'scorm-{slug}-{i}.zip'), 'w') as f:
+                    f.write('')
+        elif scorms == 0:
+            # Create deploy/content/ even with no scorms to exercise the
+            # "not packaged" vs "not deployed" branches.
+            pass
+        return course_dir
+
+    def test_not_deployed_when_deploy_folder_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(tmp, 'foo', lessons_with_interactive=3)
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Not Deployed')
+            self.assertEqual(result['expected'], 3)
+            self.assertEqual(result['actual'], 0)
+
+    def test_complete_when_design_first_lessons_all_packaged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(tmp, 'itil', lessons_with_interactive=5, scorms=5)
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Complete')
+            self.assertEqual(result['expected'], 5)
+            self.assertEqual(result['actual'], 5)
+
+    def test_complete_when_content_first_welcome_packaged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(tmp, 'data-lit', course_interactives=1, scorms=1)
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Complete')
+            self.assertEqual(result['expected'], 1)
+            self.assertEqual(result['actual'], 1)
+
+    def test_partial_when_some_lessons_packaged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(tmp, 'mid', lessons_with_interactive=5, scorms=2)
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Partial')
+            self.assertEqual(result['expected'], 5)
+            self.assertEqual(result['actual'], 2)
+
+    def test_not_packaged_when_interactives_exist_but_no_scorms(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Create deploy tree (so not "Not Deployed") but without any scorms
+            course_dir = self._make_course(tmp, 'early', lessons_with_interactive=3)
+            os.makedirs(os.path.join(course_dir, 'deploy', 'content'), exist_ok=True)
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Not Packaged')
+            self.assertEqual(result['expected'], 3)
+            self.assertEqual(result['actual'], 0)
+
+    def test_complete_when_no_interactives_and_deploy_exists(self):
+        """PDFs-only course: no interactives → nothing to SCORM-wrap. If deploy
+        tree exists, the course is fully deployed for its shape."""
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(tmp, 'pdfs-only')
+            os.makedirs(os.path.join(course_dir, 'deploy', 'content'), exist_ok=True)
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Complete')
+            self.assertEqual(result['expected'], 0)
+            self.assertEqual(result['actual'], 0)
+
+    def test_combined_lesson_and_course_level_interactives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(
+                tmp, 'hybrid', lessons_with_interactive=4, course_interactives=1, scorms=5
+            )
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['state'], 'Complete')
+            self.assertEqual(result['expected'], 5)
+            self.assertEqual(result['actual'], 5)
+
+    def test_ignores_non_scorm_zips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = self._make_course(tmp, 'zips', lessons_with_interactive=1, scorms=1)
+            # Add a non-SCORM zip that shouldn't count
+            deploy = os.path.join(course_dir, 'deploy', 'content')
+            with open(os.path.join(deploy, 'asset-bundle.zip'), 'w') as f:
+                f.write('')
+            result = gen_overview.compute_deployment_status(course_dir)
+            self.assertEqual(result['actual'], 1)
+            self.assertEqual(result['state'], 'Complete')
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds two new columns to the Design & Development Status table:

- **Deployed** — auto-derived from the source tree: counts interactives + packaged SCORMs, shows Complete / Partial / Not Packaged / Not Deployed.
- **In LMS** — manual enum field in `courses.json` (`Not Uploaded | Partial | Complete`), with click-to-toggle dropdown matching the existing Design/Dev Status UX.

Closes #44.

## Refinement to the original spec

The issue proposed "SCORM zip count == lesson count" as the Deployed completeness rule. That rule is design-first-centric and misrepresents content-first courses: Data Literacy has 1 course-level welcome interactive vs 24 lessons, so it would show "Partial (1/24)" despite being fully packaged.

Replaced with **"SCORM count == source-interactive count"**, where expected interactives are counted from:

- `modules/NN-slug/lessons/NN-slug/interactive.html` (design-first)
- `interactives/*.html` (content-first course-level welcomes)

This gives each course shape the correct reading:

| Course | Expected | Actual | Deployed |
|---|---|---|---|
| ITIL Foundations | 19 | 19 | Complete |
| Productivity Tools for Technical Reporting | 4 | 4 | Complete |
| Data Fundamentals — Data Literacy | 1 | 1 | Complete |
| (all others) | varies | 0 | Not Deployed |

A new "Not Packaged" state catches the case where `deploy/content/` exists with interactives present but zero SCORMs.

## Implementation

- **`scripts/generate-course-overview.py`** — new pure function `compute_deployment_status(course_dir)` returning `{state, expected, actual}`. Integrated into the per-course overview loop.
- **`scripts/test_generate_course_overview.py`** — 8 new unit tests covering all four states, design-first + content-first shapes, hybrid (both kinds), and the `scorm-*.zip` filename filter. **28 tests pass total** (was 20).
- **`lib/validators.js`** — allows optional `lms` field with enum validation.
- **`js/shared/constants.js`** — `DEPLOYMENT_CLASSES`, `LMS_VALUES`, `LMS_CLASSES` maps (reuse existing pill color classes; no new CSS needed).
- **`js/status/init.js`** — `deployment` and `lms` fields on each `contentData` entry.
- **`js/status/table.js`** — `renderDeploymentPill`, `renderLmsPill` helpers; two new `<th>` + `<td>` cells appended after Activities.
- **`courses.json`** — seeded `lms: "Complete"` on `itil-foundations`.

## Things to check

- [ ] `python3 -m unittest scripts.test_generate_course_overview` → 28 tests pass
- [ ] `node build.js` succeeds, no new validation warnings
- [ ] Dashboard at `status.html` renders two new columns at the end of the row
- [ ] ITIL Foundations shows Deployed: Complete, In LMS: Complete (both green)
- [ ] Data Literacy and Productivity Tools show Deployed: Complete, In LMS: Not Uploaded
- [ ] All other courses show Deployed: Not Deployed, In LMS: Not Uploaded (both gray)
- [ ] Clicking the In LMS pill opens a dropdown with 3 options, and selecting one updates the row in-session
- [ ] Partial (N/M) label appears if you manually test with a half-packaged course (e.g., delete a SCORM zip and rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)