### PR TITLE
cicd-pipeline-concepts: design + development → Complete (#94)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -357,7 +357,7 @@ var courseOverviewData = [
     "outline": {
       "exists": true,
       "modules": 4,
-      "lessons": 8
+      "lessons": 9
     },
     "syllabus": true,
     "source": {
@@ -381,7 +381,7 @@ var courseOverviewData = [
     "totalAssets": 0,
     "deployment": {
       "state": "Not Deployed",
-      "expected": 0,
+      "expected": 9,
       "actual": 0
     }
   },

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-26T14:14:33",
+  "generated": "2026-04-27T12:12:53",
   "courseCount": 64,
   "courses": [
     {
@@ -359,7 +359,7 @@
       "outline": {
         "exists": true,
         "modules": 4,
-        "lessons": 8
+        "lessons": 9
       },
       "syllabus": true,
       "source": {
@@ -383,7 +383,7 @@
       "totalAssets": 0,
       "deployment": {
         "state": "Not Deployed",
-        "expected": 0,
+        "expected": 9,
         "actual": 0
       }
     },

--- a/courses.js
+++ b/courses.js
@@ -147,13 +147,14 @@ const courseData = [
     "name": "CI/CD Pipeline Concepts",
     "hours": 10,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "Complete"
     },
     "syllabus": null,
     "outline": null,
-    "note": "OSS Course 11, Area 3 — net-new course covering CI/CD pipeline architecture, automated testing and deployment. 10h. Active dev pipeline — design work beginning soon. Audit confirms Not Started baseline (per #84).",
+    "note": "OSS Course 11, Area 3 — GitHub-Actions-focused CI/CD course. 10h, 3 modules, 9 lessons (incl. 1.5h capstone). Design folder complete in apprenti-org/design-documentation (course outline + 8 lesson outlines + 9 lesson sources + standard alignment). Phase 3 production complete via #236: 60 production files (9 lessons × 6 artifacts + 3 module READMEs + 3 MODULE-REPORTs); 18/18 alignment passes per module; 0 permanent quarantines. Course-completion report at _COURSES Phase 1 - WORKING/courses/cicd-pipeline-concepts/_REVIEW/course-completion-report.md. Module review gates written, awaiting human sign-off. Per tracking #94.",
     "driveFolder": null,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
     "statusConfirmed": true
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -145,13 +145,14 @@
       "name": "CI/CD Pipeline Concepts",
       "hours": 10,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "Complete"
       },
       "syllabus": null,
       "outline": null,
-      "note": "OSS Course 11, Area 3 \u2014 net-new course covering CI/CD pipeline architecture, automated testing and deployment. 10h. Active dev pipeline \u2014 design work beginning soon. Audit confirms Not Started baseline (per #84).",
+      "note": "OSS Course 11, Area 3 \u2014 GitHub-Actions-focused CI/CD course. 10h, 3 modules, 9 lessons (incl. 1.5h capstone). Design folder complete in apprenti-org/design-documentation (course outline + 8 lesson outlines + 9 lesson sources + standard alignment). Phase 3 production complete via #236: 60 production files (9 lessons \u00d7 6 artifacts + 3 module READMEs + 3 MODULE-REPORTs); 18/18 alignment passes per module; 0 permanent quarantines. Course-completion report at _COURSES Phase 1 - WORKING/courses/cicd-pipeline-concepts/_REVIEW/course-completion-report.md. Module review gates written, awaiting human sign-off. Per tracking #94.",
       "driveFolder": null,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
     },
     {


### PR DESCRIPTION
Closes #94.

## Summary

- Flips `cicd-pipeline-concepts` `status.design` and `status.development` from `Not Started` → `Complete` after Phase 3 content production landed via `apprenti-org/design-documentation#236`.
- Adds `sourceRepo: "https://github.com/apprenti-org/design-documentation"` (course design + production lives in design-doc).
- Refreshes `note` to describe production state (60 files, 18/18 alignment passes per module, module review gates pending sign-off).
- Regenerated `courses.js`, `course-overview.js`, `course-overview.json` via `node build.js`.

## Source-of-truth state

- **Design folder:** `apprenti-org/design-documentation:course-design/cicd-pipeline-concepts/` — course outline + 8 lesson outlines + 9 lesson sources + standard alignment doc.
- **Production:** `apprenti-org/design-documentation#236` Phase 3 — PR #237 carries the design-doc tracker. Parent-workspace artifact tree fully populated under `_COURSES Phase 1 - WORKING/courses/cicd-pipeline-concepts/` (3 modules / 9 lessons / 60 files).
- **Course-completion report:** `_COURSES Phase 1 - WORKING/courses/cicd-pipeline-concepts/_REVIEW/course-completion-report.md` (commit `892f655` on parent-workspace main).
- **Module review gates:** M1, M2, M3 MODULE-REPORTs written; awaiting human sign-off per `issue-template--content-production.md` Step 3.

## Test plan

- [x] `node build.js` ran clean
- [ ] After merge, dashboard renders `CI/CD Pipeline Concepts` as design+development complete
- [ ] Issue #94 closes on merge
- [ ] Outstanding (out-of-scope for this PR): row 7 (SCORM Packaging) opens against `apprenti-org/design-documentation#221` after `#236` closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)