### PR TITLE
ui: move runbook link from sidebar to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <div class="header-actions">
             <a class="nav-link" href="curriculum.html"><i class="fa-solid fa-diagram-project"></i> Pipeline</a>
             <a class="nav-link" href="status.html"><i class="fa-solid fa-chart-gantt"></i> Design &amp; Dev Status</a>
+            <a class="nav-link" href="https://github.com/apprenti-org/curriculum-tracking/blob/main/docs/new-course-onboarding-runbook.md" target="_blank" rel="noopener"><i class="fa-solid fa-book-open"></i> Onboarding Runbook</a>
             <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle theme"></button>
         </div>
     </header>
@@ -40,22 +41,6 @@
         <div class="nav-panel">
             <div class="stats-bar" id="stats-bar"></div>
             <div class="nav-scroll" id="nav-scroll"></div>
-            <!-- Process Docs section -->
-            <div style="border-top:1px solid var(--border);padding:12px;">
-                <div class="nav-section-label" style="padding-top:6px;">Process Docs</div>
-                <ul style="list-style:none;margin:0;padding:0 4px;">
-                    <li>
-                        <a href="https://github.com/apprenti-org/curriculum-tracking/blob/main/docs/new-course-onboarding-runbook.md"
-                           target="_blank"
-                           rel="noopener"
-                           style="font-size:12px;color:var(--text-secondary);text-decoration:none;display:block;padding:4px 0;"
-                           onmouseover="this.style.color='var(--accent-primary)'"
-                           onmouseout="this.style.color='var(--text-secondary)'">
-                            <i class="fa-solid fa-book-open" style="font-size:10px;margin-right:6px;opacity:0.7;"></i>New Course Onboarding
-                        </a>
-                    </li>
-                </ul>
-            </div>
         </div>
         <div class="detail-panel" id="detail-panel">
             <div class="detail-empty">


### PR DESCRIPTION
## Summary

Follow-up to #107. Moves the New Course Onboarding runbook link from the sidebar bottom to the header, alongside `Pipeline` and `Design & Dev Status`. Removes the now-empty Process Docs sidebar block.

## Why

The header is the established place for navigation entries that go to other pages/docs. Pinning the runbook to the sidebar bottom buried it; the header makes it discoverable on every dashboard view.

## Changes

- `index.html`: +1 header link, -16 sidebar block (net -15)
- New header link uses the existing `.nav-link` class and `fa-book-open` icon
- Opens in a new tab (`target="_blank" rel="noopener"`)

## Test plan

- [ ] Live dashboard shows "Onboarding Runbook" entry in the header alongside Pipeline / Design & Dev Status
- [ ] Sidebar bottom no longer has the Process Docs block
- [ ] Clicking the link opens the runbook on GitHub in a new tab
- [ ] No regressions on existing header links

Closes #109
