### PR TITLE
Python Basics: sync outline JSON + syllabus HTML to design-doc; OSS audit complete

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-25T22:27:50",
+  "generated": "2026-04-26T08:48:55",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -712,13 +712,14 @@ const courseData = [
     "hours": 48,
     "status": {
       "design": "Complete",
-      "development": "Not Started"
+      "development": "In Progress"
     },
     "syllabus": "Syllabus: Python Basics",
     "outline": "Course Outline: Python Basics",
-    "note": null,
+    "note": "Outline restructured 2026-04-26 to 9 modules / 10 lessons per design-doc course-outline (was 6 modules / 14 lessons reconstruction). Per-module hours are TBD pending design-doc#83 (40h syllabus vs 48h OSS target) and design-doc#90 (LO + content extraction). Deploy tree has 10 SCORM zips + 14 PDFs. Used in OSS Course 6, Area 3 and Software Developer Java curriculum.",
     "driveFolder": "https://drive.google.com/drive/folders/1Nvu0H0nNcr1Cb1JHy3zPvVUVQxjmTfsL",
-    "statusConfirmed": false
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+    "statusConfirmed": true
   },
   {
     "id": "python-coding-booster-intensive",

--- a/courses.json
+++ b/courses.json
@@ -710,13 +710,14 @@
       "hours": 48,
       "status": {
         "design": "Complete",
-        "development": "Not Started"
+        "development": "In Progress"
       },
       "syllabus": "Syllabus: Python Basics",
       "outline": "Course Outline: Python Basics",
-      "note": null,
+      "note": "Outline restructured 2026-04-26 to 9 modules / 10 lessons per design-doc course-outline (was 6 modules / 14 lessons reconstruction). Per-module hours are TBD pending design-doc#83 (40h syllabus vs 48h OSS target) and design-doc#90 (LO + content extraction). Deploy tree has 10 SCORM zips + 14 PDFs. Used in OSS Course 6, Area 3 and Software Developer Java curriculum.",
       "driveFolder": "https://drive.google.com/drive/folders/1Nvu0H0nNcr1Cb1JHy3zPvVUVQxjmTfsL",
-      "statusConfirmed": false
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+      "statusConfirmed": true
     },
     {
       "id": "python-coding-booster-intensive",

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -8442,205 +8442,116 @@ const courseOutlines = {
   "Python Basics": {
     "course": "Python Basics",
     "totalHours": 48,
-    "totalLessons": 14,
-    "totalModules": 6,
+    "totalLessons": 10,
+    "totalModules": 9,
+    "_note": "Structure synced to apprenti-org/design-documentation:course-design/python-basics/course-outline-python-basics.md (9 modules / 10 lessons). Per-module and per-lesson hours are TBD pending the hours discrepancy resolution (see apprenti-org/design-documentation#83) and content extraction (apprenti-org/design-documentation#90). totalHours: 48 reflects the OSS curriculum target (Course 6, Area 3); the upstream syllabus states 40h.",
     "modules": [
       {
         "name": "Introduction to Python",
-        "hours": 8,
-        "description": "Setting up the Python development environment and writing first programs.",
+        "hours": null,
         "lessons": [
           {
-            "title": "Course Introduction & Python Overview",
-            "hours": 2,
+            "title": "Introduction to Python",
+            "hours": null,
             "topics": [
-              "Course structure and expectations",
-              "What is Python and why learn it?",
-              "Python in software development"
-            ]
-          },
-          {
-            "title": "Setting Up the Development Environment",
-            "hours": 3,
-            "topics": [
-              "Installing Python and package managers",
-              "Installing VS Code for Python",
-              "Configuring VS Code extensions"
-            ]
-          },
-          {
-            "title": "First Python Programs",
-            "hours": 3,
-            "topics": [
-              "Writing and running Python scripts",
-              "Basic calculator demo",
-              "Modules and packages",
-              "Using Git with Python"
+              "Python overview, key features, history",
+              "PEPs and PEP8"
             ]
           }
         ]
       },
       {
-        "name": "Variables and String Manipulation",
-        "hours": 8,
-        "description": "Working with variables, data types, user input, and string operations.",
+        "name": "Variables, Inputs, and String Manipulation",
+        "hours": null,
         "lessons": [
           {
-            "title": "Variables and Data Types",
-            "hours": 4,
-            "topics": [
-              "Variable declaration and assignment",
-              "Data types: int, float, str, bool",
-              "Type conversion and casting",
-              "Naming conventions"
-            ]
-          },
-          {
-            "title": "User Input and String Manipulation",
-            "hours": 4,
-            "topics": [
-              "The input() function",
-              "String indexing and slicing",
-              "String methods",
-              "String formatting with f-strings"
-            ]
+            "title": "Variables and Strings in Python",
+            "hours": null,
+            "topics": []
           }
         ]
       },
       {
-        "name": "Collections in Python",
-        "hours": 10,
-        "description": "Understanding and manipulating Python core data structures.",
+        "name": "Arrays and Flow Control",
+        "hours": null,
         "lessons": [
           {
-            "title": "Arrays and Lists",
-            "hours": 4,
-            "topics": [
-              "Arrays in Python",
-              "Lists: creation, indexing, slicing",
-              "List methods and comprehensions"
-            ]
+            "title": "Arrays in Python",
+            "hours": null,
+            "topics": []
           },
           {
-            "title": "Tuples, Sets, and Dictionaries",
-            "hours": 4,
-            "topics": [
-              "Tuples: immutability and use cases",
-              "Sets: uniqueness and operations",
-              "Dictionaries: key-value pairs",
-              "Choosing the right collection"
-            ]
+            "title": "Lists in Python",
+            "hours": null,
+            "topics": []
           },
           {
-            "title": "Collections Practice",
-            "hours": 2,
-            "topics": [
-              "Nested collections",
-              "Combining lists and tuples",
-              "Data manipulation with sets and dictionaries"
-            ]
+            "title": "Pseudocode",
+            "hours": null,
+            "topics": []
+          },
+          {
+            "title": "Flowcharting",
+            "hours": null,
+            "topics": []
           }
         ]
       },
       {
-        "name": "Flow Control in Python",
-        "hours": 6,
-        "description": "Pseudocode, flowcharts, and control flow structures.",
-        "lessons": [
-          {
-            "title": "Pseudocode and Flowcharts",
-            "hours": 2,
-            "topics": [
-              "Writing pseudocode",
-              "Converting pseudocode to flowcharts",
-              "Problem decomposition"
-            ]
-          },
-          {
-            "title": "Flow Control Structures",
-            "hours": 4,
-            "topics": [
-              "Conditional statements (if, elif, else)",
-              "Loops: for and while",
-              "Loop control: break, continue, pass",
-              "Nested control structures"
-            ]
-          }
-        ]
-      },
-      {
-        "name": "Functions and File I/O",
-        "hours": 10,
-        "description": "Code modularity through functions, exception handling, and file operations.",
+        "name": "Functions",
+        "hours": null,
         "lessons": [
           {
             "title": "Functions",
-            "hours": 4,
-            "topics": [
-              "Defining and calling functions",
-              "Parameters, arguments, return values",
-              "Default and keyword arguments",
-              "Scope and variable lifetime"
-            ]
-          },
-          {
-            "title": "Exception Handling",
-            "hours": 2,
-            "topics": [
-              "Try/except blocks",
-              "Common exception types",
-              "Raising exceptions",
-              "Error handling best practices"
-            ]
-          },
-          {
-            "title": "File Input/Output",
-            "hours": 4,
-            "topics": [
-              "Reading and writing text files",
-              "File modes (read, write, append)",
-              "Working with file paths",
-              "Context managers (with statement)"
-            ]
+            "hours": null,
+            "topics": []
           }
         ]
       },
       {
-        "name": "Testing Python",
-        "hours": 6,
-        "description": "Software testing concepts and Python testing tools.",
+        "name": "Lists, Tuples, Sets and Dictionaries",
+        "hours": null,
+        "lessons": [
+          {
+            "title": "Lists, Tuples, Sets and Dictionaries",
+            "hours": null,
+            "topics": []
+          }
+        ]
+      },
+      {
+        "name": "File IO",
+        "hours": null,
+        "lessons": [
+          {
+            "title": "File IO",
+            "hours": null,
+            "topics": []
+          }
+        ]
+      },
+      {
+        "name": "Python in Practice (Practice Lab)",
+        "hours": null,
+        "lessons": []
+      },
+      {
+        "name": "Summative Assessment",
+        "hours": null,
+        "lessons": []
+      },
+      {
+        "name": "Testing in Python",
+        "hours": null,
         "lessons": [
           {
             "title": "Testing in Python",
-            "hours": 4,
-            "topics": [
-              "Why testing matters",
-              "Unit testing with unittest",
-              "Writing test cases",
-              "Test-driven development basics"
-            ]
-          },
-          {
-            "title": "Practice Lab: Tournament Tracker",
-            "hours": 2,
-            "topics": [
-              "Integrated lab combining all concepts",
-              "Building a complete Python application",
-              "Applying testing to a real project"
-            ]
+            "hours": null,
+            "topics": []
           }
         ]
       }
-    ],
-    "assessment": {
-      "title": "Summative Assessments",
-      "hours": 4,
-      "items": [
-        "Study Log Tracker (primary assessment)",
-        "Python Mini-Project: Collections Tracker",
-        "Python Mini-Project: Student Grade Tracker"
-      ]
-    }
+    ]
   },
   "Python Coding Booster Intensive": {
     "course": "Python Coding Booster Intensive",

--- a/outlines/python-basics.json
+++ b/outlines/python-basics.json
@@ -1,70 +1,114 @@
 {
   "course": "Python Basics",
   "totalHours": 48,
-  "totalLessons": 14,
-  "totalModules": 6,
+  "totalLessons": 10,
+  "totalModules": 9,
+  "_note": "Structure synced to apprenti-org/design-documentation:course-design/python-basics/course-outline-python-basics.md (9 modules / 10 lessons). Per-module and per-lesson hours are TBD pending the hours discrepancy resolution (see apprenti-org/design-documentation#83) and content extraction (apprenti-org/design-documentation#90). totalHours: 48 reflects the OSS curriculum target (Course 6, Area 3); the upstream syllabus states 40h.",
   "modules": [
     {
       "name": "Introduction to Python",
-      "hours": 8,
-      "description": "Setting up the Python development environment and writing first programs.",
+      "hours": null,
       "lessons": [
-        { "title": "Course Introduction & Python Overview", "hours": 2, "topics": ["Course structure and expectations", "What is Python and why learn it?", "Python in software development"] },
-        { "title": "Setting Up the Development Environment", "hours": 3, "topics": ["Installing Python and package managers", "Installing VS Code for Python", "Configuring VS Code extensions"] },
-        { "title": "First Python Programs", "hours": 3, "topics": ["Writing and running Python scripts", "Basic calculator demo", "Modules and packages", "Using Git with Python"] }
+        {
+          "title": "Introduction to Python",
+          "hours": null,
+          "topics": [
+            "Python overview, key features, history",
+            "PEPs and PEP8"
+          ]
+        }
       ]
     },
     {
-      "name": "Variables and String Manipulation",
-      "hours": 8,
-      "description": "Working with variables, data types, user input, and string operations.",
+      "name": "Variables, Inputs, and String Manipulation",
+      "hours": null,
       "lessons": [
-        { "title": "Variables and Data Types", "hours": 4, "topics": ["Variable declaration and assignment", "Data types: int, float, str, bool", "Type conversion and casting", "Naming conventions"] },
-        { "title": "User Input and String Manipulation", "hours": 4, "topics": ["The input() function", "String indexing and slicing", "String methods", "String formatting with f-strings"] }
+        {
+          "title": "Variables and Strings in Python",
+          "hours": null,
+          "topics": []
+        }
       ]
     },
     {
-      "name": "Collections in Python",
-      "hours": 10,
-      "description": "Understanding and manipulating Python core data structures.",
+      "name": "Arrays and Flow Control",
+      "hours": null,
       "lessons": [
-        { "title": "Arrays and Lists", "hours": 4, "topics": ["Arrays in Python", "Lists: creation, indexing, slicing", "List methods and comprehensions"] },
-        { "title": "Tuples, Sets, and Dictionaries", "hours": 4, "topics": ["Tuples: immutability and use cases", "Sets: uniqueness and operations", "Dictionaries: key-value pairs", "Choosing the right collection"] },
-        { "title": "Collections Practice", "hours": 2, "topics": ["Nested collections", "Combining lists and tuples", "Data manipulation with sets and dictionaries"] }
+        {
+          "title": "Arrays in Python",
+          "hours": null,
+          "topics": []
+        },
+        {
+          "title": "Lists in Python",
+          "hours": null,
+          "topics": []
+        },
+        {
+          "title": "Pseudocode",
+          "hours": null,
+          "topics": []
+        },
+        {
+          "title": "Flowcharting",
+          "hours": null,
+          "topics": []
+        }
       ]
     },
     {
-      "name": "Flow Control in Python",
-      "hours": 6,
-      "description": "Pseudocode, flowcharts, and control flow structures.",
+      "name": "Functions",
+      "hours": null,
       "lessons": [
-        { "title": "Pseudocode and Flowcharts", "hours": 2, "topics": ["Writing pseudocode", "Converting pseudocode to flowcharts", "Problem decomposition"] },
-        { "title": "Flow Control Structures", "hours": 4, "topics": ["Conditional statements (if, elif, else)", "Loops: for and while", "Loop control: break, continue, pass", "Nested control structures"] }
+        {
+          "title": "Functions",
+          "hours": null,
+          "topics": []
+        }
       ]
     },
     {
-      "name": "Functions and File I/O",
-      "hours": 10,
-      "description": "Code modularity through functions, exception handling, and file operations.",
+      "name": "Lists, Tuples, Sets and Dictionaries",
+      "hours": null,
       "lessons": [
-        { "title": "Functions", "hours": 4, "topics": ["Defining and calling functions", "Parameters, arguments, return values", "Default and keyword arguments", "Scope and variable lifetime"] },
-        { "title": "Exception Handling", "hours": 2, "topics": ["Try/except blocks", "Common exception types", "Raising exceptions", "Error handling best practices"] },
-        { "title": "File Input/Output", "hours": 4, "topics": ["Reading and writing text files", "File modes (read, write, append)", "Working with file paths", "Context managers (with statement)"] }
+        {
+          "title": "Lists, Tuples, Sets and Dictionaries",
+          "hours": null,
+          "topics": []
+        }
       ]
     },
     {
-      "name": "Testing Python",
-      "hours": 6,
-      "description": "Software testing concepts and Python testing tools.",
+      "name": "File IO",
+      "hours": null,
       "lessons": [
-        { "title": "Testing in Python", "hours": 4, "topics": ["Why testing matters", "Unit testing with unittest", "Writing test cases", "Test-driven development basics"] },
-        { "title": "Practice Lab: Tournament Tracker", "hours": 2, "topics": ["Integrated lab combining all concepts", "Building a complete Python application", "Applying testing to a real project"] }
+        {
+          "title": "File IO",
+          "hours": null,
+          "topics": []
+        }
+      ]
+    },
+    {
+      "name": "Python in Practice (Practice Lab)",
+      "hours": null,
+      "lessons": []
+    },
+    {
+      "name": "Summative Assessment",
+      "hours": null,
+      "lessons": []
+    },
+    {
+      "name": "Testing in Python",
+      "hours": null,
+      "lessons": [
+        {
+          "title": "Testing in Python",
+          "hours": null,
+          "topics": []
+        }
       ]
     }
-  ],
-  "assessment": {
-    "title": "Summative Assessments",
-    "hours": 4,
-    "items": ["Study Log Tracker (primary assessment)", "Python Mini-Project: Collections Tracker", "Python Mini-Project: Student Grade Tracker"]
-  }
+  ]
 }

--- a/syllabi/python-basics.html
+++ b/syllabi/python-basics.html
@@ -311,8 +311,8 @@ code {
         <div class="header">
             <h1>Syllabus: Python Basics</h1>
             <div class="header-meta">
-                <span><i class="fa-solid fa-layer-group"></i> Software Developer</span>
-                <span><i class="fa-regular fa-clock"></i> 48 hours</span>
+                <span><i class="fa-solid fa-layer-group"></i> Software Developer Java &middot; Operations Support Specialist — Network</span>
+                <span><i class="fa-regular fa-clock"></i> 48 hours (target)</span>
                 <span class="badge">DRAFT</span>
             </div>
         </div>
@@ -368,32 +368,22 @@ code {
         <section>
             <h2><i class="fa-solid fa-sitemap"></i> Course Outline</h2>
 
+            <div class="review-banner">
+                <i class="fa-solid fa-circle-info"></i>
+                Outline structure synced 2026-04-26 to <code>apprenti-org/design-documentation:course-design/python-basics/course-outline-python-basics.md</code> (9 modules / 10 lessons). Per-module hours and per-lesson topics are TBD pending the hours discrepancy resolution (design-doc #83) and content extraction (design-doc #90).
+            </div>
+
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">1</span>
                     <span class="module-title">Introduction to Python</span>
-                    <span class="module-hours">8 hours</span>
+                    <span class="module-hours">TBD</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Course Introduction &amp; Python Overview</div>
+                    <div class="lesson-heading">Lesson: Introduction to Python</div>
                     <ul class="topic-list">
-                        <li>Course structure and expectations</li>
-                        <li>What is Python and its role in software development</li>
-                        <li>Reference materials and resources</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Setting Up the Development Environment</div>
-                    <ul class="topic-list">
-                        <li>Installing Python and package managers (pip, conda)</li>
-                        <li>Installing VS Code and configuring Python extensions</li>
-                        <li>Introduction to the Python REPL</li>
-                        <li>First program execution</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: First Python Programs</div>
-                    <ul class="topic-list">
-                        <li>Writing and running Python scripts</li>
-                        <li>Basic calculator demonstration</li>
-                        <li>Modules and packages</li>
-                        <li>Using Git with Python projects</li>
+                        <li>Python overview, key features, history</li>
+                        <li>PEPs and PEP8</li>
                     </ul>
                 </div>
             </div>
@@ -401,136 +391,91 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">2</span>
-                    <span class="module-title">Variables and String Manipulation</span>
-                    <span class="module-hours">8 hours</span>
+                    <span class="module-title">Variables, Inputs, and String Manipulation</span>
+                    <span class="module-hours">TBD</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Variables and Data Types</div>
-                    <ul class="topic-list">
-                        <li>Variable declaration and assignment</li>
-                        <li>Data types: int, float, str, bool</li>
-                        <li>Type conversion and casting</li>
-                        <li>Variable naming conventions</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: User Input and String Manipulation</div>
-                    <ul class="topic-list">
-                        <li>The input() function for user interaction</li>
-                        <li>String indexing and slicing</li>
-                        <li>String methods: upper, lower, split, join, replace, format</li>
-                        <li>String formatting with f-strings</li>
-                        <li>Quiz: Variables and Strings in Python</li>
-                    </ul>
+                    <div class="lesson-heading">Lesson: Variables and Strings in Python</div>
                 </div>
             </div>
 
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">3</span>
-                    <span class="module-title">Collections in Python</span>
-                    <span class="module-hours">10 hours</span>
+                    <span class="module-title">Arrays and Flow Control</span>
+                    <span class="module-hours">TBD</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Arrays and Lists</div>
-                    <ul class="topic-list">
-                        <li>Arrays in Python</li>
-                        <li>Lists: creation, indexing, slicing</li>
-                        <li>List methods: append, remove, sort, reverse</li>
-                        <li>List comprehensions</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Tuples, Sets, and Dictionaries</div>
-                    <ul class="topic-list">
-                        <li>Tuples: immutability and use cases</li>
-                        <li>Sets: uniqueness and set operations</li>
-                        <li>Dictionaries: key-value pairs, access, iteration</li>
-                        <li>Choosing the right collection type</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Collections Practice</div>
-                    <ul class="topic-list">
-                        <li>Working with nested collections</li>
-                        <li>Combining lists and tuples</li>
-                        <li>Sets and dictionaries for data manipulation</li>
-                        <li>Quiz: Collections in Python</li>
-                    </ul>
+                    <div class="lesson-heading">Lesson 1: Arrays in Python</div>
+                    <div class="lesson-heading">Lesson 2: Lists in Python</div>
+                    <div class="lesson-heading">Lesson 3: Pseudocode</div>
+                    <div class="lesson-heading">Lesson 4: Flowcharting</div>
                 </div>
             </div>
 
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">4</span>
-                    <span class="module-title">Flow Control in Python</span>
-                    <span class="module-hours">6 hours</span>
+                    <span class="module-title">Functions</span>
+                    <span class="module-hours">TBD</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Pseudocode and Flowcharts</div>
-                    <ul class="topic-list">
-                        <li>Writing pseudocode</li>
-                        <li>Converting pseudocode to flowcharts</li>
-                        <li>Problem decomposition techniques</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Flow Control Structures</div>
-                    <ul class="topic-list">
-                        <li>Conditional statements: if, elif, else</li>
-                        <li>Loops: for and while</li>
-                        <li>Loop control: break, continue, pass</li>
-                        <li>Nested control structures</li>
-                        <li>Practice: Restaurant Ordering System</li>
-                    </ul>
+                    <div class="lesson-heading">Lesson: Functions</div>
                 </div>
             </div>
 
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">5</span>
-                    <span class="module-title">Functions and File I/O</span>
-                    <span class="module-hours">10 hours</span>
+                    <span class="module-title">Lists, Tuples, Sets and Dictionaries</span>
+                    <span class="module-hours">TBD</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Functions</div>
-                    <ul class="topic-list">
-                        <li>Defining and calling functions</li>
-                        <li>Parameters, arguments, and return values</li>
-                        <li>Default and keyword arguments</li>
-                        <li>Scope and variable lifetime</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Exception Handling</div>
-                    <ul class="topic-list">
-                        <li>Try/except blocks for error handling</li>
-                        <li>Common exception types</li>
-                        <li>Raising exceptions</li>
-                        <li>Best practices for error handling</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: File Input/Output</div>
-                    <ul class="topic-list">
-                        <li>Reading and writing text files</li>
-                        <li>File modes: read, write, append</li>
-                        <li>Working with file paths</li>
-                        <li>Context managers (with statement)</li>
-                        <li>Practice: Word Guessing Game</li>
-                    </ul>
+                    <div class="lesson-heading">Lesson: Lists, Tuples, Sets and Dictionaries</div>
                 </div>
             </div>
 
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">6</span>
-                    <span class="module-title">Testing Python</span>
-                    <span class="module-hours">6 hours</span>
+                    <span class="module-title">File IO</span>
+                    <span class="module-hours">TBD</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: File IO</div>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">7</span>
+                    <span class="module-title">Python in Practice (Practice Lab)</span>
+                    <span class="module-hours">TBD</span>
+                </div>
+                <div class="module-body">
+                    <p style="font-size:13px;color:var(--text-muted);">Lab project — not a lesson.</p>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">8</span>
+                    <span class="module-title">Summative Assessment</span>
+                    <span class="module-hours">TBD</span>
+                </div>
+                <div class="module-body">
+                    <p style="font-size:13px;color:var(--text-muted);">Assessment artifacts — not a lesson.</p>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">9</span>
+                    <span class="module-title">Testing in Python</span>
+                    <span class="module-hours">TBD</span>
                 </div>
                 <div class="module-body">
                     <div class="lesson-heading">Lesson: Testing in Python</div>
-                    <ul class="topic-list">
-                        <li>Why testing matters in software development</li>
-                        <li>Unit testing with unittest framework</li>
-                        <li>Writing test cases and assertions</li>
-                        <li>Test-driven development basics</li>
-                        <li>Quiz: Testing in Python</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Practice Lab — Tournament Tracker</div>
-                    <ul class="topic-list">
-                        <li>Integrated lab combining all course concepts</li>
-                        <li>Building a complete Python application</li>
-                        <li>Applying testing to a real project</li>
-                    </ul>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Resolves #61 (tracking outline JSON + syllabus HTML drift from new design-doc source) and bundles the OSS audit sub-issue #77 (under META #63).

## Outline JSON

`outlines/python-basics.json` replaced:

| | Before | After |
|---|---|---|
| Total modules | 6 (legacy reconstruction) | 9 (per design-doc) |
| Total lessons | 14 | 10 |
| Total hours | 48 | 48 (OSS target) |
| Per-module hours | hardcoded | null (TBD) |
| Per-lesson topics | rich (often stale) | minimal (titles + a few topics for Module 1) |

The 9 modules match `apprenti-org/design-documentation:course-design/python-basics/course-outline-python-basics.md`:
1. Introduction to Python (1 lesson)
2. Variables, Inputs, and String Manipulation (1 lesson)
3. Arrays and Flow Control (4 lessons: Arrays, Lists, Pseudocode, Flowcharting)
4. Functions (1 lesson)
5. Lists, Tuples, Sets and Dictionaries (1 lesson)
6. File IO (1 lesson)
7. Python in Practice (Practice Lab) (0 lessons — lab project)
8. Summative Assessment (0 lessons — assessment artifacts)
9. Testing in Python (1 lesson)

Per-module/per-lesson hours stay TBD pending design-doc#83 (40h syllabus vs 48h OSS target) and design-doc#90 (LO + content extraction).

## Syllabus HTML

`syllabi/python-basics.html`:
- Course Outline section rewritten to the 9-module structure with TBD hours
- Banner pointing to the design-doc as canonical source
- Header curriculum tag updated: "Software Developer" → "Software Developer Java · Operations Support Specialist — Network"
- Header hours updated: "48 hours" → "48 hours (target)"
- Learning outcomes (25 entries) preserved as-is — they're still aligned with the new structure

## courses.json

- `status.development`: Not Started → **In Progress** (10 SCORM zips + 14 PDFs in deploy tree — matches the linux-foundations / comptia-network-plus pattern)
- `note`: descriptive summary added (new structure, TBD hours, deploy state, curriculum membership)
- `sourceRepo`: added `https://github.com/apprenti-org/design-documentation`
- `statusConfirmed`: false → **true**

Bundles regenerated via `node build.js`.

Closes #61, closes #77. Sub-issue under META #63.

## Test plan

- [ ] Refresh dashboard: python-basics renders with 9 modules / 10 lessons; outline section shows new structure
- [ ] Course detail panel: development track now "In Progress"; "status not yet audited" badge gone; Source link to design-documentation appears
- [ ] Syllabus HTML opens; banner visible; module list shows 9 modules
- [ ] OSS curriculum view total still 560h; Software Developer Java curriculum unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)