### PR TITLE
OSS audit: comptia-network-plus — dev Not Started → In Progress, statusConfirmed: true

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-25T20:31:58",
+  "generated": "2026-04-25T22:10:10",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -204,13 +204,13 @@ const courseData = [
     "hours": 96,
     "status": {
       "design": "Complete",
-      "development": "Not Started"
+      "development": "In Progress"
     },
     "syllabus": "Syllabus: CompTIA Network+",
     "outline": "Course Outline: CompTIA Network+",
-    "note": null,
+    "note": "22/22 SCORM interactives built across 5 modules in deployment/repos/comptia-network-plus/. PDFs not yet generated. Legacy scorm-design folder retains 19 DELETE- prefixed folders pending cleanup.",
     "driveFolder": "https://drive.google.com/drive/folders/15YQcw0_TywkjXJ1D0DhQP9CeIPeSMlz0",
-    "statusConfirmed": false
+    "statusConfirmed": true
   },
   {
     "id": "data-fundamentals-data-literacy",

--- a/courses.json
+++ b/courses.json
@@ -202,13 +202,13 @@
       "hours": 96,
       "status": {
         "design": "Complete",
-        "development": "Not Started"
+        "development": "In Progress"
       },
       "syllabus": "Syllabus: CompTIA Network+",
       "outline": "Course Outline: CompTIA Network+",
-      "note": null,
+      "note": "22/22 SCORM interactives built across 5 modules in deployment/repos/comptia-network-plus/. PDFs not yet generated. Legacy scorm-design folder retains 19 DELETE- prefixed folders pending cleanup.",
       "driveFolder": "https://drive.google.com/drive/folders/15YQcw0_TywkjXJ1D0DhQP9CeIPeSMlz0",
-      "statusConfirmed": false
+      "statusConfirmed": true
     },
     {
       "id": "data-fundamentals-data-literacy",


### PR DESCRIPTION
## Summary

Audit verified comptia-network-plus against current source state (META #63 sub-issue). One status correction surfaced: 22/22 SCORM interactives are built with real authored content, but the tracking record had `development: Not Started`. Flipping to `In Progress` to match the linux-foundations and comptia-a-plus pattern, with a descriptive `note`.

## Verification

| Check | Result |
|---|---|
| Hours = OSS outline (96h, Course 2, Area 1) | ✅ |
| Outline JSON (96h / 5 modules / 22 lessons + assessment) matches `course-outline-comptia-network-plus.md` | ✅ |
| Syllabus HTML renders (`syllabi/comptia-network-plus.html`, title "Syllabus: CompTIA Network+") | ✅ |
| Drive folder URL resolves (HTTP 200) | ✅ |
| Design status `Complete` accurate | ✅ |
| Development status was `Not Started` — corrected to `In Progress` | ✅ |

## Status correction

The course has 22 of 22 SCORM zips built in `deployment/repos/comptia-network-plus/module-{1..5}/`. Each zip is ~18–22KB and contains real lesson content (`index.html`, `content.js`, `lesson.js`, `imsmanifest.xml`, etc.) — not scaffolds. Compare:

| Course | SCORMs | Tracking dev status |
|---|---|---|
| linux-foundations | 10/10 | In Progress |
| comptia-a-plus | 38/38 | In Progress |
| **comptia-network-plus (this PR)** | 22/22 | Was: Not Started → **Now: In Progress** |

Closes #71. Sub-issue under META #63.

## Test plan

- [ ] Refresh dashboard: comptia-network-plus development track now shows "In Progress" and the "status not yet audited" badge is gone
- [ ] OSS curriculum view total still 560h
- [ ] No other course records changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)