### PR TITLE
[ctse-capstone] Content Scaffolding Phase 0+1 — tracking updates

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -178,13 +178,14 @@ const courseData = [
     "name": "Client Technical Support Engineer Capstone",
     "hours": 20,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "In Progress"
     },
-    "syllabus": null,
-    "outline": null,
-    "note": "Net-new integrative capstone (20h / 4 days). Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Covers Areas 1, 2, 3 (integrative QA), and 4. New Course Onboarding chain initiated.",
+    "syllabus": "Syllabus: Client Technical Support Engineer Capstone",
+    "outline": "Course Outline: Client Technical Support Engineer Capstone",
+    "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Content scaffolding complete (Phase 0 + Phase 1). All lesson artifacts stubbed. Ready for content production.",
     "driveFolder": null,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
     "statusConfirmed": false
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -176,13 +176,14 @@
       "name": "Client Technical Support Engineer Capstone",
       "hours": 20,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "In Progress"
       },
-      "syllabus": null,
-      "outline": null,
-      "note": "Net-new integrative capstone (20h / 4 days). Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Covers Areas 1, 2, 3 (integrative QA), and 4. New Course Onboarding chain initiated.",
+      "syllabus": "Syllabus: Client Technical Support Engineer Capstone",
+      "outline": "Course Outline: Client Technical Support Engineer Capstone",
+      "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Content scaffolding complete (Phase 0 + Phase 1). All lesson artifacts stubbed. Ready for content production.",
       "driveFolder": null,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": false
     },
     {

--- a/outlines/ctse-capstone.json
+++ b/outlines/ctse-capstone.json
@@ -1,0 +1,98 @@
+{
+  "course": "Client Technical Support Engineer Capstone",
+  "totalHours": 20,
+  "totalModules": 5,
+  "totalLessons": 5,
+  "modules": [
+    {
+      "name": "Discovery — IT Environment Assessment",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "IT Environment Assessment",
+          "hours": 4,
+          "topics": [
+            "Scenario briefing: company context, IT Support Lead role, program overview, five-phase structure, deliverable rubrics",
+            "Discovery methodology: structured intake questionnaire, stakeholder interview simulation, environment walk-through exercise",
+            "Technical Support Methodology: applying a systematic intake approach to an unknown environment",
+            "Advanced Troubleshooting Techniques: identifying current pain points from symptoms; distinguishing incidents from underlying problems",
+            "Producing the environment document: required sections, level of detail, what an employer reviewer will evaluate",
+            "Checkpoint gate: IT environment document reviewed by instructor before Phase 2 begins"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Design — Service Architecture",
+      "hours": 5,
+      "lessons": [
+        {
+          "title": "Service Architecture Design",
+          "hours": 5,
+          "topics": [
+            "Ticketing Systems & Case Management: ticket categories, severity classifications, queue routing design",
+            "Customer Service Excellence Fundamentals: defining service standards from the customer perspective; drafting service descriptions in plain language",
+            "Quality Assurance & Performance Excellence: establishing measurable SLA targets (resolution time by priority, first-contact resolution rate, escalation SLA)",
+            "Advanced Communication & Stakeholder Management: escalation framework design; defining communication protocols for P1/P2 incidents; stakeholder notification criteria",
+            "Service catalog structure: scope definition (in-scope vs out-of-scope), tier mapping, internal vs vendor escalation paths",
+            "SLA document structure: priority levels, response/resolution targets, breach conditions, reporting cadence",
+            "Checkpoint gate: service catalog and SLA document reviewed by instructor before Phase 3 begins"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Build — Helpdesk Platform Configuration",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "Helpdesk Platform Configuration",
+          "hours": 4,
+          "topics": [
+            "Ticketing Systems & Case Management: creating ticket categories and queues aligned to the service catalog; mapping SLA rules to priority levels; configuring ticket fields for required metadata",
+            "Software Testing & Quality Assurance: functional testing of the configured system — submission test, routing test, SLA timer test, automation trigger test; documenting test results",
+            "Automations: configuring one automation rule (e.g., auto-assign by category, auto-acknowledge on submission); verifying trigger conditions",
+            "Knowledge base template: creating one KB article template for the highest-priority recurring issue from Phase 1 (format: symptom, cause, resolution steps, escalation trigger)",
+            "Configuration documentation: screenshot evidence + brief written explanation of each configuration decision tracing back to the service catalog and SLA document"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Operate — Simulated Ticket Processing",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "Simulated Ticket Processing",
+          "hours": 4,
+          "topics": [
+            "Technical Support Methodology: applying structured intake → diagnosis → resolution → documentation workflow for each ticket",
+            "Advanced Troubleshooting Techniques: diagnosing symptom descriptions; identifying root cause vs surface issue; applying knowledge base articles",
+            "Customer Service Excellence Fundamentals: tone and clarity in resolution notes; communication protocol for escalation scenarios (following the Phase 2 escalation framework)",
+            "System Reports & Analytics: manually tracking SLA adherence per ticket; flagging breaches; counting first-contact resolutions vs escalations",
+            "Ticket log completion: required fields, resolution note quality standards (what constitutes a substantive resolution note vs a placeholder)",
+            "Escalation scenarios: two tickets are designated as escalation scenarios — students must document the escalation trigger, the communication sent, and the resolution path"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Report — Performance Analysis and Debrief",
+      "hours": 3,
+      "lessons": [
+        {
+          "title": "Performance Report and Debrief",
+          "hours": 3,
+          "topics": [
+            "System Reports & Analytics: calculating key metrics from the Phase 4 ticket log (volume by priority, average time-to-resolve, SLA compliance rate, first-contact resolution rate, escalation rate)",
+            "Quality Assurance & Performance Excellence: interpreting metrics against SLA targets; identifying performance gaps; formulating improvement recommendations",
+            "Time Management & Productivity: analyzing throughput relative to staffing and ticket volume; identifying bottlenecks in the simulated operation",
+            "Advanced Communication & Stakeholder Management: structuring the report for a management audience; executive summary format; data visualization conventions",
+            "Professional Development & Career Growth: written reflection on the capstone experience — one design decision the student would revisit, one skill gap identified, one practice to carry into the workplace",
+            "Group debrief (final 30 min): share-outs on hardest design decision, most surprising Phase 4 result, and one improvement to the SLA document in hindsight"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -50,6 +50,11 @@
     "id": "c-plus-plus-coding-booster-intensive"
   },
   {
+    "file": "ctse-capstone.json",
+    "course": "Client Technical Support Engineer Capstone",
+    "id": "ctse-capstone"
+  },
+  {
     "file": "comptia-a-plus.json",
     "course": "CompTIA A+",
     "id": "comptia-a-plus"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -1604,6 +1604,104 @@ const courseOutlines = {
       ]
     }
   },
+  "Client Technical Support Engineer Capstone": {
+    "course": "Client Technical Support Engineer Capstone",
+    "totalHours": 20,
+    "totalModules": 5,
+    "totalLessons": 5,
+    "modules": [
+      {
+        "name": "Discovery — IT Environment Assessment",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "IT Environment Assessment",
+            "hours": 4,
+            "topics": [
+              "Scenario briefing: company context, IT Support Lead role, program overview, five-phase structure, deliverable rubrics",
+              "Discovery methodology: structured intake questionnaire, stakeholder interview simulation, environment walk-through exercise",
+              "Technical Support Methodology: applying a systematic intake approach to an unknown environment",
+              "Advanced Troubleshooting Techniques: identifying current pain points from symptoms; distinguishing incidents from underlying problems",
+              "Producing the environment document: required sections, level of detail, what an employer reviewer will evaluate",
+              "Checkpoint gate: IT environment document reviewed by instructor before Phase 2 begins"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Design — Service Architecture",
+        "hours": 5,
+        "lessons": [
+          {
+            "title": "Service Architecture Design",
+            "hours": 5,
+            "topics": [
+              "Ticketing Systems & Case Management: ticket categories, severity classifications, queue routing design",
+              "Customer Service Excellence Fundamentals: defining service standards from the customer perspective; drafting service descriptions in plain language",
+              "Quality Assurance & Performance Excellence: establishing measurable SLA targets (resolution time by priority, first-contact resolution rate, escalation SLA)",
+              "Advanced Communication & Stakeholder Management: escalation framework design; defining communication protocols for P1/P2 incidents; stakeholder notification criteria",
+              "Service catalog structure: scope definition (in-scope vs out-of-scope), tier mapping, internal vs vendor escalation paths",
+              "SLA document structure: priority levels, response/resolution targets, breach conditions, reporting cadence",
+              "Checkpoint gate: service catalog and SLA document reviewed by instructor before Phase 3 begins"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Build — Helpdesk Platform Configuration",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "Helpdesk Platform Configuration",
+            "hours": 4,
+            "topics": [
+              "Ticketing Systems & Case Management: creating ticket categories and queues aligned to the service catalog; mapping SLA rules to priority levels; configuring ticket fields for required metadata",
+              "Software Testing & Quality Assurance: functional testing of the configured system — submission test, routing test, SLA timer test, automation trigger test; documenting test results",
+              "Automations: configuring one automation rule (e.g., auto-assign by category, auto-acknowledge on submission); verifying trigger conditions",
+              "Knowledge base template: creating one KB article template for the highest-priority recurring issue from Phase 1 (format: symptom, cause, resolution steps, escalation trigger)",
+              "Configuration documentation: screenshot evidence + brief written explanation of each configuration decision tracing back to the service catalog and SLA document"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Operate — Simulated Ticket Processing",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "Simulated Ticket Processing",
+            "hours": 4,
+            "topics": [
+              "Technical Support Methodology: applying structured intake → diagnosis → resolution → documentation workflow for each ticket",
+              "Advanced Troubleshooting Techniques: diagnosing symptom descriptions; identifying root cause vs surface issue; applying knowledge base articles",
+              "Customer Service Excellence Fundamentals: tone and clarity in resolution notes; communication protocol for escalation scenarios (following the Phase 2 escalation framework)",
+              "System Reports & Analytics: manually tracking SLA adherence per ticket; flagging breaches; counting first-contact resolutions vs escalations",
+              "Ticket log completion: required fields, resolution note quality standards (what constitutes a substantive resolution note vs a placeholder)",
+              "Escalation scenarios: two tickets are designated as escalation scenarios — students must document the escalation trigger, the communication sent, and the resolution path"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Report — Performance Analysis and Debrief",
+        "hours": 3,
+        "lessons": [
+          {
+            "title": "Performance Report and Debrief",
+            "hours": 3,
+            "topics": [
+              "System Reports & Analytics: calculating key metrics from the Phase 4 ticket log (volume by priority, average time-to-resolve, SLA compliance rate, first-contact resolution rate, escalation rate)",
+              "Quality Assurance & Performance Excellence: interpreting metrics against SLA targets; identifying performance gaps; formulating improvement recommendations",
+              "Time Management & Productivity: analyzing throughput relative to staffing and ticket volume; identifying bottlenecks in the simulated operation",
+              "Advanced Communication & Stakeholder Management: structuring the report for a management audience; executive summary format; data visualization conventions",
+              "Professional Development & Career Growth: written reflection on the capstone experience — one design decision the student would revisit, one skill gap identified, one practice to carry into the workplace",
+              "Group debrief (final 30 min): share-outs on hardest design decision, most surprising Phase 4 result, and one improvement to the SLA document in hindsight"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "CompTIA A+": {
     "course": "CompTIA A+",
     "totalHours": 120,


### PR DESCRIPTION
Part of `apprenti-org/design-documentation#320`.

## Summary

- **Add** `outlines/ctse-capstone.json` — 5 modules, 5 lessons, 20h
- **Add** `ctse-capstone` to `outlines/manifest.json`
- **Update** `courses.json` for `ctse-capstone`:
  - `status.design`: `"Not Started"` → `"Complete"`
  - `status.development`: `"Not Started"` → `"In Progress"`
  - `syllabus`: `null` → `"Syllabus: Client Technical Support Engineer Capstone"`
  - `outline`: `null` → `"Course Outline: Client Technical Support Engineer Capstone"`
  - `note`: updated to reflect scaffolding complete
  - `sourceRepo`: added `"https://github.com/apprenti-org/design-documentation"`
- **Regenerate** `courses.js` and `outlines/outlines.js`

## Outline structure

5 modules / 5 lessons (one per phase):

| Module | Lesson | Hours |
|---|---|---|
| Discovery — IT Environment Assessment | IT Environment Assessment | 4h |
| Design — Service Architecture | Service Architecture Design | 5h |
| Build — Helpdesk Platform Configuration | Helpdesk Platform Configuration | 4h |
| Operate — Simulated Ticket Processing | Simulated Ticket Processing | 4h |
| Report — Performance Analysis and Debrief | Performance Report and Debrief | 3h |
| **Total** | | **20h** |

## Test plan

- [ ] Dashboard shows ctse-capstone with `Design: Complete / Development: In Progress`
- [ ] Outline panel renders 5 modules with correct lesson titles and hours
- [ ] Syllabus and outline links are non-null in detail panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)