### PR TITLE
infrastructure-as-code-fundamentals: refresh note + add sourceRepo (#121)

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-06T19:04:19",
+  "generated": "2026-05-06T19:47:36",
   "courseCount": 67,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -366,8 +366,9 @@ const courseData = [
     },
     "syllabus": null,
     "outline": "infrastructure-as-code-fundamentals",
-    "note": "OSS Course 12, Area 3 — net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h, 5 modules, 16 lessons (incl. M5 capstone authored against capstone-design-process.md v0.2.0). Content production complete; deploy tree shipped to workspace deploy/content/ with 97 PDFs + 16 SCORM zips. Pending: Phase 1 manual interactive review, Phase 3 Absorb upload, LMS publish.",
+    "note": "OSS Course 12, Area 3 — net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h, 5 modules, 16 lessons (incl. M5 capstone — first lesson authored against capstone-design-process.md v0.2.0; CBR + evidence-map locked as canonical templates). Live in Absorb 2026-05-06 (97 PDFs + 16 SCORM zips uploaded; course published to learner catalog). Apprenti-org code repos: infrastructure-as-code-student + infrastructure-as-code-instructor. Onboarding meta apprenti-org/design-documentation#281.",
     "driveFolder": null,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
     "statusConfirmed": true
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -364,8 +364,9 @@
       },
       "syllabus": null,
       "outline": "infrastructure-as-code-fundamentals",
-      "note": "OSS Course 12, Area 3 \u2014 net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h, 5 modules, 16 lessons (incl. M5 capstone authored against capstone-design-process.md v0.2.0). Content production complete; deploy tree shipped to workspace deploy/content/ with 97 PDFs + 16 SCORM zips. Pending: Phase 1 manual interactive review, Phase 3 Absorb upload, LMS publish.",
+      "note": "OSS Course 12, Area 3 \u2014 net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h, 5 modules, 16 lessons (incl. M5 capstone \u2014 first lesson authored against capstone-design-process.md v0.2.0; CBR + evidence-map locked as canonical templates). Live in Absorb 2026-05-06 (97 PDFs + 16 SCORM zips uploaded; course published to learner catalog). Apprenti-org code repos: infrastructure-as-code-student + infrastructure-as-code-instructor. Onboarding meta apprenti-org/design-documentation#281.",
       "driveFolder": null,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
     },
     {


### PR DESCRIPTION
Closes #121.

## Summary

IaC Fundamentals shipped end-to-end on 2026-05-06 (apprenti-org/design-documentation#281 closed). Two stale fields refreshed:

1. **\`note\`** — drop the trailing "Pending: Phase 1 / Phase 3 / LMS publish" (all three are done); add "Live in Absorb 2026-05-06" + apprenti-org code repos reference + onboarding meta link.
2. **\`sourceRepo\`** — added \`https://github.com/apprenti-org/design-documentation\` (matches cicd-pipeline-concepts shipped convention).

Regenerated dashboard bundles via \`node build.js\`.

## Diff

| Field | Before | After |
|---|---|---|
| \`note\` ending | "Pending: Phase 1 manual interactive review, Phase 3 Absorb upload, LMS publish." | "Live in Absorb 2026-05-06 (97 PDFs + 16 SCORM zips uploaded; course published to learner catalog). Apprenti-org code repos: infrastructure-as-code-student + infrastructure-as-code-instructor. Onboarding meta apprenti-org/design-documentation#281." |
| \`sourceRepo\` | (missing) | \`https://github.com/apprenti-org/design-documentation\` |

## Out of scope

- 25 outline-file-vs-manifest slug mismatches across the dashboard — separate audit, similar cadence to OSS audit (#63).

## Test plan

- [x] \`node build.js\` regenerated bundles cleanly
- [x] courses.js + course-overview.json reflect the updated note
- [ ] Dashboard renders IaC card with new note text post-merge