### PR TITLE
fix: register IaC outline JSON + update courses.json outline ref (#298 Phase 0)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -47,7 +47,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Advanced Python",
+      "folder": "Course: Advanced Python",
       "modules": 9
     },
     "coverage": 93,
@@ -82,7 +82,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Agile Project Management with Scrum",
+      "folder": "Course: Agile Project Management with Scrum",
       "modules": 5
     },
     "coverage": 12,
@@ -152,7 +152,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  ASPNET",
+      "folder": "Course: ASPNET",
       "modules": 1
     },
     "coverage": 83,
@@ -187,23 +187,23 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Business Analysis Fundamentals",
+      "folder": "Course: Business Analysis Fundamentals",
       "modules": 5
     },
-    "coverage": 73,
-    "lessonsWithContent": 27,
+    "coverage": 86,
+    "lessonsWithContent": 32,
     "assets": {
-      "lessons": 26,
+      "lessons": 31,
       "slides": 32,
-      "quizzes": 27,
-      "activities": 47,
+      "quizzes": 32,
+      "activities": 56,
       "demos": 7,
-      "caseStudies": 6,
+      "caseStudies": 7,
       "instructorGuides": 6,
       "modIntros": 1,
       "modRecaps": 4
     },
-    "totalAssets": 156,
+    "totalAssets": 176,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -222,7 +222,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Business and IT Fundamentals",
+      "folder": "Course: Business and IT Fundamentals",
       "modules": 8
     },
     "coverage": 92,
@@ -257,7 +257,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  C# Data Access",
+      "folder": "Course: C# Data Access",
       "modules": 1
     },
     "coverage": 71,
@@ -292,7 +292,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  C# Language Fundamentals",
+      "folder": "Course: C# Language Fundamentals",
       "modules": 1
     },
     "coverage": 92,
@@ -327,7 +327,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  C# OOP",
+      "folder": "Course: C# OOP",
       "modules": 1
     },
     "coverage": 88,
@@ -362,7 +362,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  C++ Coding Booster",
+      "folder": "Course: C++ Coding Booster",
       "modules": 9
     },
     "coverage": 0,
@@ -467,7 +467,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Security and Cybersecurity Fundamentals",
+      "folder": "Course: Security and Cybersecurity Fundamentals",
       "modules": 7
     },
     "coverage": 100,
@@ -502,7 +502,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "COURSE  CompTIA A+",
+      "folder": "COURSE: CompTIA A+",
       "modules": 7
     },
     "coverage": 15,
@@ -537,7 +537,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "COURSE  CompTIA Network+ 96",
+      "folder": "COURSE: CompTIA Network+ 96",
       "modules": 0
     },
     "coverage": 0,
@@ -572,7 +572,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Data Literacy",
+      "folder": "Course: Data Literacy",
       "modules": 9
     },
     "coverage": 0,
@@ -607,7 +607,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Data Visualizations and Power BI",
+      "folder": "Course: Data Visualizations and Power BI",
       "modules": 8
     },
     "coverage": 0,
@@ -642,7 +642,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Excel for Data Analysts",
+      "folder": "Course: Excel for Data Analysts",
       "modules": 10
     },
     "coverage": 14,
@@ -677,7 +677,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  SQL for Data",
+      "folder": "Course: SQL for Data",
       "modules": 8
     },
     "coverage": 0,
@@ -712,7 +712,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Databases in Java",
+      "folder": "Course: Databases in Java",
       "modules": 12
     },
     "coverage": null,
@@ -747,7 +747,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "COURSE  Helpdesk Software",
+      "folder": "COURSE: Helpdesk Software",
       "modules": 0
     },
     "coverage": 0,
@@ -782,7 +782,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  HTTP Services",
+      "folder": "Course: HTTP Services",
       "modules": 0
     },
     "coverage": 0,
@@ -812,7 +812,7 @@ var courseOverviewData = [
     "outline": {
       "exists": true,
       "modules": 6,
-      "lessons": 18
+      "lessons": 17
     },
     "syllabus": true,
     "source": {
@@ -852,7 +852,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  Instructor Onboarding",
+      "folder": "Course: Instructor Onboarding",
       "modules": 0
     },
     "coverage": 0,
@@ -887,7 +887,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "Course  Introduction to Advanced Concepts in Java",
+      "folder": "Course: Introduction to Advanced Concepts in Java",
       "modules": 3
     },
     "coverage": null,
@@ -922,7 +922,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Introduction to AWS Cloud Platform",
+      "folder": "Course: Introduction to AWS Cloud Platform",
       "modules": 10
     },
     "coverage": 0,
@@ -957,7 +957,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Introduction to Cloud Technologies",
+      "folder": "Course: Introduction to Cloud Technologies",
       "modules": 6
     },
     "coverage": 0,
@@ -992,7 +992,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Introduction to GitHub",
+      "folder": "Course: Introduction to GitHub",
       "modules": 1
     },
     "coverage": 0,
@@ -1027,7 +1027,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Introduction to HTML & CSS",
+      "folder": "Course: Introduction to HTML & CSS (1)",
       "modules": 3
     },
     "coverage": 0,
@@ -1062,7 +1062,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  Introduction to Microsoft Teams",
+      "folder": "Course: Introduction to Microsoft Teams",
       "modules": 0
     },
     "coverage": 0,
@@ -1097,7 +1097,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  IT Fundamentals",
+      "folder": "Course: IT Fundamentals",
       "modules": 7
     },
     "coverage": 100,
@@ -1202,7 +1202,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Java Booster",
+      "folder": "Course: Java Booster",
       "modules": 8
     },
     "coverage": 0,
@@ -1237,7 +1237,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Java Language Fundamentals",
+      "folder": "Course: Java Language Fundamentals",
       "modules": 11
     },
     "coverage": 85,
@@ -1272,7 +1272,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "Course  Java OOP",
+      "folder": "Course: Java OOP",
       "modules": 6
     },
     "coverage": null,
@@ -1306,24 +1306,24 @@ var courseOverviewData = [
     },
     "syllabus": true,
     "source": {
-      "exists": true,
-      "folder": "Course  JavaScript",
-      "modules": 4
+      "exists": false,
+      "folder": null,
+      "modules": 0
     },
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 24,
-      "slides": 11,
+      "lessons": 0,
+      "slides": 0,
       "quizzes": 0,
-      "activities": 35,
-      "demos": 5,
+      "activities": 0,
+      "demos": 0,
       "caseStudies": 0,
       "instructorGuides": 0,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 75,
+    "totalAssets": 0,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -1342,7 +1342,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  JavaScript Booster",
+      "folder": "Course: JavaScript Booster",
       "modules": 4
     },
     "coverage": 0,
@@ -1377,7 +1377,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  JavaScript React for C#",
+      "folder": "Course: JavaScript React for C#",
       "modules": 1
     },
     "coverage": 0,
