### PR TITLE
CTSE: correct curriculum composition + add ABA Banking Foundations

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -1,6 +1,41 @@
 // Auto-generated from course-overview.json — do not edit directly
 var courseOverviewData = [
   {
+    "id": "aba-banking-foundations",
+    "name": "ABA Banking Foundations",
+    "hours": null,
+    "outline": {
+      "exists": false,
+      "modules": 0,
+      "lessons": 0
+    },
+    "syllabus": false,
+    "source": {
+      "exists": false,
+      "folder": null,
+      "modules": 0
+    },
+    "coverage": null,
+    "lessonsWithContent": 0,
+    "assets": {
+      "lessons": 0,
+      "slides": 0,
+      "quizzes": 0,
+      "activities": 0,
+      "demos": 0,
+      "caseStudies": 0,
+      "instructorGuides": 0,
+      "modIntros": 0,
+      "modRecaps": 0
+    },
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
+  },
+  {
     "id": "advanced-python",
     "name": "Advanced Python",
     "hours": null,
@@ -12,7 +47,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Advanced Python",
+      "folder": "Course  Advanced Python",
       "modules": 9
     },
     "coverage": 93,
@@ -47,7 +82,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Agile Project Management with Scrum",
+      "folder": "Course  Agile Project Management with Scrum",
       "modules": 5
     },
     "coverage": 12,
@@ -117,7 +152,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: ASPNET",
+      "folder": "Course  ASPNET",
       "modules": 1
     },
     "coverage": 83,
@@ -152,23 +187,23 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Business Analysis Fundamentals",
+      "folder": "Course  Business Analysis Fundamentals",
       "modules": 5
     },
-    "coverage": 86,
-    "lessonsWithContent": 32,
+    "coverage": 73,
+    "lessonsWithContent": 27,
     "assets": {
-      "lessons": 31,
+      "lessons": 26,
       "slides": 32,
-      "quizzes": 32,
-      "activities": 56,
+      "quizzes": 27,
+      "activities": 47,
       "demos": 7,
-      "caseStudies": 7,
+      "caseStudies": 6,
       "instructorGuides": 6,
       "modIntros": 1,
       "modRecaps": 4
     },
-    "totalAssets": 176,
+    "totalAssets": 156,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -187,7 +222,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Business and IT Fundamentals",
+      "folder": "Course  Business and IT Fundamentals",
       "modules": 8
     },
     "coverage": 92,
@@ -222,7 +257,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: C# Data Access",
+      "folder": "Course  C# Data Access",
       "modules": 1
     },
     "coverage": 71,
@@ -257,7 +292,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: C# Language Fundamentals",
+      "folder": "Course  C# Language Fundamentals",
       "modules": 1
     },
     "coverage": 92,
@@ -292,7 +327,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: C# OOP",
+      "folder": "Course  C# OOP",
       "modules": 1
     },
     "coverage": 88,
@@ -327,7 +362,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: C++ Coding Booster",
+      "folder": "Course  C++ Coding Booster",
       "modules": 9
     },
     "coverage": 0,
@@ -380,9 +415,9 @@ var courseOverviewData = [
     },
     "totalAssets": 0,
     "deployment": {
-      "state": "Not Deployed",
+      "state": "Complete",
       "expected": 9,
-      "actual": 0
+      "actual": 9
     }
   },
   {
@@ -432,7 +467,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Security and Cybersecurity Fundamentals",
+      "folder": "Course  Security and Cybersecurity Fundamentals",
       "modules": 7
     },
     "coverage": 100,
@@ -467,7 +502,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "COURSE: CompTIA A+",
+      "folder": "COURSE  CompTIA A+",
       "modules": 7
     },
     "coverage": 15,
@@ -502,7 +537,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "COURSE: CompTIA Network+ 96",
+      "folder": "COURSE  CompTIA Network+ 96",
       "modules": 0
     },
     "coverage": 0,
@@ -537,7 +572,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Data Literacy",
+      "folder": "Course  Data Literacy",
       "modules": 9
     },
     "coverage": 0,
