### PR TITLE
Add ctse-capstone; update CTSE curriculum Group 5

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -174,6 +174,20 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "ctse-capstone",
+    "name": "Client Technical Support Engineer Capstone",
+    "hours": 20,
+    "status": {
+      "design": "Not Started",
+      "development": "Not Started"
+    },
+    "syllabus": null,
+    "outline": null,
+    "note": "Net-new integrative capstone (20h / 4 days). Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Covers Areas 1, 2, 3 (integrative QA), and 4. New Course Onboarding chain initiated.",
+    "driveFolder": null,
+    "statusConfirmed": false
+  },
+  {
     "id": "cloud-fundamentals",
     "name": "Cloud Fundamentals",
     "hours": 16,
@@ -970,6 +984,16 @@ const curriculaData = [
           {
             "name": "Helpdesk Software Fundamentals",
             "id": "helpdesk-software-fundamentals"
+          }
+        ]
+      },
+      {
+        "name": "Applied Support Integration",
+        "hours": 20,
+        "courses": [
+          {
+            "name": "Client Technical Support Engineer Capstone",
+            "id": "ctse-capstone"
           }
         ]
       }

--- a/courses.json
+++ b/courses.json
@@ -172,6 +172,20 @@
       "statusConfirmed": true
     },
     {
+      "id": "ctse-capstone",
+      "name": "Client Technical Support Engineer Capstone",
+      "hours": 20,
+      "status": {
+        "design": "Not Started",
+        "development": "Not Started"
+      },
+      "syllabus": null,
+      "outline": null,
+      "note": "Net-new integrative capstone (20h / 4 days). Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Covers Areas 1, 2, 3 (integrative QA), and 4. New Course Onboarding chain initiated.",
+      "driveFolder": null,
+      "statusConfirmed": false
+    },
+    {
       "id": "cloud-fundamentals",
       "name": "Cloud Fundamentals",
       "hours": 16,
@@ -953,6 +967,13 @@
           "courses": [
             "ai-foundations",
             "helpdesk-software-fundamentals"
+          ]
+        },
+        {
+          "name": "Applied Support Integration",
+          "hours": 20,
+          "courses": [
+            "ctse-capstone"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

- Adds `ctse-capstone` (Client Technical Support Engineer Capstone, 20h) to the `courses` array
- Adds Group 5 — Applied Support Integration (20h) to the `Client Technical Support Engineer` curriculum entry
- Regenerates `courses.js` (build: 66 courses, 7 curricula, 0 errors)

## Authorization

Design-folder changes and Curriculum Design Verification all-pass (15/15 checks):
- `apprenti-org/design-documentation#309` — curriculum outline/curriculum/json changes
- `apprenti-org/design-documentation#310` — verification run 2 all-pass (2026-05-04)

## Course entry

| Field | Value |
|---|---|
| id | `ctse-capstone` |
| name | Client Technical Support Engineer Capstone |
| hours | 20 |
| design status | Not Started |
| development status | Not Started |
| statusConfirmed | false |

## New Course Onboarding

Meta-issue opened separately in `apprenti-org/design-documentation` to kick off the 11-step build chain for `ctse-capstone`.