@@ -1412,7 +1412,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Layers and File IO for C#",
+      "folder": "Course: Layers and File IO for C#",
       "modules": 1
     },
     "coverage": 80,
@@ -1447,7 +1447,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  LINQ and Dependency Injection",
+      "folder": "Course: LINQ and Dependency Injection",
       "modules": 1
     },
     "coverage": 67,
@@ -1482,7 +1482,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Linux Foundations",
+      "folder": "Course: Linux Foundations",
       "modules": 4
     },
     "coverage": 100,
@@ -1517,7 +1517,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "COURSE  macOS Administration Fundamentals",
+      "folder": "COURSE: macOS Administration Fundamentals",
       "modules": 0
     },
     "coverage": 0,
@@ -1552,7 +1552,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "COURSE  Microsoft Endpoint Administrator",
+      "folder": "COURSE: Microsoft Endpoint Administrator",
       "modules": 11
     },
     "coverage": null,
@@ -1587,7 +1587,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "COURSE  Microsoft 365 Fundamentals",
+      "folder": "COURSE: Microsoft 365 Fundamentals",
       "modules": 4
     },
     "coverage": null,
@@ -1622,7 +1622,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  Networking Fundamentals",
+      "folder": "Course: Networking Fundamentals",
       "modules": 0
     },
     "coverage": null,
@@ -1657,7 +1657,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Non-Relational Data",
+      "folder": "Course: Non-Relational Data",
       "modules": 5
     },
     "coverage": 0,
@@ -1692,7 +1692,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Pandas",
+      "folder": "Course: Pandas",
       "modules": 6
     },
     "coverage": 0,
@@ -1832,7 +1832,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Python Booster",
+      "folder": "Course: Python Booster",
       "modules": 8
     },
     "coverage": 0,
@@ -1902,7 +1902,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  React",
+      "folder": "Course: React",
       "modules": 0
     },
     "coverage": null,
@@ -1937,7 +1937,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Security and Cybersecurity Fundamentals",
+      "folder": "Course: Security and Cybersecurity Fundamentals",
       "modules": 7
     },
     "coverage": null,
@@ -1971,8 +1971,8 @@ var courseOverviewData = [
     },
     "syllabus": true,
     "source": {
-      "exists": true,
-      "folder": "CURRICULUM  Software Developer Java",
+      "exists": false,
+      "folder": "Course: Software Developer Prework",
       "modules": 0
     },
     "coverage": null,
@@ -1984,11 +1984,11 @@ var courseOverviewData = [
       "activities": 0,
       "demos": 0,
       "caseStudies": 0,
-      "instructorGuides": 1,
+      "instructorGuides": 0,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 1,
+    "totalAssets": 0,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,
@@ -2007,7 +2007,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  Software Development Lifecycle",
+      "folder": "Course: Software Development Lifecycle",
       "modules": 0
     },
     "coverage": null,
@@ -2042,7 +2042,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  SQL Booster",
+      "folder": "Course: SQL Booster",
       "modules": 4
     },
     "coverage": null,
@@ -2077,7 +2077,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  SQL for C#",
+      "folder": "Course: SQL for C#",
       "modules": 1
     },
     "coverage": null,
@@ -2112,7 +2112,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  SQL for Data",
+      "folder": "Course: SQL for Data",
       "modules": 8
     },
     "coverage": 0,
@@ -2147,7 +2147,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": false,
-      "folder": "Course  Student Onboarding",
+      "folder": "Course: Student Onboarding",
       "modules": 0
     },
     "coverage": null,
@@ -2217,7 +2217,7 @@ var courseOverviewData = [
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "COURSE  Troubleshooting Supporting in an Enterprise Environment",
+      "folder": "COURSE: Troubleshooting Supporting in an Enterprise Environment",
       "modules": 7
     },
     "coverage": null,
@@ -2252,7 +2252,7 @@ var courseOverviewData = [
     "syllabus": true,
     "source": {
       "exists": true,
-      "folder": "Course  Web Development with JavaScript",
+      "folder": "Course: Web Development with JavaScript",
       "modules": 1
     },
     "coverage": 0,

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-30T16:10:12",
+  "generated": "2026-05-03T16:21:05",
   "courseCount": 65,
   "courses": [
     {
@@ -49,7 +49,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Advanced Python",
+        "folder": "Course: Advanced Python",
         "modules": 9
       },
       "coverage": 93,
@@ -84,7 +84,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Agile Project Management with Scrum",
+        "folder": "Course: Agile Project Management with Scrum",
         "modules": 5
       },
       "coverage": 12,
@@ -154,7 +154,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  ASPNET",
+        "folder": "Course: ASPNET",
         "modules": 1
       },
       "coverage": 83,
@@ -189,23 +189,23 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Business Analysis Fundamentals",
+        "folder": "Course: Business Analysis Fundamentals",
         "modules": 5
       },
-      "coverage": 73,
-      "lessonsWithContent": 27,
+      "coverage": 86,
+      "lessonsWithContent": 32,
       "assets": {
-        "lessons": 26,
+        "lessons": 31,
         "slides": 32,
-        "quizzes": 27,
-        "activities": 47,
+        "quizzes": 32,
+        "activities": 56,
         "demos": 7,
-        "caseStudies": 6,
+        "caseStudies": 7,
         "instructorGuides": 6,
         "modIntros": 1,
         "modRecaps": 4
       },
-      "totalAssets": 156,
+      "totalAssets": 176,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -224,7 +224,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Business and IT Fundamentals",
+        "folder": "Course: Business and IT Fundamentals",
         "modules": 8
       },
       "coverage": 92,
@@ -259,7 +259,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  C# Data Access",
+        "folder": "Course: C# Data Access",
         "modules": 1
       },
       "coverage": 71,
@@ -294,7 +294,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  C# Language Fundamentals",
+        "folder": "Course: C# Language Fundamentals",
         "modules": 1
       },
       "coverage": 92,
@@ -329,7 +329,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  C# OOP",
+        "folder": "Course: C# OOP",
         "modules": 1
       },
       "coverage": 88,
@@ -364,7 +364,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  C++ Coding Booster",
+        "folder": "Course: C++ Coding Booster",
         "modules": 9
       },
       "coverage": 0,
@@ -469,7 +469,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Security and Cybersecurity Fundamentals",
+        "folder": "Course: Security and Cybersecurity Fundamentals",
         "modules": 7
       },
       "coverage": 100,
@@ -504,7 +504,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "COURSE  CompTIA A+",
+        "folder": "COURSE: CompTIA A+",
         "modules": 7
       },
       "coverage": 15,
@@ -539,7 +539,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "COURSE  CompTIA Network+ 96",
+        "folder": "COURSE: CompTIA Network+ 96",
         "modules": 0
       },
       "coverage": 0,