@@ -572,7 +607,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Data Visualizations and Power BI",
+      "folder": "Course  Data Visualizations and Power BI",
       "modules": 8
     },
     "coverage": 0,
@@ -607,7 +642,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Excel for Data Analysts",
+      "folder": "Course  Excel for Data Analysts",
       "modules": 10
     },
     "coverage": 14,
@@ -642,7 +677,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: SQL for Data",
+      "folder": "Course  SQL for Data",
       "modules": 8
     },
     "coverage": 0,
@@ -677,7 +712,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Databases in Java",
+      "folder": "Course  Databases in Java",
       "modules": 12
     },
     "coverage": null,
@@ -712,7 +747,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "COURSE: Helpdesk Software",
+      "folder": "COURSE  Helpdesk Software",
       "modules": 0
     },
     "coverage": 0,
@@ -747,7 +782,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: HTTP Services",
+      "folder": "Course  HTTP Services",
       "modules": 0
     },
     "coverage": 0,
@@ -817,7 +852,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: Instructor Onboarding",
+      "folder": "Course  Instructor Onboarding",
       "modules": 0
     },
     "coverage": 0,
@@ -852,7 +887,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "Course: Introduction to Advanced Concepts in Java",
+      "folder": "Course  Introduction to Advanced Concepts in Java",
       "modules": 3
     },
     "coverage": null,
@@ -887,7 +922,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Introduction to AWS Cloud Platform",
+      "folder": "Course  Introduction to AWS Cloud Platform",
       "modules": 10
     },
     "coverage": 0,
@@ -922,7 +957,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Introduction to Cloud Technologies",
+      "folder": "Course  Introduction to Cloud Technologies",
       "modules": 6
     },
     "coverage": 0,
@@ -957,7 +992,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Introduction to GitHub",
+      "folder": "Course  Introduction to GitHub",
       "modules": 1
     },
     "coverage": 0,
@@ -992,7 +1027,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Introduction to HTML & CSS (1)",
+      "folder": "Course  Introduction to HTML & CSS",
       "modules": 3
     },
     "coverage": 0,
@@ -1027,7 +1062,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: Introduction to Microsoft Teams",
+      "folder": "Course  Introduction to Microsoft Teams",
       "modules": 0
     },
     "coverage": 0,
@@ -1062,7 +1097,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: IT Fundamentals",
+      "folder": "Course  IT Fundamentals",
       "modules": 7
     },
     "coverage": 100,
@@ -1167,7 +1202,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Java Booster",
+      "folder": "Course  Java Booster",
       "modules": 8
     },
     "coverage": 0,
@@ -1202,7 +1237,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Java Language Fundamentals",
+      "folder": "Course  Java Language Fundamentals",
       "modules": 11
     },
     "coverage": 85,
@@ -1237,7 +1272,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "Course: Java OOP",
+      "folder": "Course  Java OOP",
       "modules": 6
     },
     "coverage": null,
@@ -1271,24 +1306,24 @@ var courseOverviewData = [
     },
     "syllabus": true,
     "source": {
-      "exists": false,
-      "folder": null,
-      "modules": 0
+      "exists": true,
+      "folder": "Course  JavaScript",
+      "modules": 4
     },
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 0,
-      "slides": 0,
+      "lessons": 24,
+      "slides": 11,
       "quizzes": 0,
-      "activities": 0,
-      "demos": 0,
+      "activities": 35,
+      "demos": 5,
       "caseStudies": 0,
       "instructorGuides": 0,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0,
+    "totalAssets": 75,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1307,7 +1342,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: JavaScript Booster",
+      "folder": "Course  JavaScript Booster",
       "modules": 4
     },
     "coverage": 0,
@@ -1342,7 +1377,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: JavaScript React for C#",
+      "folder": "Course  JavaScript React for C#",
       "modules": 1
     },
     "coverage": 0,
@@ -1377,7 +1412,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Layers and File IO for C#",
+      "folder": "Course  Layers and File IO for C#",
       "modules": 1
     },
     "coverage": 80,
@@ -1412,7 +1447,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: LINQ and Dependency Injection",
+      "folder": "Course  LINQ and Dependency Injection",
       "modules": 1
     },
     "coverage": 67,
