### PR TITLE
OSS audit: java-language-fundamentals — sourceRepo + note + statusConfirmed: true

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-26T08:48:55",
+  "generated": "2026-04-26T09:02:34",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -491,9 +491,10 @@ const courseData = [
     },
     "syllabus": "Syllabus: Curriculum Software Development Java",
     "outline": "Course Outline: Java Language Fundamentals",
-    "note": null,
+    "note": "56h default (used by Software Developer Java); 40h variant for OSS via hoursOverride. Design-doc folder present in apprenti-org/design-documentation (course-outline + lessons + source mirror + standard-alignment); source migration #179 completed 2026-04-25 (117 source files mirrored). Used in OSS Course 8, Area 3 and Software Developer Java curriculum. No SCORM/PDFs yet — Phase 3 development not started.",
     "driveFolder": "https://drive.google.com/drive/folders/1WsYJI5dqg9t__bmSmUCb2qCY7ywV-SwK",
-    "statusConfirmed": false
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+    "statusConfirmed": true
   },
   {
     "id": "java-oop",

--- a/courses.json
+++ b/courses.json
@@ -489,9 +489,10 @@
       },
       "syllabus": "Syllabus: Curriculum Software Development Java",
       "outline": "Course Outline: Java Language Fundamentals",
-      "note": null,
+      "note": "56h default (used by Software Developer Java); 40h variant for OSS via hoursOverride. Design-doc folder present in apprenti-org/design-documentation (course-outline + lessons + source mirror + standard-alignment); source migration #179 completed 2026-04-25 (117 source files mirrored). Used in OSS Course 8, Area 3 and Software Developer Java curriculum. No SCORM/PDFs yet — Phase 3 development not started.",
       "driveFolder": "https://drive.google.com/drive/folders/1WsYJI5dqg9t__bmSmUCb2qCY7ywV-SwK",
-      "statusConfirmed": false
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+      "statusConfirmed": true
     },
     {
       "id": "java-oop",


### PR DESCRIPTION
## Summary

Audit verified java-language-fundamentals against current source state (META #63 sub-issue). Three additions: `sourceRepo`, descriptive `note`, `statusConfirmed: true`. No status changes.

## Verification

| Check | Result |
|---|---|
| Hours: default 56h + OSS `hoursOverride: 40` matches outline + design-doc header (Course 8, Area 3) | ✅ |
| Outline JSON (56h / 11 modules / 18 lessons) matches design-doc header | ✅ |
| Syllabus HTML renders (`syllabi/java-language-fundamentals.html`) | ✅ |
| Drive folder URL resolves (HTTP 200) | ✅ |
| `status.design: Complete` accurate (design-doc folder + standard-alignment + 117-file source mirror via #179) | ✅ |
| `status.development: Not Started` accurate (0 SCORM, 0 PDFs, working folder only has stub md files) | ✅ |

## Changes

- `sourceRepo`: added `https://github.com/apprenti-org/design-documentation` (course is in design-doc; source migration #179 completed 2026-04-25)
- `note`: descriptive summary covering 56h default / 40h OSS variant, design-doc state, source migration, dev-not-started
- `statusConfirmed`: false → **true**

## Flag for design-side follow-up (not addressed in this PR)

Design-doc per-module hours sum to **52h** but the header says **56h** (Module 1: design-doc 4h vs outline JSON 6h; Module 9: design-doc 4h vs outline JSON 6h). The tracking outline JSON inflates two modules to make the sum match the 56h total. Recommend filing a follow-up in `apprenti-org/design-documentation` under #178 to reconcile.

Closes #79. Sub-issue under META #63.

## Test plan

- [ ] Refresh dashboard: java-language-fundamentals shows Source link to design-documentation; "status not yet audited" badge gone; range pill shows `40–56 hours (varies by curriculum)` per #67
- [ ] OSS group total still 236h; SWD Java curriculum unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)