### PR TITLE
feat(ai-assisted-coding-fundamentals): add to courses.json (Row 7 tracking update)

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -176,6 +176,41 @@ var courseOverviewData = [
     }
   },
   {
+    "id": "ai-assisted-coding-fundamentals",
+    "name": "AI-Assisted Coding Fundamentals",
+    "hours": 4,
+    "outline": {
+      "exists": true,
+      "modules": 3,
+      "lessons": 5
+    },
+    "syllabus": true,
+    "source": {
+      "exists": false,
+      "folder": null,
+      "modules": 0
+    },
+    "coverage": 0,
+    "lessonsWithContent": 0,
+    "assets": {
+      "lessons": 0,
+      "slides": 0,
+      "quizzes": 0,
+      "activities": 0,
+      "demos": 0,
+      "caseStudies": 0,
+      "instructorGuides": 0,
+      "modIntros": 0,
+      "modRecaps": 0
+    },
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 3,
+      "actual": 0
+    }
+  },
+  {
     "id": "ai-assisted-test-driven-development",
     "name": "AI-Assisted Test Driven Development",
     "hours": 2,
@@ -835,9 +870,9 @@ var courseOverviewData = [
     },
     "totalAssets": 123,
     "deployment": {
-      "state": "Not Deployed",
+      "state": "Complete",
       "expected": 0,
-      "actual": 0
+      "actual": 18
     }
   },
   {

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-05-13T10:29:39",
-  "courseCount": 69,
+  "generated": "2026-05-14T11:42:25",
+  "courseCount": 70,
   "courses": [
     {
       "id": "aba-banking-foundations",
@@ -174,6 +174,41 @@
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,
+        "actual": 0
+      }
+    },
+    {
+      "id": "ai-assisted-coding-fundamentals",
+      "name": "AI-Assisted Coding Fundamentals",
+      "hours": 4,
+      "outline": {
+        "exists": true,
+        "modules": 3,
+        "lessons": 5
+      },
+      "syllabus": true,
+      "source": {
+        "exists": false,
+        "folder": null,
+        "modules": 0
+      },
+      "coverage": 0,
+      "lessonsWithContent": 0,
+      "assets": {
+        "lessons": 0,
+        "slides": 0,
+        "quizzes": 0,
+        "activities": 0,
+        "demos": 0,
+        "caseStudies": 0,
+        "instructorGuides": 0,
+        "modIntros": 0,
+        "modRecaps": 0
+      },
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 3,
         "actual": 0
       }
     },
@@ -837,9 +872,9 @@
       },
       "totalAssets": 123,
       "deployment": {
-        "state": "Not Deployed",
+        "state": "Complete",
         "expected": 0,
-        "actual": 0
+        "actual": 18
       }
     },
     {

--- a/courses.js
+++ b/courses.js
@@ -75,6 +75,20 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "ai-assisted-coding-fundamentals",
+    "name": "AI-Assisted Coding Fundamentals",
+    "hours": 4,
+    "status": {
+      "design": "Complete",
+      "development": "Complete"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Net-new 4h course for Software Developer (JVFD). 2 modules, 4 lessons: Your First AI-Assisted Program (1h), Prompting AI Effectively for Code (1h), Debugging and Refactoring with AI (1h), Reviewing AI-Generated Code for Security and Accuracy (1h). Phase 3 content production complete (issue #476); interactive.html produced for all 4 lessons. Starter/solution repos staged (code-manifest issue #474). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+    "driveFolder": null,
+    "statusConfirmed": false
+  },
+  {
     "id": "ai-assisted-test-driven-development",
     "name": "AI-Assisted Test Driven Development",
     "hours": 2,

--- a/courses.json
+++ b/courses.json
@@ -73,6 +73,20 @@
       "statusConfirmed": true
     },
     {
+      "id": "ai-assisted-coding-fundamentals",
+      "name": "AI-Assisted Coding Fundamentals",
+      "hours": 4,
+      "status": {
+        "design": "Complete",
+        "development": "Complete"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Net-new 4h course for Software Developer (JVFD). 2 modules, 4 lessons: Your First AI-Assisted Program (1h), Prompting AI Effectively for Code (1h), Debugging and Refactoring with AI (1h), Reviewing AI-Generated Code for Security and Accuracy (1h). Phase 3 content production complete (issue #476); interactive.html produced for all 4 lessons. Starter/solution repos staged (code-manifest issue #474). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+      "driveFolder": null,
+      "statusConfirmed": false
+    },
+    {
       "id": "ai-assisted-test-driven-development",
       "name": "AI-Assisted Test Driven Development",
       "hours": 2,


### PR DESCRIPTION
## Summary

- Adds `ai-assisted-coding-fundamentals` to `courses.json` with `status.development: "Complete"` and `status.design: "Complete"`
- Outline entry was already present from Row 2; this PR adds the development-complete flag as Phase 3 (Content Production) closes
- Course: 4h, 2 modules, 4 lessons; JVFD curriculum; net-new

## Related

Design-documentation PR: apprenti-org/design-documentation#477 (closes #476)

## Test plan

- [ ] `courses.json` entry for `ai-assisted-coding-fundamentals` present and valid JSON
- [ ] `node build.js` runs clean (no sort errors)
- [ ] Dashboard shows course with both design and development status = Complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)