@@ -1447,7 +1482,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Linux Foundations",
+      "folder": "Course  Linux Foundations",
       "modules": 4
     },
     "coverage": 100,
@@ -1482,7 +1517,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "COURSE: macOS Administration Fundamentals",
+      "folder": "COURSE  macOS Administration Fundamentals",
       "modules": 0
     },
     "coverage": 0,
@@ -1517,7 +1552,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "COURSE: Microsoft Endpoint Administrator",
+      "folder": "COURSE  Microsoft Endpoint Administrator",
       "modules": 11
     },
     "coverage": null,
@@ -1552,7 +1587,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "COURSE: Microsoft 365 Fundamentals",
+      "folder": "COURSE  Microsoft 365 Fundamentals",
       "modules": 4
     },
     "coverage": null,
@@ -1587,7 +1622,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: Networking Fundamentals",
+      "folder": "Course  Networking Fundamentals",
       "modules": 0
     },
     "coverage": null,
@@ -1622,7 +1657,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Non-Relational Data",
+      "folder": "Course  Non-Relational Data",
       "modules": 5
     },
     "coverage": 0,
@@ -1657,7 +1692,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Pandas",
+      "folder": "Course  Pandas",
       "modules": 6
     },
     "coverage": 0,
@@ -1797,7 +1832,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Python Booster",
+      "folder": "Course  Python Booster",
       "modules": 8
     },
     "coverage": 0,
@@ -1867,7 +1902,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: React",
+      "folder": "Course  React",
       "modules": 0
     },
     "coverage": null,
@@ -1902,7 +1937,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Security and Cybersecurity Fundamentals",
+      "folder": "Course  Security and Cybersecurity Fundamentals",
       "modules": 7
     },
     "coverage": null,
@@ -1936,8 +1971,8 @@ var courseOverviewData = [
     },
     "syllabus": true,
     "source": {
-      "exists": false,
-      "folder": "Course: Software Developer Prework",
+      "exists": true,
+      "folder": "CURRICULUM  Software Developer Java",
       "modules": 0
     },
     "coverage": null,
@@ -1949,11 +1984,11 @@ var courseOverviewData = [
       "activities": 0,
       "demos": 0,
       "caseStudies": 0,
-      "instructorGuides": 0,
+      "instructorGuides": 1,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0,
+    "totalAssets": 1,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1972,7 +2007,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: Software Development Lifecycle",
+      "folder": "Course  Software Development Lifecycle",
       "modules": 0
     },
     "coverage": null,
@@ -2007,7 +2042,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: SQL Booster",
+      "folder": "Course  SQL Booster",
       "modules": 4
     },
     "coverage": null,
@@ -2042,7 +2077,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: SQL for C#",
+      "folder": "Course  SQL for C#",
       "modules": 1
     },
     "coverage": null,
@@ -2077,7 +2112,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: SQL for Data",
+      "folder": "Course  SQL for Data",
       "modules": 8
     },
     "coverage": 0,
@@ -2112,7 +2147,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course: Student Onboarding",
+      "folder": "Course  Student Onboarding",
       "modules": 0
     },
     "coverage": null,
@@ -2182,7 +2217,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "COURSE: Troubleshooting Supporting in an Enterprise Environment",
+      "folder": "COURSE  Troubleshooting Supporting in an Enterprise Environment",
       "modules": 7
     },
     "coverage": null,
