### PR TITLE
Scope Phase 1 PDF recognition (fix #36)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -543,7 +543,7 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 51,
+      "lessons": 26,
       "slides": 0,
       "quizzes": 1,
       "activities": 45,
@@ -553,7 +553,7 @@ var courseOverviewData = [
       "modIntros": 1,
       "modRecaps": 0
     },
-    "totalAssets": 98,
+    "totalAssets": 73,
     "deployment": {
       "state": "Complete",
       "expected": 1,
@@ -578,7 +578,7 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 28,
+      "lessons": 14,
       "slides": 14,
       "quizzes": 0,
       "activities": 59,
@@ -588,7 +588,7 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 106,
+    "totalAssets": 92,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -613,17 +613,17 @@ var courseOverviewData = [
     "coverage": 14,
     "lessonsWithContent": 2,
     "assets": {
-      "lessons": 30,
+      "lessons": 15,
       "slides": 25,
       "quizzes": 0,
       "activities": 80,
-      "demos": 4,
+      "demos": 2,
       "caseStudies": 0,
       "instructorGuides": 0,
       "modIntros": 3,
       "modRecaps": 0
     },
-    "totalAssets": 142,
+    "totalAssets": 125,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -648,17 +648,17 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 33,
+      "lessons": 17,
       "slides": 12,
       "quizzes": 0,
       "activities": 83,
-      "demos": 8,
+      "demos": 5,
       "caseStudies": 0,
       "instructorGuides": 6,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 142,
+    "totalAssets": 123,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -683,7 +683,7 @@ var courseOverviewData = [
     "coverage": null,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 41,
+      "lessons": 24,
       "slides": 2,
       "quizzes": 0,
       "activities": 49,
@@ -693,7 +693,7 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 92,
+    "totalAssets": 75,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -858,7 +858,7 @@ var courseOverviewData = [
     "coverage": null,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 24,
+      "lessons": 16,
       "slides": 0,
       "quizzes": 0,
       "activities": 20,
@@ -868,7 +868,7 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 44,
+    "totalAssets": 36,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -893,17 +893,17 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 74,
+      "lessons": 39,
       "slides": 10,
       "quizzes": 0,
       "activities": 45,
-      "demos": 4,
+      "demos": 2,
       "caseStudies": 0,
       "instructorGuides": 0,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 133,
+    "totalAssets": 96,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -928,17 +928,17 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 43,
+      "lessons": 21,
       "slides": 2,
       "quizzes": 0,
-      "activities": 2,
-      "demos": 12,
+      "activities": 4,
+      "demos": 6,
       "caseStudies": 0,
       "instructorGuides": 0,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 59,
+    "totalAssets": 33,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1243,17 +1243,17 @@ var courseOverviewData = [
     "coverage": null,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 48,
+      "lessons": 24,
       "slides": 0,
       "quizzes": 0,
       "activities": 67,
-      "demos": 17,
+      "demos": 9,
       "caseStudies": 0,
       "instructorGuides": 0,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 132,
+    "totalAssets": 100,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1628,7 +1628,7 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 13,
+      "lessons": 12,
       "slides": 1,
       "quizzes": 0,
       "activities": 28,
@@ -1638,7 +1638,7 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 43,
+    "totalAssets": 42,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1663,7 +1663,7 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 11,
+      "lessons": 6,
       "slides": 1,
       "quizzes": 0,
       "activities": 18,
@@ -1673,7 +1673,7 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 30,
+    "totalAssets": 25,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1768,7 +1768,7 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 11,
+      "lessons": 9,
       "slides": 4,
       "quizzes": 1,
       "activities": 60,
@@ -1778,7 +1778,7 @@ var courseOverviewData = [
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 77,
+    "totalAssets": 75,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -2083,17 +2083,17 @@ var courseOverviewData = [
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 33,
+      "lessons": 17,
       "slides": 12,
       "quizzes": 0,
       "activities": 83,
-      "demos": 8,
+      "demos": 5,
       "caseStudies": 0,
       "instructorGuides": 6,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 142,
+    "totalAssets": 123,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-18T00:07:29",
+  "generated": "2026-04-18T06:37:11",
   "courseCount": 64,
   "courses": [
     {
@@ -545,7 +545,7 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 51,
+        "lessons": 26,
         "slides": 0,
         "quizzes": 1,
         "activities": 45,
@@ -555,7 +555,7 @@
         "modIntros": 1,
         "modRecaps": 0
       },
-      "totalAssets": 98,
+      "totalAssets": 73,
       "deployment": {
         "state": "Complete",
         "expected": 1,
@@ -580,7 +580,7 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 28,
+        "lessons": 14,
         "slides": 14,
         "quizzes": 0,
         "activities": 59,
@@ -590,7 +590,7 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 106,
+      "totalAssets": 92,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -615,17 +615,17 @@
       "coverage": 14,
       "lessonsWithContent": 2,
       "assets": {
-        "lessons": 30,
+        "lessons": 15,
         "slides": 25,
         "quizzes": 0,
         "activities": 80,
-        "demos": 4,
+        "demos": 2,
         "caseStudies": 0,
         "instructorGuides": 0,
         "modIntros": 3,
         "modRecaps": 0
       },
-      "totalAssets": 142,
+      "totalAssets": 125,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -650,17 +650,17 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 33,
+        "lessons": 17,
         "slides": 12,
         "quizzes": 0,
         "activities": 83,
-        "demos": 8,
+        "demos": 5,
         "caseStudies": 0,
         "instructorGuides": 6,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 142,
+      "totalAssets": 123,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -685,7 +685,7 @@
       "coverage": null,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 41,
+        "lessons": 24,
         "slides": 2,
         "quizzes": 0,
         "activities": 49,
@@ -695,7 +695,7 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 92,
+      "totalAssets": 75,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -860,7 +860,7 @@
       "coverage": null,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 24,
+        "lessons": 16,
         "slides": 0,
         "quizzes": 0,
         "activities": 20,
@@ -870,7 +870,7 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 44,
+      "totalAssets": 36,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -895,17 +895,17 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 74,
+        "lessons": 39,
         "slides": 10,
         "quizzes": 0,
         "activities": 45,
-        "demos": 4,
+        "demos": 2,
         "caseStudies": 0,
         "instructorGuides": 0,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 133,
+      "totalAssets": 96,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -930,17 +930,17 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 43,
+        "lessons": 21,
         "slides": 2,
         "quizzes": 0,
-        "activities": 2,
-        "demos": 12,
+        "activities": 4,
+        "demos": 6,
         "caseStudies": 0,
         "instructorGuides": 0,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 59,
+      "totalAssets": 33,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1245,17 +1245,17 @@
       "coverage": null,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 48,
+        "lessons": 24,
         "slides": 0,
         "quizzes": 0,
         "activities": 67,
-        "demos": 17,
+        "demos": 9,
         "caseStudies": 0,
         "instructorGuides": 0,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 132,
+      "totalAssets": 100,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1630,7 +1630,7 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 13,
+        "lessons": 12,
         "slides": 1,
         "quizzes": 0,
         "activities": 28,
@@ -1640,7 +1640,7 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 43,
+      "totalAssets": 42,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1665,7 +1665,7 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 11,
+        "lessons": 6,
         "slides": 1,
         "quizzes": 0,
         "activities": 18,
@@ -1675,7 +1675,7 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 30,
+      "totalAssets": 25,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1770,7 +1770,7 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 11,
+        "lessons": 9,
         "slides": 4,
         "quizzes": 1,
         "activities": 60,
@@ -1780,7 +1780,7 @@
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 77,
+      "totalAssets": 75,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -2085,17 +2085,17 @@
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 33,
+        "lessons": 17,
         "slides": 12,
         "quizzes": 0,
         "activities": 83,
-        "demos": 8,
+        "demos": 5,
         "caseStudies": 0,
         "instructorGuides": 6,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 142,
+      "totalAssets": 123,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,

--- a/scripts/generate-course-overview.py
+++ b/scripts/generate-course-overview.py
@@ -39,7 +39,37 @@ def auto_detect_base():
     return None
 
 def is_doc(f):
-    return f.endswith('.gdoc') or f.endswith('.docx') or f.endswith('.doc') or f.endswith('.md') or f.endswith('.pdf')
+    # Restricted to author-editable source formats. `.pdf` is intentionally
+    # excluded: legacy _COURSES/ trees contain rendered PDF mirrors alongside
+    # .gdoc sources, and including .pdf here double-counts them as lessons,
+    # quizzes, activities, etc. Phase 1 deploy-tree PDFs are handled by
+    # count_phase1_assets and by is_phase1_lesson_doc, both of which
+    # recognize .pdf directly without relying on this helper.
+    # See curriculum-tracking#36.
+    return f.endswith('.gdoc') or f.endswith('.docx') or f.endswith('.doc') or f.endswith('.md')
+
+
+def is_phase1_lesson_doc(f):
+    """True if f is a Phase 1 lesson-content PDF.
+
+    Recognizes `lesson-NN-<name>.pdf` but rejects the paired artifacts
+    (instructor guide, quiz, exercise). The qualifier check anchors to the
+    *first token* after the `lesson-NN-` prefix, so a lesson whose title
+    happens to contain 'exercise' mid-name (e.g.
+    `lesson-05-building-exercise-routines.pdf`) still counts.
+
+    Kept separate from is_doc() to scope .pdf recognition to Phase 1 trees
+    — legacy _COURSES/ source trees contain .pdf mirrors of .gdoc files
+    that must not double-count. See curriculum-tracking#36.
+    """
+    fl = f.lower()
+    if not fl.endswith('.pdf'):
+        return False
+    if not re.match(r'^lesson-\d{2}-', fl):
+        return False
+    if re.match(r'^lesson-\d{2}-(instructor|quiz|exercise)(?:-|\.)', fl):
+        return False
+    return True
 
 def is_slides(f):
     return f.endswith('.pptx') or f.endswith('.gslides')
@@ -828,16 +858,12 @@ def check_lesson_exists(mod_files, lesson_number, position_in_module=None):
         fl = f.lower()
         if re.match(r'Lesson\s+' + str(lesson_number) + r'\b', f, re.IGNORECASE) and is_doc(f):
             return True
-    # Phase 1 naming: lesson-NN-<name>.pdf (excluding instructor guides,
-    # quizzes, and exercises which are counted separately)
+    # Phase 1 lesson-content PDFs. See is_phase1_lesson_doc / #36.
     for num in set(filter(None, [lesson_number, position_in_module])):
         phase1_prefix = f"lesson-{num:02d}-"
         for f in mod_files:
             fl = f.lower()
-            if (fl.startswith(phase1_prefix) and is_doc(f)
-                and 'instructor-guide' not in fl
-                and 'quiz' not in fl
-                and 'exercise' not in fl):
+            if fl.startswith(phase1_prefix) and is_phase1_lesson_doc(f):
                 return True
     for num in set(filter(None, [lesson_number, position_in_module])):
         target_flat = f"{num:02d}-"
@@ -906,7 +932,13 @@ def compute_coverage(modules, source_data):
                             break
 
         mod_files = mod_source['files'] if mod_source else []
-        has_numbered_lessons = any(re.match(r'Lesson\s+\d+', f) for f in mod_files if is_doc(f))
+        # Phase 1 tree lessons come in as `lesson-NN-*.pdf`; legacy _COURSES/
+        # trees use `Lesson N ...`. Recognize both shapes here so the
+        # coverage scan routes into check_lesson_exists either way.
+        has_numbered_lessons = (
+            any(re.match(r'Lesson\s+\d+', f) for f in mod_files if is_doc(f))
+            or any(is_phase1_lesson_doc(f) for f in mod_files)
+        )
 
         for lesson_idx, lesson in enumerate(module['lessons']):
             position_in_module = lesson_idx + 1

--- a/scripts/test_generate_course_overview.py
+++ b/scripts/test_generate_course_overview.py
@@ -399,5 +399,57 @@ class TestDeploymentStatus(unittest.TestCase):
             self.assertEqual(result['state'], 'Complete')
 
 
+class TestPhase1PdfScoping(unittest.TestCase):
+    """Tests for #36: the Phase 1 lesson-NN-*.pdf recognition must NOT
+    expand is_doc() globally. Legacy _COURSES/ trees contain PDFs that
+    should not be double-counted as lessons, quizzes, etc.
+    """
+
+    def test_is_doc_excludes_pdf(self):
+        # is_doc() must only recognize author-editable source docs;
+        # .pdf belongs to the deploy/output layer and is handled
+        # separately by count_phase1_assets and the Phase 1 branch of
+        # check_lesson_exists.
+        self.assertFalse(gen_overview.is_doc('Lesson_ ETL with Pandas.pdf'))
+        self.assertFalse(gen_overview.is_doc('lesson-03-intro.pdf'))
+        # Still recognized:
+        self.assertTrue(gen_overview.is_doc('Lesson_ ETL with Pandas.gdoc'))
+        self.assertTrue(gen_overview.is_doc('Lesson_ ETL with Pandas.docx'))
+        self.assertTrue(gen_overview.is_doc('Lesson_ ETL with Pandas.md'))
+
+    def test_count_assets_ignores_legacy_pdfs(self):
+        # A legacy _COURSES/ tree with .gdoc source + a .pdf sibling must
+        # count only the .gdoc as a lesson (the .pdf is a rendered mirror,
+        # not an additional artifact).
+        files = [
+            'Lesson_ ETL with Pandas.gdoc',
+            'Lesson_ ETL with Pandas.pdf',
+        ]
+        counts = gen_overview.count_assets(files)
+        self.assertEqual(counts['lessons'], 1)
+
+    def test_check_lesson_exists_phase1_branch_recognizes_lesson_pdf(self):
+        # The Phase 1 branch still matches `lesson-NN-<name>.pdf` even
+        # though is_doc() no longer accepts .pdf globally.
+        files = ['lesson-03-what-is-itsm.pdf']
+        self.assertTrue(gen_overview.check_lesson_exists(files, 3))
+
+    def test_check_lesson_exists_phase1_branch_excludes_qualifiers(self):
+        # Quiz and instructor-guide alone are not lesson content.
+        self.assertFalse(gen_overview.check_lesson_exists(['lesson-03-quiz.pdf'], 3))
+        self.assertFalse(gen_overview.check_lesson_exists(['lesson-03-instructor-guide.pdf'], 3))
+        self.assertFalse(gen_overview.check_lesson_exists(['lesson-03-exercise-my-task.pdf'], 3))
+        self.assertFalse(gen_overview.check_lesson_exists(
+            ['lesson-03-instructor-guide-exercise-my-task.pdf'], 3
+        ))
+
+    def test_check_lesson_exists_phase1_branch_false_positive_guard(self):
+        # A lesson whose title embeds 'exercise' mid-name (not as the first
+        # token after the lesson-NN- prefix) should still count.
+        # curriculum-tracking#36 secondary.
+        files = ['lesson-05-building-exercise-routines.pdf']
+        self.assertTrue(gen_overview.check_lesson_exists(files, 5))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Reverts `.pdf` out of `is_doc()` and replaces it with a narrow helper `is_phase1_lesson_doc()`. Fixes the regression introduced by PR #34 where every legacy `_COURSES/` course got its lesson / demo / activity counts inflated because PDF mirrors of `.gdoc` sources started counting.

Closes #36.

## Root cause

`is_doc()` is used from every branch of `count_assets()`. When `.pdf` was added there to make Phase 1 coverage detection work, the change quietly bled into legacy tree scanning.

## Fix

- `is_doc()` → back to `.gdoc | .docx | .doc | .md` only
- New `is_phase1_lesson_doc(f)` — returns True for `lesson-NN-<name>.pdf`, rejecting paired `instructor-guide` / `quiz` / `exercise` artifacts
- Used by:
  1. `check_lesson_exists` Phase 1 branch (replaces inline .pdf + substring exclusion logic)
  2. `compute_coverage` — `has_numbered_lessons` now OR's in Phase 1 shape detection, so ITIL routes into `check_lesson_exists` (100% coverage preserved)

## Secondary fix (per issue body)

The qualifier exclusion used substring matching (`'exercise' not in fl`), which would wrongly exclude a lesson like `lesson-05-building-exercise-routines.pdf`. Replaced with a regex that anchors to the *first token* after `lesson-NN-`: `^lesson-\d{2}-(instructor|quiz|exercise)(?:-|\.)`. Lessons whose titles contain 'exercise' mid-name now count correctly.

## Verification — legacy counts reverted

| Course | lessons (main → branch) | demos | slides |
|---|---|---|---|
| pandas | 11 → **6** | 0 → 0 | 1 → 1 |
| introduction-to-aws-cloud-platform | 74 → **39** | 4 → 2 | 10 → 10 |
| sql-fundamentals-for-operations | 33 → **17** | 8 → 5 | 12 → 12 |
| data-fundamentals-excel-for-data-analysts | 30 → **15** | 4 → 2 | 25 → 25 |
| data-fundamentals-data-literacy | 51 → **26** | 0 → 0 | 0 → 0 |

## Regression preserved

- ITIL Foundations: still 100% coverage (19/19 lessons)
- Productivity Tools for Technical Reporting: still 100% coverage (4/4 lessons)

## Tests

5 new unit tests (33 total, all passing):

- `test_is_doc_excludes_pdf` — scope guard
- `test_count_assets_ignores_legacy_pdfs` — the reason for the change
- `test_check_lesson_exists_phase1_branch_recognizes_lesson_pdf`
- `test_check_lesson_exists_phase1_branch_excludes_qualifiers` — instructor-guide, quiz, exercise artifacts
- `test_check_lesson_exists_phase1_branch_false_positive_guard` — `lesson-05-building-exercise-routines.pdf` still counts

Run: `python3 -m unittest scripts.test_generate_course_overview`

## Things to check

- [x] `python3 -m unittest scripts.test_generate_course_overview` → 33 pass
- [x] `node build.js` succeeds with no new validation errors
- [x] Dashboard lesson counts for pandas / intro-to-aws / sql-ops / excel / data-literacy match the table above
- [x] ITIL Foundations coverage still 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)