### PR TITLE
ai-assisted-learning-and-study-skills: mark development Complete (#354)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -52,11 +52,11 @@ const courseData = [
     "hours": 2,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": null,
     "outline": true,
-    "note": "Net-new 2h cross-curriculum course. Module 1: AI as a Learning Tool. 2 lessons: Prompting Structures and AI-Assisted Problem Solving (1h); AI for Self-Assessment and Critical Verification (1h). Cross-curriculum: CTSE, Cloud Ops, DANL, CyberSec, ITBA, SWD, ITSP, Web Dev. RTI/OJL mapping deferred per curriculum. Content scaffolding complete (Phase 0 + 1).",
+    "note": "Net-new 2h cross-curriculum course. Module 1: AI as a Learning Tool. 2 lessons: Prompting Structures and AI-Assisted Problem Solving (1h); AI for Self-Assessment and Critical Verification (1h). Cross-curriculum: CTSE, Cloud Ops, DANL, CyberSec, ITBA, SWD, ITSP, Web Dev. Content production complete (Phase 3, issue #354). RTI/OJL mapping deferred per curriculum.",
     "driveFolder": null,
     "statusConfirmed": false
   },

--- a/courses.json
+++ b/courses.json
@@ -50,11 +50,11 @@
       "hours": 2,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": null,
       "outline": true,
-      "note": "Net-new 2h cross-curriculum course. Module 1: AI as a Learning Tool. 2 lessons: Prompting Structures and AI-Assisted Problem Solving (1h); AI for Self-Assessment and Critical Verification (1h). Cross-curriculum: CTSE, Cloud Ops, DANL, CyberSec, ITBA, SWD, ITSP, Web Dev. RTI/OJL mapping deferred per curriculum. Content scaffolding complete (Phase 0 + 1).",
+      "note": "Net-new 2h cross-curriculum course. Module 1: AI as a Learning Tool. 2 lessons: Prompting Structures and AI-Assisted Problem Solving (1h); AI for Self-Assessment and Critical Verification (1h). Cross-curriculum: CTSE, Cloud Ops, DANL, CyberSec, ITBA, SWD, ITSP, Web Dev. Content production complete (Phase 3, issue #354). RTI/OJL mapping deferred per curriculum.",
       "driveFolder": null,
       "statusConfirmed": false
     },


### PR DESCRIPTION
## Summary

- Sets `status.development` from `"In Progress"` to `"Complete"` for `ai-assisted-learning-and-study-skills` in `courses.json`
- Updates `note` to reflect content production completion (Phase 3, issue #354)
- Rebuilds `courses.js`

## Course

**AI Assisted Learning and Study Skills** — 2h, cross-curriculum, 1 module, 2 lessons

Phase 3 content production complete per `apprenti-org/design-documentation#354`:
- 14 production files authored: content.md, instructor-guide.md, quiz.md, activity pairs, interactive.html (×2 lessons) + MODULE-REPORT.md + course-completion-report.md
- 0 quarantines; all artifacts pass manual structural verification against locked canonical templates

## Test plan

- [ ] Dashboard shows `ai-assisted-learning-and-study-skills` with development status **Complete**
- [ ] Outline still renders (outline flag remains `true`)
- [ ] No regressions on other course entries

Closes part of `apprenti-org/design-documentation#354` (tracking-repo side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)