@@ -2217,7 +2252,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course: Web Development with JavaScript",
+      "folder": "Course  Web Development with JavaScript",
       "modules": 1
     },
     "coverage": 0,

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,7 +1,42 @@
 {
-  "generated": "2026-04-27T18:10:21",
-  "courseCount": 64,
+  "generated": "2026-04-30T14:29:56",
+  "courseCount": 65,
   "courses": [
+    {
+      "id": "aba-banking-foundations",
+      "name": "ABA Banking Foundations",
+      "hours": null,
+      "outline": {
+        "exists": false,
+        "modules": 0,
+        "lessons": 0
+      },
+      "syllabus": false,
+      "source": {
+        "exists": false,
+        "folder": null,
+        "modules": 0
+      },
+      "coverage": null,
+      "lessonsWithContent": 0,
+      "assets": {
+        "lessons": 0,
+        "slides": 0,
+        "quizzes": 0,
+        "activities": 0,
+        "demos": 0,
+        "caseStudies": 0,
+        "instructorGuides": 0,
+        "modIntros": 0,
+        "modRecaps": 0
+      },
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
+    },
     {
       "id": "advanced-python",
       "name": "Advanced Python",
@@ -14,7 +49,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Advanced Python",
+        "folder": "Course  Advanced Python",
         "modules": 9
       },
       "coverage": 93,
@@ -49,7 +84,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Agile Project Management with Scrum",
+        "folder": "Course  Agile Project Management with Scrum",
         "modules": 5
       },
       "coverage": 12,
@@ -119,7 +154,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: ASPNET",
+        "folder": "Course  ASPNET",
         "modules": 1
       },
       "coverage": 83,
@@ -154,23 +189,23 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Business Analysis Fundamentals",
+        "folder": "Course  Business Analysis Fundamentals",
         "modules": 5
       },
-      "coverage": 86,
-      "lessonsWithContent": 32,
+      "coverage": 73,
+      "lessonsWithContent": 27,
       "assets": {
-        "lessons": 31,
+        "lessons": 26,
         "slides": 32,
-        "quizzes": 32,
-        "activities": 56,
+        "quizzes": 27,
+        "activities": 47,
         "demos": 7,
-        "caseStudies": 7,
+        "caseStudies": 6,
         "instructorGuides": 6,
         "modIntros": 1,
         "modRecaps": 4
       },
-      "totalAssets": 176,
+      "totalAssets": 156,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -189,7 +224,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Business and IT Fundamentals",
+        "folder": "Course  Business and IT Fundamentals",
         "modules": 8
       },
       "coverage": 92,
@@ -224,7 +259,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: C# Data Access",
+        "folder": "Course  C# Data Access",
         "modules": 1
       },
       "coverage": 71,
@@ -259,7 +294,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: C# Language Fundamentals",
+        "folder": "Course  C# Language Fundamentals",
         "modules": 1
       },
       "coverage": 92,
@@ -294,7 +329,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: C# OOP",
+        "folder": "Course  C# OOP",
         "modules": 1
       },
       "coverage": 88,
@@ -329,7 +364,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: C++ Coding Booster",
+        "folder": "Course  C++ Coding Booster",
         "modules": 9
       },
       "coverage": 0,
@@ -382,9 +417,9 @@
       },
       "totalAssets": 0,
       "deployment": {
-        "state": "Not Deployed",
+        "state": "Complete",
         "expected": 9,
-        "actual": 0
+        "actual": 9
       }
     },
     {
@@ -434,7 +469,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Security and Cybersecurity Fundamentals",
+        "folder": "Course  Security and Cybersecurity Fundamentals",
         "modules": 7
       },
       "coverage": 100,
@@ -469,7 +504,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "COURSE: CompTIA A+",
+        "folder": "COURSE  CompTIA A+",
         "modules": 7
       },
       "coverage": 15,
@@ -504,7 +539,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "COURSE: CompTIA Network+ 96",
+        "folder": "COURSE  CompTIA Network+ 96",
         "modules": 0
       },
       "coverage": 0,
@@ -539,7 +574,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Data Literacy",
+        "folder": "Course  Data Literacy",
         "modules": 9
       },
       "coverage": 0,
@@ -574,7 +609,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Data Visualizations and Power BI",
+        "folder": "Course  Data Visualizations and Power BI",
         "modules": 8
       },
       "coverage": 0,
@@ -609,7 +644,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Excel for Data Analysts",
+        "folder": "Course  Excel for Data Analysts",
         "modules": 10
       },
       "coverage": 14,
@@ -644,7 +679,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: SQL for Data",
+        "folder": "Course  SQL for Data",
         "modules": 8
       },
       "coverage": 0,
