### PR TITLE
cicd-pipeline-concepts row 7 Phase 4: outline SCORM entries + L9 capstone (#238)

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-27T12:12:53",
+  "generated": "2026-04-27T18:10:21",
   "courseCount": 64,
   "courses": [
     {

--- a/outlines/cicd-pipeline-concepts.json
+++ b/outlines/cicd-pipeline-concepts.json
@@ -2,7 +2,7 @@
   "course": "CI/CD Pipeline Concepts",
   "totalHours": 10,
   "totalModules": 3,
-  "totalLessons": 8,
+  "totalLessons": 9,
   "modules": [
     {
       "name": "CI/CD pipeline concepts and tooling",
@@ -21,6 +21,7 @@
           ],
           "objects": [
             "Object: Lesson: CI/CD Fundamentals and Version Control for CI",
+            "SCORM: Interactive — CI/CD Fundamentals and Version Control for CI",
             "Assessment: Quiz: CI/CD Fundamentals and Version Control for CI"
           ]
         },
@@ -36,6 +37,7 @@
           ],
           "objects": [
             "Object: Lesson: Introduction to GitHub Actions",
+            "SCORM: Interactive — Introduction to GitHub Actions",
             "Assessment: Quiz: Introduction to GitHub Actions"
           ]
         },
@@ -51,6 +53,7 @@
           ],
           "objects": [
             "Object: Lesson: Build Automation and Automated Testing as a CI Step",
+            "SCORM: Interactive — Build Automation and Automated Testing as a CI Step",
             "Assessment: Quiz: Build Automation and Automated Testing as a CI Step"
           ]
         }
@@ -73,6 +76,7 @@
           ],
           "objects": [
             "Object: Lesson: Multi-Stage Pipelines",
+            "SCORM: Interactive — Multi-Stage Pipelines",
             "Assessment: Quiz: Multi-Stage Pipelines"
           ]
         },
@@ -88,6 +92,7 @@
           ],
           "objects": [
             "Object: Lesson: Secrets, Environments, and Environment Protection",
+            "SCORM: Interactive — Secrets, Environments, and Environment Protection",
             "Assessment: Quiz: Secrets, Environments, and Environment Protection"
           ]
         },
@@ -104,6 +109,7 @@
           ],
           "objects": [
             "Object: Lesson: Monitoring and Feedback Loops",
+            "SCORM: Interactive — Monitoring and Feedback Loops",
             "Assessment: Quiz: Monitoring and Feedback Loops"
           ]
         }
@@ -126,6 +132,7 @@
           ],
           "objects": [
             "Object: Lesson: Deployment Strategies",
+            "SCORM: Interactive — Deployment Strategies",
             "Assessment: Quiz: Deployment Strategies"
           ]
         },
@@ -142,7 +149,26 @@
           ],
           "objects": [
             "Object: Lesson: Release Management",
+            "SCORM: Interactive — Release Management",
             "Assessment: Quiz: Release Management"
+          ]
+        },
+        {
+          "title": "Build a Working CI/CD Pipeline (Capstone)",
+          "hours": 1.5,
+          "topics": [
+            "Lab brief: 4-stage pipeline (lint, test, build, deploy-staging) with one environment + one secret",
+            "Phase 1: Build the 4-Stage Pipeline (35 min) — author the workflow YAML",
+            "Phase 2: Configure the staging Environment (15 min) — protection rule + secret",
+            "Phase 3: Verify and Document (20 min) — green run + README section",
+            "Stretch goal (optional): swap in a Course 7 / Course 12 codebase",
+            "Individual capstone lab: produce green end-to-end run + portfolio-grade README"
+          ],
+          "objects": [
+            "Object: Lesson: Build a Working CI/CD Pipeline (Capstone)",
+            "SCORM: Interactive — Build a Working CI/CD Pipeline (Capstone)",
+            "Assessment: Quiz: Build a Working CI/CD Pipeline (Capstone)",
+            "Object: Activity — Build a 4-Stage CI/CD Pipeline End-to-End (Capstone)"
           ]
         }
       ]


### PR DESCRIPTION
Closes #238 row 7 tracking deliverable (no separate tracking-repo issue — the umbrella is `apprenti-org/design-documentation#238`).

## Summary

- Insert \`SCORM: Interactive — <title>\` entry into \`objects[]\` for all 9 cicd-pipeline-concepts lessons
- Add L9 capstone (\`Build a Working CI/CD Pipeline (Capstone)\`, 1.5h) to M3.lessons — was missing because L9 had no separate lesson outline file in design-doc (capstone authored direct from the course outline's M3 capstone block)
- \`totalLessons\`: 8 → 9
- Regenerate \`course-overview.json\` via \`node build.js\`

## Source-of-truth reconciled

- All 9 lessons now have a SCORM entry matching the row-7 packaging output (parent-workspace commit \`6b4f45d\`)
- \`courses.json\` \`status.design\` + \`status.development\` remain "Complete" (set in tracking #94 / PR #95 after row 6 content production)
- \`sourceRepo\` unchanged

## Out of scope

- Row 8 (Deployment) — separate onboarding issue against \`apprenti-org/design-documentation#221\`
- Backports of v1.3.0/v1.4.0/v1.5.0/scroll fixes to other courses (\`#241\`, \`#242\`, \`#247\` etc.)

## Test plan

- [x] outline JSON has 9 lessons each with SCORM entry
- [x] \`node build.js\` ran clean
- [ ] Dashboard renders M3 with 3 lessons after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)