### PR TITLE
chore(sql-fundamentals): update tracking entry — rename id, flip status to Complete

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -926,16 +926,16 @@ const courseData = [
     "statusConfirmed": false
   },
   {
-    "id": "sql-fundamentals-for-operations",
-    "name": "SQL Fundamentals for Operations",
+    "id": "sql-fundamentals",
+    "name": "SQL Fundamentals",
     "hours": 24,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "Complete"
     },
     "syllabus": null,
     "outline": null,
-    "note": "OSS Course 10, Area 3 — net-new course, to be authored as a slim variant of SQL for Data (existing 'Reduce from SQL for Data' note). 24h matches the standard's SQL minimum. Active dev pipeline — design work beginning soon. Audit confirms Not Started baseline (per #83).",
+    "note": "OSS Course 10, Area 3. Derived from sql-for-data (50h Data Analyst) — 24h ops-flavored variant. 13 lessons, 9 modules. Live in Absorb 2026-05-18. See apprenti-org/design-documentation#361 onboarding meta.",
     "driveFolder": null,
     "statusConfirmed": true
   },
@@ -1250,8 +1250,8 @@ const curriculaData = [
             "id": "web-development-with-javascript"
           },
           {
-            "name": "SQL Fundamentals for Operations",
-            "id": "sql-fundamentals-for-operations"
+            "name": "SQL Fundamentals",
+            "id": "sql-fundamentals"
           },
           {
             "name": "CI/CD Pipeline Concepts",

--- a/courses.json
+++ b/courses.json
@@ -924,16 +924,16 @@
       "statusConfirmed": false
     },
     {
-      "id": "sql-fundamentals-for-operations",
-      "name": "SQL Fundamentals for Operations",
+      "id": "sql-fundamentals",
+      "name": "SQL Fundamentals",
       "hours": 24,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "Complete"
       },
       "syllabus": null,
       "outline": null,
-      "note": "OSS Course 10, Area 3 \u2014 net-new course, to be authored as a slim variant of SQL for Data (existing 'Reduce from SQL for Data' note). 24h matches the standard's SQL minimum. Active dev pipeline \u2014 design work beginning soon. Audit confirms Not Started baseline (per #83).",
+      "note": "OSS Course 10, Area 3. Derived from sql-for-data (50h Data Analyst) \u2014 24h ops-flavored variant. 13 lessons, 9 modules. Live in Absorb 2026-05-18. See apprenti-org/design-documentation#361 onboarding meta.",
       "driveFolder": null,
       "statusConfirmed": true
     },
@@ -1157,7 +1157,7 @@
               "note": "Reduced from 56h base to 40h to match A-28 standard (Java+JS combined = 80h)"
             },
             "web-development-with-javascript",
-            "sql-fundamentals-for-operations",
+            "sql-fundamentals",
             "ci-cd-pipeline-concepts",
             "infrastructure-as-code-fundamentals",
             "ai-foundations"


### PR DESCRIPTION
## Summary

Updates the `sql-fundamentals` entry in `courses.json` to reflect actual post-LMS-publish state. Course shipped to Absorb 2026-05-18.

Closes #138.

## Changes

- `id`: `sql-fundamentals-for-operations` → `sql-fundamentals` (canonical slug across design-documentation, courses folder, and code repos)
- `name`: `"SQL Fundamentals for Operations"` → `"SQL Fundamentals"`
- `status.design`: `"Not Started"` → `"Complete"`
- `status.development`: `"Not Started"` → `"Complete"`
- `note`: stale → current accurate state
- `statusConfirmed`: stays `true` (operator-confirmed post-LMS-publish)
- Curriculum-bundle membership reference updated to the new id
- `courses.js` regenerated via `node build.js`

## Out of scope

- Populating `syllabus`, `outline`, `driveFolder` links — separate follow-up
- Updating sql-for-data's tracking entry (also stale) — separate issue if needed
- Adding `tracking/repo/outlines/sql-fundamentals.json` outline file — separate follow-up

## Test plan

- [ ] Local `node build.js` ran clean (validation passed)
- [ ] `git diff` shows only courses.json + courses.js
- [ ] sql-fundamentals appears in the dashboard with status "Complete" after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)