@@ -679,7 +714,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Databases in Java",
+        "folder": "Course  Databases in Java",
         "modules": 12
       },
       "coverage": null,
@@ -714,7 +749,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "COURSE: Helpdesk Software",
+        "folder": "COURSE  Helpdesk Software",
         "modules": 0
       },
       "coverage": 0,
@@ -749,7 +784,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: HTTP Services",
+        "folder": "Course  HTTP Services",
         "modules": 0
       },
       "coverage": 0,
@@ -819,7 +854,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: Instructor Onboarding",
+        "folder": "Course  Instructor Onboarding",
         "modules": 0
       },
       "coverage": 0,
@@ -854,7 +889,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "Course: Introduction to Advanced Concepts in Java",
+        "folder": "Course  Introduction to Advanced Concepts in Java",
         "modules": 3
       },
       "coverage": null,
@@ -889,7 +924,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Introduction to AWS Cloud Platform",
+        "folder": "Course  Introduction to AWS Cloud Platform",
         "modules": 10
       },
       "coverage": 0,
@@ -924,7 +959,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Introduction to Cloud Technologies",
+        "folder": "Course  Introduction to Cloud Technologies",
         "modules": 6
       },
       "coverage": 0,
@@ -959,7 +994,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Introduction to GitHub",
+        "folder": "Course  Introduction to GitHub",
         "modules": 1
       },
       "coverage": 0,
@@ -994,7 +1029,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Introduction to HTML & CSS (1)",
+        "folder": "Course  Introduction to HTML & CSS",
         "modules": 3
       },
       "coverage": 0,
@@ -1029,7 +1064,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: Introduction to Microsoft Teams",
+        "folder": "Course  Introduction to Microsoft Teams",
         "modules": 0
       },
       "coverage": 0,
@@ -1064,7 +1099,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: IT Fundamentals",
+        "folder": "Course  IT Fundamentals",
         "modules": 7
       },
       "coverage": 100,
@@ -1169,7 +1204,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Java Booster",
+        "folder": "Course  Java Booster",
         "modules": 8
       },
       "coverage": 0,
@@ -1204,7 +1239,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Java Language Fundamentals",
+        "folder": "Course  Java Language Fundamentals",
         "modules": 11
       },
       "coverage": 85,
@@ -1239,7 +1274,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "Course: Java OOP",
+        "folder": "Course  Java OOP",
         "modules": 6
       },
       "coverage": null,
@@ -1273,24 +1308,24 @@
       },
       "syllabus": true,
       "source": {
-        "exists": false,
-        "folder": null,
-        "modules": 0
+        "exists": true,
+        "folder": "Course  JavaScript",
+        "modules": 4
       },
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 0,
-        "slides": 0,
+        "lessons": 24,
+        "slides": 11,
         "quizzes": 0,
-        "activities": 0,
-        "demos": 0,
+        "activities": 35,
+        "demos": 5,
         "caseStudies": 0,
         "instructorGuides": 0,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0,
+      "totalAssets": 75,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1309,7 +1344,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: JavaScript Booster",
+        "folder": "Course  JavaScript Booster",
         "modules": 4
       },
       "coverage": 0,
@@ -1344,7 +1379,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: JavaScript React for C#",
+        "folder": "Course  JavaScript React for C#",
         "modules": 1
       },
       "coverage": 0,
@@ -1379,7 +1414,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Layers and File IO for C#",
+        "folder": "Course  Layers and File IO for C#",
         "modules": 1
       },
       "coverage": 80,
@@ -1414,7 +1449,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: LINQ and Dependency Injection",
+        "folder": "Course  LINQ and Dependency Injection",
         "modules": 1
       },
       "coverage": 67,
@@ -1449,7 +1484,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Linux Foundations",
+        "folder": "Course  Linux Foundations",
         "modules": 4
       },
       "coverage": 100,
@@ -1484,7 +1519,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "COURSE: macOS Administration Fundamentals",
+        "folder": "COURSE  macOS Administration Fundamentals",
         "modules": 0
       },
       "coverage": 0,
