### PR TITLE
ctse-capstone: add SCORM objects to lesson outlines (Row 8)

### DIFF
--- a/outlines/ctse-capstone.json
+++ b/outlines/ctse-capstone.json
@@ -18,6 +18,9 @@
             "Advanced Troubleshooting Techniques: identifying current pain points from symptoms; distinguishing incidents from underlying problems",
             "Producing the environment document: required sections, level of detail, what an employer reviewer will evaluate",
             "Checkpoint gate: IT environment document reviewed by instructor before Phase 2 begins"
+          ],
+          "objects": [
+            "SCORM: Interactive — IT Environment Assessment"
           ]
         }
       ]
@@ -37,6 +40,9 @@
             "Service catalog structure: scope definition (in-scope vs out-of-scope), tier mapping, internal vs vendor escalation paths",
             "SLA document structure: priority levels, response/resolution targets, breach conditions, reporting cadence",
             "Checkpoint gate: service catalog and SLA document reviewed by instructor before Phase 3 begins"
+          ],
+          "objects": [
+            "SCORM: Interactive — Service Architecture Design"
           ]
         }
       ]
@@ -54,6 +60,9 @@
             "Automations: configuring one automation rule (e.g., auto-assign by category, auto-acknowledge on submission); verifying trigger conditions",
             "Knowledge base template: creating one KB article template for the highest-priority recurring issue from Phase 1 (format: symptom, cause, resolution steps, escalation trigger)",
             "Configuration documentation: screenshot evidence + brief written explanation of each configuration decision tracing back to the service catalog and SLA document"
+          ],
+          "objects": [
+            "SCORM: Interactive — Helpdesk Platform Configuration"
           ]
         }
       ]
@@ -72,6 +81,9 @@
             "System Reports & Analytics: manually tracking SLA adherence per ticket; flagging breaches; counting first-contact resolutions vs escalations",
             "Ticket log completion: required fields, resolution note quality standards (what constitutes a substantive resolution note vs a placeholder)",
             "Escalation scenarios: two tickets are designated as escalation scenarios — students must document the escalation trigger, the communication sent, and the resolution path"
+          ],
+          "objects": [
+            "SCORM: Interactive — Simulated Ticket Processing"
           ]
         }
       ]
@@ -90,6 +102,9 @@
             "Advanced Communication & Stakeholder Management: structuring the report for a management audience; executive summary format; data visualization conventions",
             "Professional Development & Career Growth: written reflection on the capstone experience — one design decision the student would revisit, one skill gap identified, one practice to carry into the workplace",
             "Group debrief (final 30 min): share-outs on hardest design decision, most surprising Phase 4 result, and one improvement to the SLA document in hindsight"
+          ],
+          "objects": [
+            "SCORM: Interactive — Performance Report and Debrief"
           ]
         }
       ]

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -1624,6 +1624,9 @@ const courseOutlines = {
               "Advanced Troubleshooting Techniques: identifying current pain points from symptoms; distinguishing incidents from underlying problems",
               "Producing the environment document: required sections, level of detail, what an employer reviewer will evaluate",
               "Checkpoint gate: IT environment document reviewed by instructor before Phase 2 begins"
+            ],
+            "objects": [
+              "SCORM: Interactive — IT Environment Assessment"
             ]
           }
         ]
@@ -1643,6 +1646,9 @@ const courseOutlines = {
               "Service catalog structure: scope definition (in-scope vs out-of-scope), tier mapping, internal vs vendor escalation paths",
               "SLA document structure: priority levels, response/resolution targets, breach conditions, reporting cadence",
               "Checkpoint gate: service catalog and SLA document reviewed by instructor before Phase 3 begins"
+            ],
+            "objects": [
+              "SCORM: Interactive — Service Architecture Design"
             ]
           }
         ]
@@ -1660,6 +1666,9 @@ const courseOutlines = {
               "Automations: configuring one automation rule (e.g., auto-assign by category, auto-acknowledge on submission); verifying trigger conditions",
               "Knowledge base template: creating one KB article template for the highest-priority recurring issue from Phase 1 (format: symptom, cause, resolution steps, escalation trigger)",
               "Configuration documentation: screenshot evidence + brief written explanation of each configuration decision tracing back to the service catalog and SLA document"
+            ],
+            "objects": [
+              "SCORM: Interactive — Helpdesk Platform Configuration"
             ]
           }
         ]
@@ -1678,6 +1687,9 @@ const courseOutlines = {
               "System Reports & Analytics: manually tracking SLA adherence per ticket; flagging breaches; counting first-contact resolutions vs escalations",
               "Ticket log completion: required fields, resolution note quality standards (what constitutes a substantive resolution note vs a placeholder)",
               "Escalation scenarios: two tickets are designated as escalation scenarios — students must document the escalation trigger, the communication sent, and the resolution path"
+            ],
+            "objects": [
+              "SCORM: Interactive — Simulated Ticket Processing"
             ]
           }
         ]
@@ -1696,6 +1708,9 @@ const courseOutlines = {
               "Advanced Communication & Stakeholder Management: structuring the report for a management audience; executive summary format; data visualization conventions",
               "Professional Development & Career Growth: written reflection on the capstone experience — one design decision the student would revisit, one skill gap identified, one practice to carry into the workplace",
               "Group debrief (final 30 min): share-outs on hardest design decision, most surprising Phase 4 result, and one improvement to the SLA document in hindsight"
+            ],
+            "objects": [
+              "SCORM: Interactive — Performance Report and Debrief"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

- Adds `objects` array to each of the 5 lessons in `outlines/ctse-capstone.json` with `SCORM: Interactive — [Title]` entries
- Rebuilds `outlines/outlines.js`

## SCORM packages produced

| Lesson | Package | Status |
|---|---|---|
| L01: IT Environment Assessment | scorm-ctse-capstone-L01.zip | Packaged ✅ |
| L02: Service Architecture Design | scorm-ctse-capstone-L02.zip | Packaged ✅ |
| L03: Helpdesk Platform Configuration | scorm-ctse-capstone-L03.zip | Packaged ✅ |
| L04: Simulated Ticket Processing | scorm-ctse-capstone-L04.zip | Packaged ✅ |
| L05: Performance Report and Debrief | scorm-ctse-capstone-L05.zip | Packaged ✅ |

All 5 packages verified (completeSCORM count=2 per package).

## Phase 3 note

LMS Verification (Phase 3 of the SCORM Packaging process) is a manual step — at least one package must be test-uploaded to Absorb and verified for completion tracking before the remaining 4 are uploaded. This step is flagged in [apprenti-org/design-documentation#324](https://github.com/apprenti-org/design-documentation/issues/324).

Closes apprenti-org/design-documentation#324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)