### PR TITLE
[ctse-capstone] Content Production complete — status.development → Complete

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -179,11 +179,11 @@ const courseData = [
     "hours": 20,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": "Syllabus: Client Technical Support Engineer Capstone",
     "outline": "Course Outline: Client Technical Support Engineer Capstone",
-    "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Content scaffolding complete (Phase 0 + Phase 1). All lesson artifacts stubbed. Ready for content production.",
+    "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. All content produced: content.md, instructor-guide.md, Capstone Deliverables checklist (quiz.md), and interactive.html for all 5 lessons. Course-completion report at _REVIEW/course-completion-report.md.",
     "driveFolder": null,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation",
     "statusConfirmed": false

--- a/courses.json
+++ b/courses.json
@@ -177,11 +177,11 @@
       "hours": 20,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": "Syllabus: Client Technical Support Engineer Capstone",
       "outline": "Course Outline: Client Technical Support Engineer Capstone",
-      "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. Content scaffolding complete (Phase 0 + Phase 1). All lesson artifacts stubbed. Ready for content production.",
+      "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. All content produced: content.md, instructor-guide.md, Capstone Deliverables checklist (quiz.md), and interactive.html for all 5 lessons. Course-completion report at _REVIEW/course-completion-report.md.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": false


### PR DESCRIPTION
## Summary

- Flips `status.development` from `"In Progress"` to `"Complete"` for `ctse-capstone`
- Updates `note` to reflect full artifact set produced
- Rebuilds `courses.js`

## What was produced (in rti-workspace working folder)

All 5 capstone phases (lessons) now have the complete artifact set:
- `content.md` — scenario framing, capstone walkthrough, learning objectives (frontmatter fixed: ISO dates, YAML arrays, full module names)
- `instructor-guide.md` — phase-by-phase teaching notes, timing table, common student Q&A, facilitation tips
- `quiz.md` — Capstone Deliverables checklist (binary pass/fail; hard gates per phase) per `capstone-design-process.md` §7
- `interactive.html` — phase briefing deck (9 slides per phase)
- `MODULE-REPORT.md` — module-level production summary (one per module)
- `_REVIEW/course-completion-report.md` — course-level completion report

## Capstone structure note

`quiz.md` files use the Capstone Deliverables format (`type: capstone_deliverables`) rather than the standard MC/MS/TF quiz format. This is per `capstone-design-process.md` §5 and §7.

Closes apprenti-org/design-documentation#323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