@@ -1519,7 +1554,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "COURSE: Microsoft Endpoint Administrator",
+        "folder": "COURSE  Microsoft Endpoint Administrator",
         "modules": 11
       },
       "coverage": null,
@@ -1554,7 +1589,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "COURSE: Microsoft 365 Fundamentals",
+        "folder": "COURSE  Microsoft 365 Fundamentals",
         "modules": 4
       },
       "coverage": null,
@@ -1589,7 +1624,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: Networking Fundamentals",
+        "folder": "Course  Networking Fundamentals",
         "modules": 0
       },
       "coverage": null,
@@ -1624,7 +1659,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Non-Relational Data",
+        "folder": "Course  Non-Relational Data",
         "modules": 5
       },
       "coverage": 0,
@@ -1659,7 +1694,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Pandas",
+        "folder": "Course  Pandas",
         "modules": 6
       },
       "coverage": 0,
@@ -1799,7 +1834,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Python Booster",
+        "folder": "Course  Python Booster",
         "modules": 8
       },
       "coverage": 0,
@@ -1869,7 +1904,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: React",
+        "folder": "Course  React",
         "modules": 0
       },
       "coverage": null,
@@ -1904,7 +1939,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Security and Cybersecurity Fundamentals",
+        "folder": "Course  Security and Cybersecurity Fundamentals",
         "modules": 7
       },
       "coverage": null,
@@ -1938,8 +1973,8 @@
       },
       "syllabus": true,
       "source": {
-        "exists": false,
-        "folder": "Course: Software Developer Prework",
+        "exists": true,
+        "folder": "CURRICULUM  Software Developer Java",
         "modules": 0
       },
       "coverage": null,
@@ -1951,11 +1986,11 @@
         "activities": 0,
         "demos": 0,
         "caseStudies": 0,
-        "instructorGuides": 0,
+        "instructorGuides": 1,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0,
+      "totalAssets": 1,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1974,7 +2009,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: Software Development Lifecycle",
+        "folder": "Course  Software Development Lifecycle",
         "modules": 0
       },
       "coverage": null,
@@ -2009,7 +2044,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: SQL Booster",
+        "folder": "Course  SQL Booster",
         "modules": 4
       },
       "coverage": null,
@@ -2044,7 +2079,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: SQL for C#",
+        "folder": "Course  SQL for C#",
         "modules": 1
       },
       "coverage": null,
@@ -2079,7 +2114,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: SQL for Data",
+        "folder": "Course  SQL for Data",
         "modules": 8
       },
       "coverage": 0,
@@ -2114,7 +2149,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course: Student Onboarding",
+        "folder": "Course  Student Onboarding",
         "modules": 0
       },
       "coverage": null,
@@ -2184,7 +2219,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "COURSE: Troubleshooting Supporting in an Enterprise Environment",
+        "folder": "COURSE  Troubleshooting Supporting in an Enterprise Environment",
         "modules": 7
       },
       "coverage": null,
@@ -2219,7 +2254,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course: Web Development with JavaScript",
+        "folder": "Course  Web Development with JavaScript",
         "modules": 1
       },
       "coverage": 0,