@@ -574,7 +574,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Data Literacy",
+        "folder": "Course: Data Literacy",
         "modules": 9
       },
       "coverage": 0,
@@ -609,7 +609,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Data Visualizations and Power BI",
+        "folder": "Course: Data Visualizations and Power BI",
         "modules": 8
       },
       "coverage": 0,
@@ -644,7 +644,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Excel for Data Analysts",
+        "folder": "Course: Excel for Data Analysts",
         "modules": 10
       },
       "coverage": 14,
@@ -679,7 +679,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  SQL for Data",
+        "folder": "Course: SQL for Data",
         "modules": 8
       },
       "coverage": 0,
@@ -714,7 +714,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Databases in Java",
+        "folder": "Course: Databases in Java",
         "modules": 12
       },
       "coverage": null,
@@ -749,7 +749,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "COURSE  Helpdesk Software",
+        "folder": "COURSE: Helpdesk Software",
         "modules": 0
       },
       "coverage": 0,
@@ -784,7 +784,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  HTTP Services",
+        "folder": "Course: HTTP Services",
         "modules": 0
       },
       "coverage": 0,
@@ -814,7 +814,7 @@
       "outline": {
         "exists": true,
         "modules": 6,
-        "lessons": 18
+        "lessons": 17
       },
       "syllabus": true,
       "source": {
@@ -854,7 +854,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  Instructor Onboarding",
+        "folder": "Course: Instructor Onboarding",
         "modules": 0
       },
       "coverage": 0,
@@ -889,7 +889,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "Course  Introduction to Advanced Concepts in Java",
+        "folder": "Course: Introduction to Advanced Concepts in Java",
         "modules": 3
       },
       "coverage": null,
@@ -924,7 +924,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Introduction to AWS Cloud Platform",
+        "folder": "Course: Introduction to AWS Cloud Platform",
         "modules": 10
       },
       "coverage": 0,
@@ -959,7 +959,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Introduction to Cloud Technologies",
+        "folder": "Course: Introduction to Cloud Technologies",
         "modules": 6
       },
       "coverage": 0,
@@ -994,7 +994,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Introduction to GitHub",
+        "folder": "Course: Introduction to GitHub",
         "modules": 1
       },
       "coverage": 0,
@@ -1029,7 +1029,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Introduction to HTML & CSS",
+        "folder": "Course: Introduction to HTML & CSS (1)",
         "modules": 3
       },
       "coverage": 0,
@@ -1064,7 +1064,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  Introduction to Microsoft Teams",
+        "folder": "Course: Introduction to Microsoft Teams",
         "modules": 0
       },
       "coverage": 0,
@@ -1099,7 +1099,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  IT Fundamentals",
+        "folder": "Course: IT Fundamentals",
         "modules": 7
       },
       "coverage": 100,
@@ -1204,7 +1204,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Java Booster",
+        "folder": "Course: Java Booster",
         "modules": 8
       },
       "coverage": 0,
@@ -1239,7 +1239,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Java Language Fundamentals",
+        "folder": "Course: Java Language Fundamentals",
         "modules": 11
       },
       "coverage": 85,
@@ -1274,7 +1274,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "Course  Java OOP",
+        "folder": "Course: Java OOP",
         "modules": 6
       },
       "coverage": null,
@@ -1308,24 +1308,24 @@
       },
       "syllabus": true,
       "source": {
-        "exists": true,
-        "folder": "Course  JavaScript",
-        "modules": 4
+        "exists": false,
+        "folder": null,
+        "modules": 0
       },
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 24,
-        "slides": 11,
+        "lessons": 0,
+        "slides": 0,
         "quizzes": 0,
-        "activities": 35,
-        "demos": 5,
+        "activities": 0,
+        "demos": 0,
         "caseStudies": 0,
         "instructorGuides": 0,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 75,
+      "totalAssets": 0,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -1344,7 +1344,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  JavaScript Booster",
+        "folder": "Course: JavaScript Booster",
         "modules": 4
       },
       "coverage": 0,
@@ -1379,7 +1379,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  JavaScript React for C#",
+        "folder": "Course: JavaScript React for C#",
         "modules": 1
       },
       "coverage": 0,
@@ -1414,7 +1414,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Layers and File IO for C#",
+        "folder": "Course: Layers and File IO for C#",
         "modules": 1
       },
       "coverage": 80,
@@ -1449,7 +1449,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  LINQ and Dependency Injection",
+        "folder": "Course: LINQ and Dependency Injection",
         "modules": 1
       },
       "coverage": 67,
@@ -1484,7 +1484,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Linux Foundations",
+        "folder": "Course: Linux Foundations",
         "modules": 4
       },
       "coverage": 100,
@@ -1519,7 +1519,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "COURSE  macOS Administration Fundamentals",
+        "folder": "COURSE: macOS Administration Fundamentals",
         "modules": 0
       },
       "coverage": 0,
@@ -1554,7 +1554,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "COURSE  Microsoft Endpoint Administrator",
+        "folder": "COURSE: Microsoft Endpoint Administrator",
         "modules": 11
       },
       "coverage": null,
@@ -1589,7 +1589,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "COURSE  Microsoft 365 Fundamentals",
+        "folder": "COURSE: Microsoft 365 Fundamentals",
         "modules": 4
       },
       "coverage": null,
@@ -1624,7 +1624,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  Networking Fundamentals",
+        "folder": "Course: Networking Fundamentals",
         "modules": 0
       },
       "coverage": null,
@@ -1659,7 +1659,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Non-Relational Data",
+        "folder": "Course: Non-Relational Data",
         "modules": 5
       },
       "coverage": 0,
@@ -1694,7 +1694,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Pandas",
+        "folder": "Course: Pandas",
         "modules": 6
       },
       "coverage": 0,
@@ -1834,7 +1834,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Python Booster",
+        "folder": "Course: Python Booster",
         "modules": 8
       },
       "coverage": 0,
@@ -1904,7 +1904,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  React",
+        "folder": "Course: React",
         "modules": 0
       },
       "coverage": null,
@@ -1939,7 +1939,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Security and Cybersecurity Fundamentals",
+        "folder": "Course: Security and Cybersecurity Fundamentals",
         "modules": 7
       },
       "coverage": null,
@@ -1973,8 +1973,8 @@
       },
       "syllabus": true,
       "source": {
-        "exists": true,
-        "folder": "CURRICULUM  Software Developer Java",
+        "exists": false,
+        "folder": "Course: Software Developer Prework",
         "modules": 0
       },
       "coverage": null,
@@ -1986,11 +1986,11 @@
         "activities": 0,
         "demos": 0,
         "caseStudies": 0,
