### PR TITLE
OSS audit: comptia-a-plus — statusConfirmed: true

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-25T22:10:10",
+  "generated": "2026-04-25T22:27:50",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -196,7 +196,7 @@ const courseData = [
     "outline": "Course Outline: CompTIA A+",
     "note": "v0.4.2 — 38/38 SCORM interactives complete. All modules 1-7 deployed. Content synced from review HTMLs, titles normalized.",
     "driveFolder": "https://drive.google.com/drive/folders/1Sc6HPEa8bYFzm50IHccFEuLKBgqkU22o",
-    "statusConfirmed": false
+    "statusConfirmed": true
   },
   {
     "id": "comptia-network-plus",

--- a/courses.json
+++ b/courses.json
@@ -194,7 +194,7 @@
       "outline": "Course Outline: CompTIA A+",
       "note": "v0.4.2 \u2014 38/38 SCORM interactives complete. All modules 1-7 deployed. Content synced from review HTMLs, titles normalized.",
       "driveFolder": "https://drive.google.com/drive/folders/1Sc6HPEa8bYFzm50IHccFEuLKBgqkU22o",
-      "statusConfirmed": false
+      "statusConfirmed": true
     },
     {
       "id": "comptia-network-plus",


### PR DESCRIPTION
## Summary

Audit verified comptia-a-plus against current source state (META #63 sub-issue). All checks passed; flipping `statusConfirmed` to `true`. No data corrections needed.

## Verification

| Check | Result |
|---|---|
| Hours: default 120h + OSS `hoursOverride: 96` matches outline (Course 3, Area 2) | ✅ |
| Outline JSON (120h / 7 modules / 38 lessons) matches `course-outline-comptia-a-plus.md` | ✅ |
| Syllabus HTML renders (`syllabi/comptia-a-plus.html`, title "Syllabus: CompTIA A+") | ✅ |
| Drive folder URL resolves (HTTP 200) | ✅ |
| Design status `Complete` accurate (38/38 SCORM interactives across modules 1–7) | ✅ |
| Development status `In Progress` accurate (no PDFs yet) | ✅ |
| Existing `note` ("v0.4.2 — 38/38 SCORM interactives complete...") is current | ✅ |

Closes #73. Sub-issue under META #63.

## Test plan

- [ ] Refresh dashboard: comptia-a-plus no longer shows the "status not yet audited" badge
- [ ] OSS Area 2 still totals 132h (96+20+16); detail panel header shows `96–120 hours (varies by curriculum)` per #67
- [ ] No other course records changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)