--- a/courses.js
+++ b/courses.js
@@ -3,6 +3,22 @@ var dashboardVersion = "0.4.2";
 
 const courseData = [
   {
+    "id": "aba-banking-foundations",
+    "name": "ABA Banking Foundations",
+    "hours": null,
+    "status": {
+      "design": "External",
+      "development": "External"
+    },
+    "external": true,
+    "provider": "American Bankers Association",
+    "syllabus": null,
+    "outline": null,
+    "note": "External provider (American Bankers Association). Course details TBD — hours, syllabus URL, and RTI area coverage to be confirmed.",
+    "driveFolder": null,
+    "statusConfirmed": false
+  },
+  {
     "id": "advanced-python",
     "name": "Advanced Python",
     "hours": null,
@@ -913,7 +929,7 @@ const curriculaData = [
     "name": "Client Technical Support Engineer",
     "groups": [
       {
-        "name": "Foundational IT & Operations",
+        "name": "Foundational IT and Operations",
         "hours": 120,
         "courses": [
           {
@@ -923,13 +939,37 @@ const curriculaData = [
         ]
       },
       {
-        "name": "Foundations of IT Service Management",
-        "hours": 42,
+        "name": "Fundamentals of IT Service Management",
+        "hours": 20,
         "courses": [
           {
+            "name": "ITIL Foundations",
+            "id": "itil-foundations"
+          }
+        ]
+      },
+      {
+        "name": "Banking Fundamentals and Customer Service",
+        "hours": null,
+        "external": true,
+        "courses": [
+          {
+            "name": "ABA Banking Foundations",
+            "id": "aba-banking-foundations"
+          }
+        ]
+      },
+      {
+        "name": "AI and Advanced Supports",
+        "hours": 36,
+        "courses": [
+          {
+            "name": "AI Foundations",
+            "id": "ai-foundations"
+          },
+          {
             "name": "Helpdesk Software Fundamentals",
-            "id": "helpdesk-software-fundamentals",
-            "hoursOverride": 13
+            "id": "helpdesk-software-fundamentals"
           }
         ]
       }

--- a/courses.json
+++ b/courses.json
@@ -1,6 +1,22 @@
 {
   "courses": [
     {
+      "id": "aba-banking-foundations",
+      "name": "ABA Banking Foundations",
+      "hours": null,
+      "status": {
+        "design": "External",
+        "development": "External"
+      },
+      "external": true,
+      "provider": "American Bankers Association",
+      "syllabus": null,
+      "outline": null,
+      "note": "External provider (American Bankers Association). Course details TBD — hours, syllabus URL, and RTI area coverage to be confirmed.",
+      "driveFolder": null,
+      "statusConfirmed": false
+    },
+    {
       "id": "advanced-python",
       "name": "Advanced Python",
       "hours": null,
@@ -910,20 +926,33 @@
       "name": "Client Technical Support Engineer",
       "groups": [
         {
-          "name": "Foundational IT & Operations",
+          "name": "Foundational IT and Operations",
           "hours": 120,
           "courses": [
             "comptia-a-plus"
           ]
         },
         {
-          "name": "Foundations of IT Service Management",
-          "hours": 42,
+          "name": "Fundamentals of IT Service Management",
+          "hours": 20,
           "courses": [
-            {
-              "id": "helpdesk-software-fundamentals",
-              "hoursOverride": 13
-            }
+            "itil-foundations"
+          ]
+        },
+        {
+          "name": "Banking Fundamentals and Customer Service",
+          "hours": null,
+          "external": true,
+          "courses": [
+            "aba-banking-foundations"
+          ]
+        },
+        {
+          "name": "AI and Advanced Supports",
+          "hours": 36,
+          "courses": [
+            "ai-foundations",
+            "helpdesk-software-fundamentals"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

- Corrects CTSE curriculum composition in `courses.json` to match the verified design-folder (apprenti-org/design-documentation#273)
- Adds `aba-banking-foundations` as an external-provider course entry
- Removes the 4 incorrect net-new course entries that were added under the old design; cleans up orphaned outline JSON files

## Changes

**courses.json:**
- New course: `aba-banking-foundations` â€” external, American Bankers Association, hours TBD
- Curricula entry for Client Technical Support Engineer: 4 groups corrected (names and course assignments match design-folder); groups now reference real course IDs (comptia-a-plus, itil-foundations, aba-banking-foundations, ai-foundations, helpdesk-software-fundamentals)

**Removed (orphaned outline JSON files â€” never committed, no course record):**
- `outlines/advanced-banking-compliance-and-professionalism.json`
- `outlines/advanced-support-products-and-career-development.json`
- `outlines/foundational-skills-and-product-knowledge.json`
- `outlines/platform-processing-and-diagnosis.json`

**Regenerated:** `courses.js`, `course-overview.js`, `course-overview.json`

## Test plan

- [ ] ABA Banking Foundations appears in dashboard with External status
- [ ] CTSE curriculum shows 4 correct groups with correct course assignments
- [ ] No references to removed old-course slugs remain in dashboard
- [ ] Build completes cleanly

Relates to apprenti-org/design-documentation#273

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