-        "instructorGuides": 1,
+        "instructorGuides": 0,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 1,
+      "totalAssets": 0,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
@@ -2009,7 +2009,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  Software Development Lifecycle",
+        "folder": "Course: Software Development Lifecycle",
         "modules": 0
       },
       "coverage": null,
@@ -2044,7 +2044,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  SQL Booster",
+        "folder": "Course: SQL Booster",
         "modules": 4
       },
       "coverage": null,
@@ -2079,7 +2079,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  SQL for C#",
+        "folder": "Course: SQL for C#",
         "modules": 1
       },
       "coverage": null,
@@ -2114,7 +2114,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  SQL for Data",
+        "folder": "Course: SQL for Data",
         "modules": 8
       },
       "coverage": 0,
@@ -2149,7 +2149,7 @@
       "syllabus": true,
       "source": {
         "exists": false,
-        "folder": "Course  Student Onboarding",
+        "folder": "Course: Student Onboarding",
         "modules": 0
       },
       "coverage": null,
@@ -2219,7 +2219,7 @@
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "COURSE  Troubleshooting Supporting in an Enterprise Environment",
+        "folder": "COURSE: Troubleshooting Supporting in an Enterprise Environment",
         "modules": 7
       },
       "coverage": null,
@@ -2254,7 +2254,7 @@
       "syllabus": true,
       "source": {
         "exists": true,
-        "folder": "Course  Web Development with JavaScript",
+        "folder": "Course: Web Development with JavaScript",
         "modules": 1
       },
       "coverage": 0,

--- a/courses.js
+++ b/courses.js
@@ -332,12 +332,12 @@ const courseData = [
     "name": "Infrastructure as Code Fundamentals",
     "hours": 22,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "In Progress"
     },
     "syllabus": null,
-    "outline": null,
-    "note": "OSS Course 12, Area 3 — net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h. Active dev pipeline — design work beginning soon. Audit confirms Not Started baseline (per #85).",
+    "outline": "infrastructure-as-code-fundamentals",
+    "note": "OSS Course 12, Area 3 — net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h. Phase 0 reconciliation complete (apprenti-org/design-documentation#298); outline JSON registered. Phase 1 scaffolding ahead.",
     "driveFolder": null,
     "statusConfirmed": true
   },

--- a/courses.json
+++ b/courses.json
@@ -330,12 +330,12 @@
       "name": "Infrastructure as Code Fundamentals",
       "hours": 22,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "In Progress"
       },
       "syllabus": null,
-      "outline": null,
-      "note": "OSS Course 12, Area 3 \u2014 net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h. Active dev pipeline \u2014 design work beginning soon. Audit confirms Not Started baseline (per #85).",
+      "outline": "infrastructure-as-code-fundamentals",
+      "note": "OSS Course 12, Area 3 \u2014 net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h. Phase 0 reconciliation complete (apprenti-org/design-documentation#298); outline JSON registered. Phase 1 scaffolding ahead.",
       "driveFolder": null,
       "statusConfirmed": true
     },

