### PR TITLE
OSS audit: web-development-with-javascript — note + statusConfirmed: true

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-26T09:02:34",
+  "generated": "2026-04-26T10:04:20",
   "courseCount": 64,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -901,9 +901,9 @@ const courseData = [
     },
     "syllabus": null,
     "outline": "Course Outline: Web Development with JavaScript",
-    "note": null,
+    "note": "Pre-design-doc-workflow course; source content lives in Drive folder. Tracking outline JSON (web-dev-javascript-react.json) and syllabus HTML reconstructed from source — 40h / 8 modules / 17 lessons. No working folder or design-doc folder yet (no Phase 0 reconciliation done). Used in OSS Course 9, Area 3.",
     "driveFolder": "https://drive.google.com/drive/folders/1sgXBEFNAIVxqU5fj2Z6KA8NGQDjeMXRv",
-    "statusConfirmed": false
+    "statusConfirmed": true
   }
 ];
 

--- a/courses.json
+++ b/courses.json
@@ -899,9 +899,9 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Web Development with JavaScript",
-      "note": null,
+      "note": "Pre-design-doc-workflow course; source content lives in Drive folder. Tracking outline JSON (web-dev-javascript-react.json) and syllabus HTML reconstructed from source — 40h / 8 modules / 17 lessons. No working folder or design-doc folder yet (no Phase 0 reconciliation done). Used in OSS Course 9, Area 3.",
       "driveFolder": "https://drive.google.com/drive/folders/1sgXBEFNAIVxqU5fj2Z6KA8NGQDjeMXRv",
-      "statusConfirmed": false
+      "statusConfirmed": true
     }
   ],
   "curricula": [


### PR DESCRIPTION
## Summary

Audit verified web-development-with-javascript against current source state (META #63 sub-issue). Adds descriptive `note`, flips `statusConfirmed: true`. No status changes.

## Verification

| Check | Result |
|---|---|
| Hours = OSS outline (40h, Course 9, Area 3) | ✅ |
| Outline JSON (40h / 8 modules / 17 lessons; sums internally consistent) | ✅ |
| Syllabus HTML renders (`syllabi/web-dev-javascript-react.html`, legacy `-react` filename) | ✅ |
| Drive folder URL resolves (HTTP 200) | ✅ |
| `status.design: Complete` accurate (Drive source + reconstructed outline/syllabus) | ✅ |
| `status.development: Not Started` accurate (0 SCORM, 0 PDFs) | ✅ |

## Pre-design-doc-workflow state — flagged in note

The course has Drive source content but has not been migrated to the design-doc workflow:
- No `_COURSES Phase 1 - WORKING/courses/web-development-with-javascript/` working folder
- No `apprenti-org/design-documentation:course-design/web-development-with-javascript/` design-doc folder
- Outline JSON and syllabus HTML are reconstructed from Drive source

Future Phase 0 reconciliation work is tracked separately (would file in `apprenti-org/design-documentation` under a new onboarding meta-issue when ready).

Closes #81. Sub-issue under META #63.

## Test plan

- [ ] Refresh dashboard: web-development-with-javascript no longer shows "status not yet audited" badge
- [ ] OSS Area 3 still totals 236h
- [ ] No other course records changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)