### PR TITLE
OSS audit: linux-foundations — statusConfirmed: true

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-25T20:19:29",
+  "generated": "2026-04-25T20:31:58",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -591,7 +591,7 @@ const courseData = [
     "outline": "Course Outline: Linux Foundations",
     "note": "Full source content across 4 modules (10 lessons) + summative assessment. All lessons have content docs, slides, quizzes, activities, and demos. 10/10 interactive SCORM reviews built. Instructor guides embedded in 34/42 activity/lab/demo docs.",
     "driveFolder": "https://drive.google.com/drive/folders/1ilPpEuWyes1hj1xuEwPixQbj8SUbEkR0",
-    "statusConfirmed": false
+    "statusConfirmed": true
   },
   {
     "id": "macos-administration-fundamentals",

--- a/courses.json
+++ b/courses.json
@@ -589,7 +589,7 @@
       "outline": "Course Outline: Linux Foundations",
       "note": "Full source content across 4 modules (10 lessons) + summative assessment. All lessons have content docs, slides, quizzes, activities, and demos. 10/10 interactive SCORM reviews built. Instructor guides embedded in 34/42 activity/lab/demo docs.",
       "driveFolder": "https://drive.google.com/drive/folders/1ilPpEuWyes1hj1xuEwPixQbj8SUbEkR0",
-      "statusConfirmed": false
+      "statusConfirmed": true
     },
     {
       "id": "macos-administration-fundamentals",


### PR DESCRIPTION
## Summary

Audit verified linux-foundations against current source state (META #63 sub-issue). All checks passed; flipping `statusConfirmed` to `true`.

## Verification

| Check | Result |
|---|---|
| Hours = OSS outline (80h, Course 1, Area 1) | ✅ |
| Outline JSON structure (4 mods / 10 lessons + 4h summative = 80h) matches `course-outline-linux-foundations.md` | ✅ |
| Syllabus HTML renders (`syllabi/linux-foundations.html`, title "Syllabus: Linux Foundations") | ✅ |
| Drive folder URL resolves (HTTP 200) | ✅ |
| Design status `Complete` accurate (10/10 SCORM reviews built) | ✅ |
| Development status `In Progress` accurate (instructor guides 34/42, no PDFs yet) | ✅ |

Closes #69. Sub-issue under META #63.

## Test plan

- [x] Refresh dashboard; linux-foundations no longer shows the "status not yet audited" badge
- [x] OSS curriculum view total still 560h
- [x] No other course records changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)