--- a/outlines/infrastructure-as-code-fundamentals.json
+++ b/outlines/infrastructure-as-code-fundamentals.json
@@ -1,0 +1,277 @@
+{
+  "course": "Infrastructure as Code Fundamentals",
+  "totalHours": 22,
+  "totalModules": 4,
+  "totalLessons": 15,
+  "modules": [
+    {
+      "name": "Infrastructure as Code fundamentals",
+      "hours": 3,
+      "lessons": [
+        {
+          "title": "What Is Infrastructure as Code?",
+          "hours": 1,
+          "topics": [
+            "The pre-IaC world: ClickOps, snowflake servers, configuration drift",
+            "IaC definition and the four properties learners will hear repeatedly: declarative, idempotent, version-controlled, reproducible",
+            "Provisioning vs. configuration management vs. orchestration — a vocabulary map",
+            "Where IaC lives in the broader DevOps lifecycle (relationship to CI/CD from Course 11)",
+            "The IaC market overview: Terraform, CloudFormation, Pulumi, Ansible, Bicep — what each is for",
+            "Individual reading + discussion: a short pre-IaC vs. post-IaC scenario; learners identify the failure modes IaC eliminates"
+          ],
+          "objects": [
+            "Object: Lesson: What Is Infrastructure as Code?",
+            "Assessment: Quiz: What Is Infrastructure as Code?"
+          ]
+        },
+        {
+          "title": "Declarative vs. Imperative, State, and Idempotency",
+          "hours": 1.5,
+          "topics": [
+            "Declarative (\"what I want\") vs. imperative (\"how to get there\") — concrete code comparisons",
+            "Idempotency: the same code applied N times produces the same end state",
+            "State: why an IaC tool needs to know what it created, and the failure modes when state is lost or corrupted",
+            "Drift: when the real world diverges from the declared state",
+            "Reading an execution plan before applying it (`terraform plan` preview, no install yet)",
+            "Pair discussion: given three sample shell scripts and three sample Terraform snippets, classify each as declarative or imperative and explain why"
+          ],
+          "objects": [
+            "Object: Lesson: Declarative vs. Imperative, State, and Idempotency",
+            "Assessment: Quiz: Declarative vs. Imperative, State, and Idempotency"
+          ]
+        },
+        {
+          "title": "Version Control for IaC — A Tour",
+          "hours": 0.5,
+          "topics": [
+            "Why infrastructure code lives in Git the same way application code does",
+            "The IaC `.gitignore` essentials: state files, lockfiles, credentials, `.terraform/` directories",
+            "What's different about reviewing IaC PRs vs. application-code PRs (state-affecting changes, blast radius, secrets) — brief tour, deeper PR-review treatment lands in M4 L13",
+            "Repo layout patterns at a glance: monorepo vs. per-environment vs. per-component",
+            "Quick demo + Q&A: instructor shows the recommended IaC `.gitignore` and walks through one \"what would you flag in this PR?\" example"
+          ],
+          "objects": [
+            "Object: Lesson: Version Control for IaC — A Tour",
+            "Assessment: Quiz: Version Control for IaC — A Tour"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Terraform fundamentals",
+      "hours": 11,
+      "lessons": [
+        {
+          "title": "Terraform Setup and First Resource",
+          "hours": 1.5,
+          "topics": [
+            "Installing the Terraform CLI; verifying with `terraform version` *(OJL 3d)*",
+            "Provider concept and the AWS (or LocalStack) provider block",
+            "Authoring a first `.tf` file: a single S3 bucket",
+            "The Terraform workflow: `init`, `plan`, `apply`, `destroy`",
+            "Reading the plan output and what each `+`, `-`, `~` symbol means",
+            "Code-along: provision and destroy a single S3 bucket end-to-end; commit the `.tf` file but not the state"
+          ],
+          "objects": [
+            "Object: Lesson: Terraform Setup and First Resource",
+            "Assessment: Quiz: Terraform Setup and First Resource"
+          ]
+        },
+        {
+          "title": "HCL Syntax — Variables, Outputs, and Locals",
+          "hours": 1.5,
+          "topics": [
+            "HCL block structure: `resource`, `variable`, `output`, `locals`, `data` *(OJL 3d)*",
+            "Input variables: declaration, default values, type constraints, `terraform.tfvars` files",
+            "Output values: surfacing IDs, ARNs, and URLs after apply",
+            "Locals: computed values used inside the configuration",
+            "Variable precedence: env vars vs. tfvars vs. CLI flags",
+            "Pair coding: parameterize the L4 bucket using a variable for `bucket_name` and an output for the bucket ARN"
+          ],
+          "objects": [
+            "Object: Lesson: HCL Syntax — Variables, Outputs, and Locals",
+            "Assessment: Quiz: HCL Syntax — Variables, Outputs, and Locals"
+          ]
+        },
+        {
+          "title": "Multiple Resources and Resource Dependencies",
+          "hours": 1.5,
+          "topics": [
+            "Implicit dependencies (resource references in expressions) *(OJL 3d)*",
+            "Explicit dependencies with `depends_on`",
+            "The dependency graph; reading `terraform graph` output at a high level",
+            "Worked example: an EC2 instance that depends on a security group that depends on a VPC reference",
+            "`count` and `for_each` for creating sets of similar resources",
+            "Individual: extend the L5 bucket configuration with a second bucket and an IAM policy that grants read on both, demonstrating implicit dependencies"
+          ],
+          "objects": [
+            "Object: Lesson: Multiple Resources and Resource Dependencies",
+            "Assessment: Quiz: Multiple Resources and Resource Dependencies"
+          ]
+        },
+        {
+          "title": "Terraform State",
+          "hours": 2,
+          "topics": [
+            "What state is and why Terraform needs it *(OJL 3d)*",
+            "Local state (`terraform.tfstate`) — the default and its limits",
+            "Remote state with an S3 backend + DynamoDB lock table",
+            "State locking: what happens when two engineers run `apply` simultaneously",
+            "Reading state with `terraform show` and `terraform state list`",
+            "State surgery basics: `terraform state mv` and `terraform state rm` — what they do and when they're needed",
+            "Sensitive data in state: never commit, mark outputs `sensitive = true`",
+            "Code-along: migrate a project from local state to a remote S3 backend with locking, then trigger a deliberate lock conflict in a paired session"
+          ],
+          "objects": [
+            "Object: Lesson: Terraform State",
+            "Assessment: Quiz: Terraform State"
+          ]
+        },
+        {
+          "title": "Modules — Reusable Terraform Components",
+          "hours": 2,
+          "topics": [
+            "The module concept: composing infrastructure from parameterized building blocks *(OJL 3d)*",
+            "Authoring a local module: required folder layout, `variables.tf`, `outputs.tf`, `main.tf`",
+            "Calling a module: `source`, `version`, passing inputs, reading outputs",
+            "The Terraform Registry: finding and using community modules; reading module docs",
+            "Versioning modules; pinning vs. floating versions",
+            "When to make a module vs. when to inline (the over-modularization anti-pattern)",
+            "Individual: refactor the L6 multi-resource configuration into a `web-bucket` local module with two inputs and two outputs, then consume it from a root configuration"
+          ],
+          "objects": [
+            "Object: Lesson: Modules — Reusable Terraform Components",
+            "Assessment: Quiz: Modules — Reusable Terraform Components"
+          ]
+        },
+        {
+          "title": "The Terraform Workflow in a Team Setting",
+          "hours": 1.5,
+          "topics": [
+            "Branching strategy for IaC PRs *(OJL 3d)*",
+            "Running `plan` in CI and posting the plan to a PR comment",
+            "Apply gates: who pushes the button, when, and against which environment",
+            "Workspaces (and why most teams use directory-per-environment instead)",
+            "Drift detection: scheduled `plan` runs that flag uncommitted changes in the real world",
+            "Pair coding: open a PR that changes the bucket configuration; another learner reviews the `plan` output and either approves or requests changes"
+          ],
+          "objects": [
+            "Object: Lesson: The Terraform Workflow in a Team Setting",
+            "Assessment: Quiz: The Terraform Workflow in a Team Setting"
+          ]
+        },
+        {
+          "title": "Failure Modes and Debugging IaC",
+          "hours": 1,
+          "topics": [
+            "The scenarios that distinguish supporting IaC in production from running `terraform apply` on the happy path *(OJL 3d)*",
+            "Broken or missing Terraform state: lost state file, accidental deletion, state drift after out-of-band changes",
+            "Incorrect dependencies that trigger destroy-and-recreate: when a small attribute change destroys a resource the team expected to be modified in place",
+            "Reading a risky `terraform plan`: recognizing destructive changes, refusing to apply, escalating",
+            "Diagnosing through `terraform plan`, `terraform refresh`, `terraform state list`, `terraform state show`",
+            "Recovery moves: `terraform import` to rebuild state for an existing resource, releasing a stuck state lock, walking back a misapply",
+            "Guided lab: instructor presents three broken-state scenarios (missing state file, attribute change that would destroy a database, stuck lock); learners diagnose each, explain in writing what would happen if they applied as-is, and execute the recovery"
+          ],
+          "objects": [
+            "Object: Lesson: Failure Modes and Debugging IaC",
+            "Assessment: Quiz: Failure Modes and Debugging IaC"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Configuration management with Ansible — concept + demo",
+      "hours": 2,
+      "lessons": [
+        {
+          "title": "Provisioning vs. Configuration Management",
+          "hours": 1,
+          "topics": [
+            "Provisioning (Terraform) vs. configuration management (Ansible, Chef, Puppet) — the distinction and where the boundary blurs",
+            "The \"build immutable, configure mutable\" debate at a survey level",
+            "When Terraform alone is enough; when Ansible adds value (post-provision software install, in-place patching)",
+            "Why this distinction matters in modern IaC and on the OSS-Network apprentice's most likely encounters with Ansible on the job",
+            "Group discussion: given three real-world infrastructure tasks, identify which is provisioning, which is configuration, and which is both"
+          ],
+          "objects": [
+            "Object: Lesson: Provisioning vs. Configuration Management",
+            "Assessment: Quiz: Provisioning vs. Configuration Management"
+          ]
+        },
+        {
+          "title": "Ansible at a Glance — Guided Demo",
+          "hours": 1,
+          "topics": [
+            "Instructor-led guided demo; students observe and ask questions, no individual hands-on",
+            "Ansible's agentless model: SSH + Python on the target",
+            "YAML and the playbook structure: plays, tasks, modules, handlers",
+            "Inventory files: static vs. dynamic",
+            "Walkthrough of a 3-task playbook against an EC2 target: install nginx, write a config file, start the service — narrating idempotency at each step",
+            "When to glue Terraform + Ansible together vs. picking one",
+            "Observation + Q&A during the demo; learners record one question and one observation in their notes for later cohort discussion"
+          ],
+          "objects": [
+            "Object: Lesson: Ansible at a Glance — Guided Demo",
+            "Assessment: Quiz: Ansible at a Glance — Guided Demo"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Best practices for production-ready IaC",
+      "hours": 3,
+      "lessons": [
+        {
+          "title": "Secrets, Sensitive Data, and Cloud-Native IaC at a Glance",
+          "hours": 1,
+          "topics": [
+            "Why hardcoded secrets in `.tf` files (and Git history) are a recurring breach vector *(OJL 3d)*",
+            "Environment variables and `TF_VAR_` prefix",
+            "Vendor-native secret stores: AWS Secrets Manager, Azure Key Vault, HashiCorp Vault overview",
+            "Sensitive variables and outputs (`sensitive = true`)",
+            "State file as a secrets-leak vector — encryption at rest, access control on the backend bucket",
+            "Brief landscape comparison (≈10 min): how CloudFormation, ARM/Bicep, and GCP DM handle the same secrets problem; when a team would deliberately choose a vendor-native tool over Terraform",
+            "Individual: refactor a sample `.tf` file that contains a hardcoded password to read from a `TF_VAR_db_password` environment variable, and mark the corresponding output `sensitive`"
+          ],
+          "objects": [
+            "Object: Lesson: Secrets, Sensitive Data, and Cloud-Native IaC at a Glance",
+            "Assessment: Quiz: Secrets, Sensitive Data, and Cloud-Native IaC at a Glance"
+          ]
+        },
+        {
+          "title": "Cost Awareness and Cleanup Discipline",
+          "hours": 1,
+          "topics": [
+            "Cloud resources cost money even when \"idle\" — EC2 sitting at 0% CPU, RDS instances overnight, NAT gateways, NLBs, EIPs, unattached EBS volumes",
+            "The IaC-specific risk: easy to provision means easy to forget — and forgotten infrastructure is billed forever",
+            "`terraform destroy` as a first-class workflow operation, not an afterthought",
+            "Avoiding orphaned resources from failed applies (resources created before the apply errored out)",
+            "Tagging strategies for cost attribution: `Owner`, `Environment`, `CostCenter`, `AutoStop` patterns",
+            "Where AWS Cost Explorer and Cost Allocation Tags fit in the IaC workflow",
+            "Lab: provision a small Terraform stack (an EC2 instance plus an EBS volume plus an EIP), use AWS Pricing Calculator (or a provided rate sheet) to identify the cost meters, run `terraform destroy`, then verify in the AWS console that all three resources are gone — including the EIP, which often outlives an apply error"
+          ],
+          "objects": [
+            "Object: Lesson: Cost Awareness and Cleanup Discipline",
+            "Assessment: Quiz: Cost Awareness and Cleanup Discipline"
+          ]
+        },
+        {
+          "title": "IaC Code Review, Testing, and Documentation",
+          "hours": 1,
+          "topics": [
+            "The IaC PR review checklist: what reviewers look for that's different from app-code review *(OJL 3d)*",
+            "`terraform fmt` and `terraform validate` as pre-commit gates",
+            "`tflint` and policy-as-code (OPA / Sentinel) at a survey level",
+            "Documenting modules: the README convention (`terraform-docs` overview)",
+            "Plan-output discipline: when a \"small\" plan is actually a big change (callback to L10 failure modes)",
+            "Pair: review another learner's PR from L9 using a provided checklist; submit one approve/request-changes review with at least two specific comments"
+          ],
+          "objects": [
+            "Object: Lesson: IaC Code Review, Testing, and Documentation",
+            "Assessment: Quiz: IaC Code Review, Testing, and Documentation"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -95,6 +95,11 @@
     "id": "http-services"
   },
   {
+    "file": "infrastructure-as-code-fundamentals.json",
+    "course": "Infrastructure as Code Fundamentals",
+    "id": "infrastructure-as-code-fundamentals"
+  },
+  {
     "file": "instructor-onboarding.json",
     "course": "Instructor Onboarding",
     "id": "instructor-onboarding"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -4388,6 +4388,283 @@ const courseOutlines = {
       }
     ]
   },
+  "Infrastructure as Code Fundamentals": {
+    "course": "Infrastructure as Code Fundamentals",
+    "totalHours": 22,
+    "totalModules": 4,
+    "totalLessons": 15,
+    "modules": [
+      {
+        "name": "Infrastructure as Code fundamentals",
+        "hours": 3,
+        "lessons": [
+          {
+            "title": "What Is Infrastructure as Code?",
+            "hours": 1,
+            "topics": [
+              "The pre-IaC world: ClickOps, snowflake servers, configuration drift",
+              "IaC definition and the four properties learners will hear repeatedly: declarative, idempotent, version-controlled, reproducible",
+              "Provisioning vs. configuration management vs. orchestration — a vocabulary map",
+              "Where IaC lives in the broader DevOps lifecycle (relationship to CI/CD from Course 11)",
+              "The IaC market overview: Terraform, CloudFormation, Pulumi, Ansible, Bicep — what each is for",
+              "Individual reading + discussion: a short pre-IaC vs. post-IaC scenario; learners identify the failure modes IaC eliminates"
+            ],
+            "objects": [
+              "Object: Lesson: What Is Infrastructure as Code?",
+              "Assessment: Quiz: What Is Infrastructure as Code?"
+            ]
+          },
+          {
+            "title": "Declarative vs. Imperative, State, and Idempotency",
+            "hours": 1.5,
+            "topics": [
+              "Declarative (\"what I want\") vs. imperative (\"how to get there\") — concrete code comparisons",
+              "Idempotency: the same code applied N times produces the same end state",
+              "State: why an IaC tool needs to know what it created, and the failure modes when state is lost or corrupted",
+              "Drift: when the real world diverges from the declared state",
+              "Reading an execution plan before applying it (`terraform plan` preview, no install yet)",
+              "Pair discussion: given three sample shell scripts and three sample Terraform snippets, classify each as declarative or imperative and explain why"
+            ],
+            "objects": [
+              "Object: Lesson: Declarative vs. Imperative, State, and Idempotency",
+              "Assessment: Quiz: Declarative vs. Imperative, State, and Idempotency"
+            ]
+          },
+          {
+            "title": "Version Control for IaC — A Tour",
+            "hours": 0.5,
+            "topics": [
+              "Why infrastructure code lives in Git the same way application code does",
+              "The IaC `.gitignore` essentials: state files, lockfiles, credentials, `.terraform/` directories",
+              "What's different about reviewing IaC PRs vs. application-code PRs (state-affecting changes, blast radius, secrets) — brief tour, deeper PR-review treatment lands in M4 L13",
+              "Repo layout patterns at a glance: monorepo vs. per-environment vs. per-component",
+              "Quick demo + Q&A: instructor shows the recommended IaC `.gitignore` and walks through one \"what would you flag in this PR?\" example"
+            ],
+            "objects": [
+              "Object: Lesson: Version Control for IaC — A Tour",
+              "Assessment: Quiz: Version Control for IaC — A Tour"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Terraform fundamentals",
+        "hours": 11,
+        "lessons": [
+          {
+            "title": "Terraform Setup and First Resource",
+            "hours": 1.5,
+            "topics": [
+              "Installing the Terraform CLI; verifying with `terraform version` *(OJL 3d)*",
+              "Provider concept and the AWS (or LocalStack) provider block",
+              "Authoring a first `.tf` file: a single S3 bucket",
+              "The Terraform workflow: `init`, `plan`, `apply`, `destroy`",
+              "Reading the plan output and what each `+`, `-`, `~` symbol means",
+              "Code-along: provision and destroy a single S3 bucket end-to-end; commit the `.tf` file but not the state"
+            ],
+            "objects": [
+              "Object: Lesson: Terraform Setup and First Resource",
+              "Assessment: Quiz: Terraform Setup and First Resource"
+            ]
+          },
+          {
+            "title": "HCL Syntax — Variables, Outputs, and Locals",
+            "hours": 1.5,
+            "topics": [
+              "HCL block structure: `resource`, `variable`, `output`, `locals`, `data` *(OJL 3d)*",
+              "Input variables: declaration, default values, type constraints, `terraform.tfvars` files",
+              "Output values: surfacing IDs, ARNs, and URLs after apply",
+              "Locals: computed values used inside the configuration",
+              "Variable precedence: env vars vs. tfvars vs. CLI flags",
+              "Pair coding: parameterize the L4 bucket using a variable for `bucket_name` and an output for the bucket ARN"
+            ],
+            "objects": [
+              "Object: Lesson: HCL Syntax — Variables, Outputs, and Locals",
+              "Assessment: Quiz: HCL Syntax — Variables, Outputs, and Locals"
+            ]
+          },
+          {
+            "title": "Multiple Resources and Resource Dependencies",
+            "hours": 1.5,
+            "topics": [
+              "Implicit dependencies (resource references in expressions) *(OJL 3d)*",
+              "Explicit dependencies with `depends_on`",
+              "The dependency graph; reading `terraform graph` output at a high level",
+              "Worked example: an EC2 instance that depends on a security group that depends on a VPC reference",
+              "`count` and `for_each` for creating sets of similar resources",
+              "Individual: extend the L5 bucket configuration with a second bucket and an IAM policy that grants read on both, demonstrating implicit dependencies"
+            ],
+            "objects": [
+              "Object: Lesson: Multiple Resources and Resource Dependencies",
+              "Assessment: Quiz: Multiple Resources and Resource Dependencies"
+            ]
+          },
+          {
+            "title": "Terraform State",
+            "hours": 2,
+            "topics": [
+              "What state is and why Terraform needs it *(OJL 3d)*",
+              "Local state (`terraform.tfstate`) — the default and its limits",
+              "Remote state with an S3 backend + DynamoDB lock table",
+              "State locking: what happens when two engineers run `apply` simultaneously",
+              "Reading state with `terraform show` and `terraform state list`",
+              "State surgery basics: `terraform state mv` and `terraform state rm` — what they do and when they're needed",
+              "Sensitive data in state: never commit, mark outputs `sensitive = true`",
+              "Code-along: migrate a project from local state to a remote S3 backend with locking, then trigger a deliberate lock conflict in a paired session"
+            ],
+            "objects": [
+              "Object: Lesson: Terraform State",
+              "Assessment: Quiz: Terraform State"
+            ]
+          },
+          {
+            "title": "Modules — Reusable Terraform Components",
+            "hours": 2,
+            "topics": [
+              "The module concept: composing infrastructure from parameterized building blocks *(OJL 3d)*",
+              "Authoring a local module: required folder layout, `variables.tf`, `outputs.tf`, `main.tf`",
+              "Calling a module: `source`, `version`, passing inputs, reading outputs",
+              "The Terraform Registry: finding and using community modules; reading module docs",
+              "Versioning modules; pinning vs. floating versions",
+              "When to make a module vs. when to inline (the over-modularization anti-pattern)",
+              "Individual: refactor the L6 multi-resource configuration into a `web-bucket` local module with two inputs and two outputs, then consume it from a root configuration"
+            ],
+            "objects": [
+              "Object: Lesson: Modules — Reusable Terraform Components",
+              "Assessment: Quiz: Modules — Reusable Terraform Components"
+            ]
+          },
+          {
+            "title": "The Terraform Workflow in a Team Setting",
+            "hours": 1.5,
+            "topics": [
+              "Branching strategy for IaC PRs *(OJL 3d)*",
+              "Running `plan` in CI and posting the plan to a PR comment",
+              "Apply gates: who pushes the button, when, and against which environment",
+              "Workspaces (and why most teams use directory-per-environment instead)",
+              "Drift detection: scheduled `plan` runs that flag uncommitted changes in the real world",
+              "Pair coding: open a PR that changes the bucket configuration; another learner reviews the `plan` output and either approves or requests changes"
+            ],
+            "objects": [
+              "Object: Lesson: The Terraform Workflow in a Team Setting",
+              "Assessment: Quiz: The Terraform Workflow in a Team Setting"
+            ]
+          },
+          {
+            "title": "Failure Modes and Debugging IaC",
+            "hours": 1,
+            "topics": [
+              "The scenarios that distinguish supporting IaC in production from running `terraform apply` on the happy path *(OJL 3d)*",
+              "Broken or missing Terraform state: lost state file, accidental deletion, state drift after out-of-band changes",
+              "Incorrect dependencies that trigger destroy-and-recreate: when a small attribute change destroys a resource the team expected to be modified in place",
+              "Reading a risky `terraform plan`: recognizing destructive changes, refusing to apply, escalating",
+              "Diagnosing through `terraform plan`, `terraform refresh`, `terraform state list`, `terraform state show`",
+              "Recovery moves: `terraform import` to rebuild state for an existing resource, releasing a stuck state lock, walking back a misapply",
+              "Guided lab: instructor presents three broken-state scenarios (missing state file, attribute change that would destroy a database, stuck lock); learners diagnose each, explain in writing what would happen if they applied as-is, and execute the recovery"
+            ],
+            "objects": [
+              "Object: Lesson: Failure Modes and Debugging IaC",
+              "Assessment: Quiz: Failure Modes and Debugging IaC"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Configuration management with Ansible — concept + demo",
+        "hours": 2,
+        "lessons": [
+          {
+            "title": "Provisioning vs. Configuration Management",
+            "hours": 1,
+            "topics": [
+              "Provisioning (Terraform) vs. configuration management (Ansible, Chef, Puppet) — the distinction and where the boundary blurs",
+              "The \"build immutable, configure mutable\" debate at a survey level",
+              "When Terraform alone is enough; when Ansible adds value (post-provision software install, in-place patching)",
+              "Why this distinction matters in modern IaC and on the OSS-Network apprentice's most likely encounters with Ansible on the job",
+              "Group discussion: given three real-world infrastructure tasks, identify which is provisioning, which is configuration, and which is both"
+            ],
+            "objects": [
+              "Object: Lesson: Provisioning vs. Configuration Management",
+              "Assessment: Quiz: Provisioning vs. Configuration Management"
+            ]
+          },
+          {
+            "title": "Ansible at a Glance — Guided Demo",
+            "hours": 1,
+            "topics": [
+              "Instructor-led guided demo; students observe and ask questions, no individual hands-on",
+              "Ansible's agentless model: SSH + Python on the target",
+              "YAML and the playbook structure: plays, tasks, modules, handlers",
+              "Inventory files: static vs. dynamic",
+              "Walkthrough of a 3-task playbook against an EC2 target: install nginx, write a config file, start the service — narrating idempotency at each step",
+              "When to glue Terraform + Ansible together vs. picking one",
+              "Observation + Q&A during the demo; learners record one question and one observation in their notes for later cohort discussion"
+            ],
+            "objects": [
+              "Object: Lesson: Ansible at a Glance — Guided Demo",
+              "Assessment: Quiz: Ansible at a Glance — Guided Demo"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Best practices for production-ready IaC",
+        "hours": 3,
+        "lessons": [
+          {
+            "title": "Secrets, Sensitive Data, and Cloud-Native IaC at a Glance",
+            "hours": 1,
+            "topics": [
+              "Why hardcoded secrets in `.tf` files (and Git history) are a recurring breach vector *(OJL 3d)*",
+              "Environment variables and `TF_VAR_` prefix",
+              "Vendor-native secret stores: AWS Secrets Manager, Azure Key Vault, HashiCorp Vault overview",
+              "Sensitive variables and outputs (`sensitive = true`)",
+              "State file as a secrets-leak vector — encryption at rest, access control on the backend bucket",
+              "Brief landscape comparison (≈10 min): how CloudFormation, ARM/Bicep, and GCP DM handle the same secrets problem; when a team would deliberately choose a vendor-native tool over Terraform",
+              "Individual: refactor a sample `.tf` file that contains a hardcoded password to read from a `TF_VAR_db_password` environment variable, and mark the corresponding output `sensitive`"
+            ],
+            "objects": [
+              "Object: Lesson: Secrets, Sensitive Data, and Cloud-Native IaC at a Glance",
+              "Assessment: Quiz: Secrets, Sensitive Data, and Cloud-Native IaC at a Glance"
+            ]
+          },
+          {
+            "title": "Cost Awareness and Cleanup Discipline",
+            "hours": 1,
+            "topics": [
+              "Cloud resources cost money even when \"idle\" — EC2 sitting at 0% CPU, RDS instances overnight, NAT gateways, NLBs, EIPs, unattached EBS volumes",
+              "The IaC-specific risk: easy to provision means easy to forget — and forgotten infrastructure is billed forever",
+              "`terraform destroy` as a first-class workflow operation, not an afterthought",
+              "Avoiding orphaned resources from failed applies (resources created before the apply errored out)",
+              "Tagging strategies for cost attribution: `Owner`, `Environment`, `CostCenter`, `AutoStop` patterns",
+              "Where AWS Cost Explorer and Cost Allocation Tags fit in the IaC workflow",
+              "Lab: provision a small Terraform stack (an EC2 instance plus an EBS volume plus an EIP), use AWS Pricing Calculator (or a provided rate sheet) to identify the cost meters, run `terraform destroy`, then verify in the AWS console that all three resources are gone — including the EIP, which often outlives an apply error"
+            ],
+            "objects": [
+              "Object: Lesson: Cost Awareness and Cleanup Discipline",
+              "Assessment: Quiz: Cost Awareness and Cleanup Discipline"
+            ]
+          },
+          {
+            "title": "IaC Code Review, Testing, and Documentation",
+            "hours": 1,
+            "topics": [
+              "The IaC PR review checklist: what reviewers look for that's different from app-code review *(OJL 3d)*",
+              "`terraform fmt` and `terraform validate` as pre-commit gates",
+              "`tflint` and policy-as-code (OPA / Sentinel) at a survey level",
+              "Documenting modules: the README convention (`terraform-docs` overview)",
+              "Plan-output discipline: when a \"small\" plan is actually a big change (callback to L10 failure modes)",
+              "Pair: review another learner's PR from L9 using a provided checklist; submit one approve/request-changes review with at least two specific comments"
+            ],
+            "objects": [
+              "Object: Lesson: IaC Code Review, Testing, and Documentation",
+              "Assessment: Quiz: IaC Code Review, Testing, and Documentation"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "Instructor Onboarding": {
     "course": "Instructor Onboarding",
     "totalHours": 48,


### PR DESCRIPTION
## Summary

Phase 0 reconciliation outputs for Infrastructure as Code Fundamentals (apprenti-org/design-documentation#298 sub-issue of #281). The extractor produced an outline JSON and updated courses.json, but the canonical id in courses.json is `infrastructure-as-code-fundamentals` (with `-fundamentals` suffix) while the extractor named the outline file with the workspace folder slug `infrastructure-as-code`. This PR aligns the file + references to the canonical id (option A from user decision).

## Changes

- RENAMED: `outlines/infrastructure-as-code.json` → `outlines/infrastructure-as-code-fundamentals.json`
- UPDATED: `outlines/manifest.json` — adds new entry "Infrastructure as Code Fundamentals" → "infrastructure-as-code-fundamentals.json"
- UPDATED: `courses.json` — IaC entry `outline` field set from `null` → `"infrastructure-as-code-fundamentals"`; `status.design` set to "Complete"; `status.development` set to "In Progress" (Phase 0 result)
- REGENERATED: `courses.js`, `outlines/outlines.js`, `course-overview.js`, `course-overview.json`

## Test plan

- [ ] Live dashboard renders the IaC entry with the outline accessible
- [ ] No broken links in the outline-JSON-to-course mapping
- [ ] courses.json + courses.js are in sync after regen

## Companion concern (separate issue ahead)

Phase 0's standard-alignment check did not reflect OJL 3.d (the primary IaC competency). A separate issue is being filed against the extractor for that — it's not blocking Phase 1 but should be investigated.

Closes apprenti-org/design-documentation#298 partially (Phase 0 deliverables; Phase 1 still ahead).
