### PR TITLE
feat(ai-assisted-cicd-pipelines): add to tracking — Phase 0+1 scaffolding

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -176,6 +176,41 @@ var courseOverviewData = [
     }
   },
   {
+    "id": "ai-assisted-cicd-pipelines",
+    "name": "AI-Assisted CI/CD Pipelines",
+    "hours": 2,
+    "outline": {
+      "exists": true,
+      "modules": 2,
+      "lessons": 3
+    },
+    "syllabus": true,
+    "source": {
+      "exists": false,
+      "folder": null,
+      "modules": 0
+    },
+    "coverage": 0,
+    "lessonsWithContent": 0,
+    "assets": {
+      "lessons": 0,
+      "slides": 0,
+      "quizzes": 0,
+      "activities": 0,
+      "demos": 0,
+      "caseStudies": 0,
+      "instructorGuides": 0,
+      "modIntros": 0,
+      "modRecaps": 0
+    },
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
+  },
+  {
     "id": "ai-assisted-coding-fundamentals",
     "name": "AI-Assisted Coding Fundamentals",
     "hours": 4,
@@ -2276,38 +2311,38 @@ var courseOverviewData = [
     }
   },
   {
-    "id": "sql-fundamentals-for-operations",
-    "name": "SQL Fundamentals for Operations",
+    "id": "sql-fundamentals",
+    "name": "SQL Fundamentals",
     "hours": 24,
     "outline": {
-      "exists": true,
-      "modules": 2,
-      "lessons": 11
+      "exists": false,
+      "modules": 0,
+      "lessons": 0
     },
     "syllabus": false,
     "source": {
       "exists": true,
-      "folder": "Course  SQL for Data",
-      "modules": 8
+      "folder": "sql-fundamentals/deploy/content",
+      "modules": 9
     },
-    "coverage": 0,
+    "coverage": null,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 17,
-      "slides": 12,
-      "quizzes": 0,
-      "activities": 83,
-      "demos": 5,
+      "lessons": 27,
+      "slides": 13,
+      "quizzes": 2,
+      "activities": 16,
+      "demos": 0,
       "caseStudies": 0,
-      "instructorGuides": 6,
+      "instructorGuides": 3,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 123,
+    "totalAssets": 61,
     "deployment": {
-      "state": "Not Deployed",
-      "expected": 0,
-      "actual": 0
+      "state": "Complete",
+      "expected": 13,
+      "actual": 13
     }
   },
   {

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-05-14T15:04:34",
-  "courseCount": 70,
+  "generated": "2026-05-18T11:17:18",
+  "courseCount": 71,
   "courses": [
     {
       "id": "aba-banking-foundations",
@@ -150,6 +150,41 @@
         "exists": true,
         "modules": 5,
         "lessons": 13
+      },
+      "syllabus": true,
+      "source": {
+        "exists": false,
+        "folder": null,
+        "modules": 0
+      },
+      "coverage": 0,
+      "lessonsWithContent": 0,
+      "assets": {
+        "lessons": 0,
+        "slides": 0,
+        "quizzes": 0,
+        "activities": 0,
+        "demos": 0,
+        "caseStudies": 0,
+        "instructorGuides": 0,
+        "modIntros": 0,
+        "modRecaps": 0
+      },
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
+    },
+    {
+      "id": "ai-assisted-cicd-pipelines",
+      "name": "AI-Assisted CI/CD Pipelines",
+      "hours": 2,
+      "outline": {
+        "exists": true,
+        "modules": 2,
+        "lessons": 3
       },
       "syllabus": true,
       "source": {
@@ -2278,38 +2313,38 @@
       }
     },
     {
-      "id": "sql-fundamentals-for-operations",
-      "name": "SQL Fundamentals for Operations",
+      "id": "sql-fundamentals",
+      "name": "SQL Fundamentals",
       "hours": 24,
       "outline": {
-        "exists": true,
-        "modules": 2,
-        "lessons": 11
+        "exists": false,
+        "modules": 0,
+        "lessons": 0
       },
       "syllabus": false,
       "source": {
         "exists": true,
-        "folder": "Course  SQL for Data",
-        "modules": 8
+        "folder": "sql-fundamentals/deploy/content",
+        "modules": 9
       },
-      "coverage": 0,
+      "coverage": null,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 17,
-        "slides": 12,
-        "quizzes": 0,
-        "activities": 83,
-        "demos": 5,
+        "lessons": 27,
+        "slides": 13,
+        "quizzes": 2,
+        "activities": 16,
+        "demos": 0,
         "caseStudies": 0,
-        "instructorGuides": 6,
+        "instructorGuides": 3,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 123,
+      "totalAssets": 61,
       "deployment": {
-        "state": "Not Deployed",
-        "expected": 0,
-        "actual": 0
+        "state": "Complete",
+        "expected": 13,
+        "actual": 13
       }
     },
     {

--- a/courses.js
+++ b/courses.js
@@ -75,6 +75,21 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "ai-assisted-cicd-pipelines",
+    "name": "AI-Assisted CI/CD Pipelines",
+    "hours": 2,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
+    "outline": true,
+    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content scaffolding in progress (Phase 0 + 1 complete, Row 5 of onboarding — meta #525). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+    "driveFolder": null,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+    "statusConfirmed": false
+  },
+  {
     "id": "ai-assisted-coding-fundamentals",
     "name": "AI-Assisted Coding Fundamentals",
     "hours": 4,

--- a/courses.json
+++ b/courses.json
@@ -73,6 +73,21 @@
       "statusConfirmed": true
     },
     {
+      "id": "ai-assisted-cicd-pipelines",
+      "name": "AI-Assisted CI/CD Pipelines",
+      "hours": 2,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
+      "outline": true,
+      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content scaffolding in progress (Phase 0 + 1 complete, Row 5 of onboarding \u2014 meta #525). RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "driveFolder": null,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+      "statusConfirmed": false
+    },
+    {
       "id": "ai-assisted-coding-fundamentals",
       "name": "AI-Assisted Coding Fundamentals",
       "hours": 4,
@@ -82,7 +97,7 @@
       },
       "syllabus": "syllabi/ai-assisted-coding-fundamentals.html",
       "outline": true,
-      "note": "Net-new 4h course for Software Developer (JVFD). 2 modules, 4 lessons: Your First AI-Assisted Program (1h), Prompting AI Effectively for Code (1h), Debugging and Refactoring with AI (1h), Reviewing AI-Generated Code for Security and Accuracy (1h). All 12 onboarding rows complete: content production (#476), SCORM packaging (#478), deployment (#479), starter asset audit (#480), LMS upload (#486). Student repo: apprenti-org/ai-assisted-coding-fundamentals-student. RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+      "note": "Net-new 4h course for Software Developer (JVFD). 2 modules, 4 lessons: Your First AI-Assisted Program (1h), Prompting AI Effectively for Code (1h), Debugging and Refactoring with AI (1h), Reviewing AI-Generated Code for Security and Accuracy (1h). All 12 onboarding rows complete: content production (#476), SCORM packaging (#478), deployment (#479), starter asset audit (#480), LMS upload (#486). Student repo: apprenti-org/ai-assisted-coding-fundamentals-student. RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "statusConfirmed": true
     },

--- a/js/shared/constants.js
+++ b/js/shared/constants.js
@@ -34,6 +34,7 @@ var LMS_CLASSES = {
 var syllabiMap = {
     'Advanced Python': 'advanced-python.html',
     'Agile Project Management with Scrum': 'agile-project-management.html',
+    'AI-Assisted CI/CD Pipelines': 'ai-assisted-cicd-pipelines.html',
     'AI-Assisted Coding Fundamentals': 'ai-assisted-coding-fundamentals.html',
     'ASP.NET': 'aspnet.html',
     'Business Analysis Fundamentals': 'business-analysis-fundamentals.html',

--- a/outlines/ai-assisted-cicd-pipelines.json
+++ b/outlines/ai-assisted-cicd-pipelines.json
@@ -1,0 +1,42 @@
+{
+  "course": "ai-assisted-cicd-pipelines",
+  "totalHours": 2,
+  "totalModules": 1,
+  "totalLessons": 2,
+  "modules": [
+    {
+      "name": "AI-Assisted CI/CD Pipelines",
+      "hours": 2,
+      "lessons": [
+        {
+          "title": "CI/CD Concepts and Generating Workflows with AI",
+          "hours": 1,
+          "topics": [
+            "**What CI/CD is and why it matters (10 min)**",
+            "**GitHub Actions anatomy (15 min)**",
+            "**Using AI to generate workflow YAML (20 min)**",
+            "**Wrap-Up and Reflection (5 min)**"
+          ],
+          "objects": [
+            "Object: Lesson: CI/CD Concepts and Generating Workflows with AI",
+            "Assessment: Quiz: CI/CD Concepts and Generating Workflows with AI"
+          ]
+        },
+        {
+          "title": "Building a Spring Application Pipeline with GitHub Actions",
+          "hours": 1,
+          "topics": [
+            "**Setting up the project (10 min)**",
+            "**Code-along: TemperatureConverter pipeline (35 min)**",
+            "**Using AI to read build logs (10 min)**",
+            "**Wrap-Up and Reflection (5 min)**"
+          ],
+          "objects": [
+            "Object: Lesson: Building a Spring Application Pipeline with GitHub Actions",
+            "Assessment: Quiz: Building a Spring Application Pipeline with GitHub Actions"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -20,6 +20,11 @@
     "id": "ai-foundations"
   },
   {
+    "file": "ai-assisted-cicd-pipelines.json",
+    "course": "AI-Assisted CI/CD Pipelines",
+    "id": "ai-assisted-cicd-pipelines"
+  },
+  {
     "file": "ai-assisted-coding-fundamentals.json",
     "course": "AI-Assisted Coding Fundamentals",
     "id": "ai-assisted-coding-fundamentals"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -821,6 +821,48 @@ const courseOutlines = {
       }
     ]
   },
+  "AI-Assisted CI/CD Pipelines": {
+    "course": "ai-assisted-cicd-pipelines",
+    "totalHours": 2,
+    "totalModules": 1,
+    "totalLessons": 2,
+    "modules": [
+      {
+        "name": "AI-Assisted CI/CD Pipelines",
+        "hours": 2,
+        "lessons": [
+          {
+            "title": "CI/CD Concepts and Generating Workflows with AI",
+            "hours": 1,
+            "topics": [
+              "**What CI/CD is and why it matters (10 min)**",
+              "**GitHub Actions anatomy (15 min)**",
+              "**Using AI to generate workflow YAML (20 min)**",
+              "**Wrap-Up and Reflection (5 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: CI/CD Concepts and Generating Workflows with AI",
+              "Assessment: Quiz: CI/CD Concepts and Generating Workflows with AI"
+            ]
+          },
+          {
+            "title": "Building a Spring Application Pipeline with GitHub Actions",
+            "hours": 1,
+            "topics": [
+              "**Setting up the project (10 min)**",
+              "**Code-along: TemperatureConverter pipeline (35 min)**",
+              "**Using AI to read build logs (10 min)**",
+              "**Wrap-Up and Reflection (5 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: Building a Spring Application Pipeline with GitHub Actions",
+              "Assessment: Quiz: Building a Spring Application Pipeline with GitHub Actions"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "AI-Assisted Coding Fundamentals": {
     "course": "AI-Assisted Coding Fundamentals",
     "totalHours": 4,

--- a/syllabi/ai-assisted-cicd-pipelines.html
+++ b/syllabi/ai-assisted-cicd-pipelines.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Syllabus: Java Language Fundamentals</title>
+    <title>Syllabus: AI-Assisted CI/CD Pipelines</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
 :root[data-theme="dark"] {
@@ -309,19 +309,64 @@ code {
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
         <div class="header">
-            <h1>Syllabus: Java Language Fundamentals</h1>
+            <h1>Syllabus: AI-Assisted CI/CD Pipelines</h1>
             <div class="header-meta">
-                <span><i class="fa-solid fa-layer-group"></i> software-development-java,operations-support-specialist</span>
-                <span><i class="fa-regular fa-clock"></i> 56 hours</span>
+                <span><i class="fa-solid fa-layer-group"></i> Software Developer (JVFD)</span>
+                <span><i class="fa-regular fa-clock"></i> 2 hours</span>
                 <span class="badge">CURRENT</span>
             </div>
         </div>
         <section>
             <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
-            <p>Java Language Fundamentals is a 56-hour course covering essential Java programming concepts from foundational syntax through object-oriented design patterns. Learners progress from setting up the Java development environment through hands-on projects including a shopping cart application and text adventure game. The course emphasizes practical application, testing methodologies, exception handling, and comprehensive capstone projects that integrate all concepts into real-world software solutions.</p>
+            <p>Course description pending.</p>
         </section>
 
         <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
+            <ol class="outcomes">
+                <li>Describe what CI/CD is and explain the role of GitHub Actions in a developer workflow.</li>
+                <li>Identify the key components of a GitHub Actions workflow file: triggers, jobs, steps, and runners.</li>
+                <li>Write a prompt that generates a GitHub Actions workflow YAML for a Spring Boot application.</li>
+                <li>Read and validate an AI-generated workflow file before committing it.</li>
+                <li>Create a Spring Boot project in IntelliJ and push it to a personal GitHub repository.</li>
+                <li>Configure a GitHub Actions workflow that builds and tests the project on every push.</li>
+                <li>Demonstrate a red/green build cycle: commit a failing test, observe the failure in GitHub Actions, implement the fix, observe the passing build.</li>
+                <li>Use AI to interpret a build log and identify the root cause of a pipeline failure.</li>
+            </ol>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-sitemap"></i> Course Outline</h2>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">1</span>
+                    <span class="module-title">AI-Assisted CI/CD Pipelines</span>
+                    <span class="module-hours">2 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 1: CI/CD Concepts and Generating Workflows with AI (1h)</div>
+                    <ul class="topic-list">
+                        <li>What CI/CD is and why it matters (10 min)</li>
+                        <li>GitHub Actions anatomy (15 min)</li>
+                        <li>Using AI to generate workflow YAML (20 min)</li>
+                        <li>Wrap-Up and Reflection (5 min)</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 2: Building a Spring Application Pipeline with GitHub Actions (1h)</div>
+                    <ul class="topic-list">
+                        <li>Setting up the project (10 min)</li>
+                        <li>Code-along: TemperatureConverter pipeline (35 min)</li>
+                        <li>Using AI to read build logs (10 min)</li>
+                        <li>Wrap-Up and Reflection (5 min)</li>
+                    </ul>
+                </div>
+            </div>
+
+        </section>
 
     </div>
 </body>

--- a/syllabi/cicd-pipeline-concepts.html
+++ b/syllabi/cicd-pipeline-concepts.html
@@ -313,7 +313,7 @@ code {
             <div class="header-meta">
                 <span><i class="fa-solid fa-layer-group"></i> Operations Support Specialist — Network</span>
                 <span><i class="fa-regular fa-clock"></i> 10 hours</span>
-                <span class="badge">DRAFT</span>
+                <span class="badge">CURRENT</span>
             </div>
         </div>
         <section>
@@ -324,24 +324,49 @@ code {
         <hr class="divider">
 
         <section>
-            <h2><i class="fa-solid fa-trophy"></i> Summative Assessment: Pipeline Design and Implementation</h2>
-            <div class="assessment-box">
-                <p>Learners will design and implement a functional CI/CD pipeline for a sample application or infrastructure project. The assessment evaluates understanding of pipeline architecture, ability to select and configure appropriate tools, knowledge of deployment strategies, and practical implementation skills. Learners will demonstrate their pipeline through automated testing, successful deployments, and documented workflows.</p>
-            </div>
-        </section>
-
-        <hr class="divider">
-
-        <section>
             <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
             <ol class="outcomes">
-                <li>Explain the principles of continuous integration and continuous deployment</li>
-                <li>Design version control workflows and branching strategies for team collaboration</li>
-                <li>Configure automated build and testing processes</li>
-                <li>Select appropriate CI/CD tools for specific use cases</li>
-                <li>Implement deployment strategies that minimize risk and downtime</li>
-                <li>Monitor and troubleshoot CI/CD pipelines</li>
-                <li>Document and communicate pipeline workflows to team members</li>
+                <li>Define continuous integration (CI) and continuous deployment (CD), and explain why teams adopt them.</li>
+                <li>Distinguish trunk-based from feature-branch development workflows and identify when each fits.</li>
+                <li>Configure GitHub branch protection rules with required status checks on a sample repository.</li>
+                <li>Write CI-friendly commit messages using the conventional commits format.</li>
+                <li>Identify the GitHub Actions events (`push`, `pull_request`, `schedule`) that trigger pipeline runs.</li>
+                <li>Identify the four-level GitHub Actions object model: workflow, job, step, action.</li>
+                <li>Locate and parse a workflow file in the `.github/workflows/` directory.</li>
+                <li>Use marketplace actions (`actions/checkout`, `actions/setup-python`) to compose a workflow without writing custom shell.</li>
+                <li>Author a one-stage workflow file that runs on every push and prints the Python version.</li>
+                <li>Add a test job to an existing workflow that runs alongside the build job. (OJL 3b)</li>
+                <li>Interpret status check results on a pull request and trace failures back to the failing step.</li>
+                <li>Configure dependency caching with `actions/cache` to reduce workflow run time.</li>
+                <li>Debug a red build by reading workflow logs and identifying root cause vs symptom.</li>
+                <li>Distinguish jobs from steps and identify when work belongs in a separate job versus another step. (OJL 3b)</li>
+                <li>Express job dependencies using `needs:` to build a directed pipeline graph.</li>
+                <li>Use matrix strategies (`strategy.matrix`) to run a job across multiple language/OS versions in parallel.</li>
+                <li>Identify use cases for reusable workflows and composite actions.</li>
+                <li>Read a 6-stage / 2-environment promotion pipeline and explain how each stage gates the next.</li>
+                <li>Distinguish repository secrets, organization secrets, and environment secrets, and identify when to use each. (OJL 3b)</li>
+                <li>Configure a GitHub Environment with required reviewers and deployment branch restrictions.</li>
+                <li>Reference environment-scoped secrets safely in workflow YAML using the `secrets.&lt;NAME&gt;` context.</li>
+                <li>Describe how OIDC enables credential-less cloud deployment and why it's preferred over long-lived access keys.</li>
+                <li>Read workflow run statuses from the GitHub UI and identify common failure patterns from the run summary.</li>
+                <li>Add a status badge to a repository README using the GitHub Actions badge URL convention.</li>
+                <li>Configure required status checks to enforce CI gating on the default branch.</li>
+                <li>Identify the workflow-failure notification options available in GitHub and via third-party integrations.</li>
+                <li>Apply pipeline observability practices: what to log, what to time, and where to surface results.</li>
+                <li>Define blue-green deployment and identify the operational scenarios where its tradeoffs fit best. (OJL 3b)</li>
+                <li>Describe canary releases and explain the role of the observation window in catching regressions early.</li>
+                <li>Explain rolling updates and the role of the load balancer in coordinating node replacement.</li>
+                <li>Compare deployment strategies for a given operational scenario and recommend one with rationale.</li>
+                <li>Identify how each deployment strategy is expressed in a GitHub Actions workflow.</li>
+                <li>Apply semantic versioning rules (MAJOR.MINOR.PATCH) to determine the correct version bump for a code change. (OJL 3b)</li>
+                <li>Tag a release in Git and configure a tag-triggered GitHub Actions workflow.</li>
+                <li>Generate release notes from conventional commit history.</li>
+                <li>Execute a tag-based rollback when a deployment fails.</li>
+                <li>Run post-deployment verification using smoke tests and health checks.</li>
+                <li>Author a 4-stage CI/CD workflow (Lint → Test → Build → Deploy) on a course-provided sample repository. (OJL 3b)</li>
+                <li>Configure a GitHub Environment with one protection rule and one consumed secret.</li>
+                <li>Trigger the pipeline on pull request and produce a green end-to-end run.</li>
+                <li>Document the pipeline shape in a README section that an external reader can use to understand the architecture.</li>
             </ol>
         </section>
 
@@ -353,19 +378,34 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">1</span>
-                    <span class="module-title">Continuous Integration Fundamentals</span>
+                    <span class="module-title">CI/CD pipeline concepts and tooling</span>
                     <span class="module-hours">3 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Version Control Essentials</div>
+                    <div class="lesson-heading">Lesson: 1: CI/CD Fundamentals and Version Control for CI (1h)</div>
                     <ul class="topic-list">
-                        <li>Git workflows and branching</li>
-                        <li>Code review practices</li>
+                        <li>What CI is, what CD is, and why teams adopt them</li>
+                        <li>Trunk-based vs feature-branch development</li>
+                        <li>Branch protection rules and required status checks</li>
+                        <li>Conventional commits and CI-friendly history</li>
+                        <li>Events that trigger pipelines (push, pull_request, schedule)</li>
+                        <li>Individual: configure branch protection on a sample repo with one required status check</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Build Automation</div>
+                    <div class="lesson-heading">Lesson: 2: Introduction to GitHub Actions (1h)</div>
                     <ul class="topic-list">
-                        <li>Automated testing integration</li>
-                        <li>Build pipeline setup</li>
+                        <li>Workflows, jobs, steps — the GitHub Actions object model</li>
+                        <li>The `.github/workflows/` directory and YAML basics</li>
+                        <li>Events, runners, and the marketplace actions ecosystem</li>
+                        <li>Authoring a first one-stage workflow that builds a generic Python sample</li>
+                        <li>Pair coding: write and commit a `build.yml` that runs on every push and prints the Python version</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 3: Build Automation and Automated Testing as a CI Step (1h)</div>
+                    <ul class="topic-list">
+                        <li>Adding a test job alongside the build job (OJL 3b)</li>
+                        <li>Status checks and the failing-build experience</li>
+                        <li>Caching dependencies between runs (`actions/cache`)</li>
+                        <li>Reading workflow logs and debugging a red build</li>
+                        <li>Individual: extend the Lesson 2 workflow with a `pytest` job and intentionally break a test to observe the failure flow</li>
                     </ul>
                 </div>
             </div>
@@ -373,23 +413,35 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">2</span>
-                    <span class="module-title">Continuous Deployment and Release Management</span>
-                    <span class="module-hours">4 hours</span>
+                    <span class="module-title">Pipeline architecture</span>
+                    <span class="module-hours">3 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Pipeline Architecture</div>
+                    <div class="lesson-heading">Lesson: 4: Multi-Stage Pipelines (1h)</div>
                     <ul class="topic-list">
-                        <li>Pipeline stages and tools</li>
-                        <li>Feedback mechanisms</li>
+                        <li>Jobs vs steps and when to split (OJL 3b)</li>
+                        <li>`needs:` and the pipeline DAG</li>
+                        <li>Matrix strategies for cross-version testing</li>
+                        <li>Reusable workflows and composite actions</li>
+                        <li>Worked example (instructor-led, not built by learners): a 6-stage / 2-environment promotion pipeline showing what production CI/CD architecture looks like</li>
+                        <li>Pair coding: refactor a single-job workflow into two dependent jobs using `needs:`</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Deployment Strategies</div>
+                    <div class="lesson-heading">Lesson: 5: Secrets, Environments, and Environment Protection (1h)</div>
                     <ul class="topic-list">
-                        <li>Blue-green and canary deployments</li>
-                        <li>Rolling updates</li>
+                        <li>Repository secrets vs organization secrets vs environment-scoped secrets (OJL 3b)</li>
+                        <li>Configuring a GitHub Environment with required reviewers</li>
+                        <li>Deployment branches and tag-based gating</li>
+                        <li>OIDC for cloud-credential-less deployment (overview)</li>
+                        <li>Individual: configure a `staging` environment with one secret and one required reviewer</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Release Management</div>
+                    <div class="lesson-heading">Lesson: 6: Monitoring and Feedback Loops (1h)</div>
                     <ul class="topic-list">
-                        <li>Versioning and rollback</li>
+                        <li>Workflow run statuses and surfacing them in the repo</li>
+                        <li>Status badges in the README</li>
+                        <li>Required checks on PRs and merge gating</li>
+                        <li>Failure notifications: GitHub email, third-party (Slack/PagerDuty) overview</li>
+                        <li>Pipeline observability — what to log, what to time</li>
+                        <li>Individual: add a status badge to a repo README and configure required-check enforcement on the default branch</li>
                     </ul>
                 </div>
             </div>
@@ -397,35 +449,31 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">3</span>
-                    <span class="module-title">CI/CD Tools and Implementation</span>
-                    <span class="module-hours">3 hours</span>
+                    <span class="module-title">Automated testing and deployment</span>
+                    <span class="module-hours">4 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Tool Exploration</div>
+                    <div class="lesson-heading">Lesson: 7: Deployment Strategies (1.25h)</div>
                     <ul class="topic-list">
-                        <li>Jenkins, GitLab CI, GitHub Actions</li>
-                        <li>Tool comparison</li>
+                        <li>Blue-green deployments — what, when, the tradeoffs (OJL 3b)</li>
+                        <li>Canary releases — gradual rollout, observation windows</li>
+                        <li>Rolling updates — load-balancer-driven node replacement</li>
+                        <li>How each strategy is expressed in a GitHub Actions workflow</li>
+                        <li>~20-minute in-lesson activity: short write-up choosing one strategy for a given scenario, with rationale</li>
+                        <li>Individual write-up (in-lesson): "Given a small SaaS product with 2 production app servers, which deployment strategy would you recommend, and why?"</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Hands-On Pipeline Creation</div>
+                    <div class="lesson-heading">Lesson: 8: Release Management (1.25h)</div>
                     <ul class="topic-list">
-                        <li>Building automated pipelines</li>
-                        <li>Integration and troubleshooting</li>
+                        <li>Semantic versioning (MAJOR.MINOR.PATCH) and what bumps what (OJL 3b)</li>
+                        <li>Tagging releases and the relationship between tags and pipelines</li>
+                        <li>Auto-generated release notes</li>
+                        <li>Rollback strategies — the previous-tag pattern, blue-green flip</li>
+                        <li>Post-deployment verification — smoke tests, health checks</li>
+                        <li>Pair coding: tag a release, observe the tag-triggered workflow run, then perform a tag-based rollback</li>
                     </ul>
                 </div>
             </div>
 
-        </section>
-
-        <hr class="divider">
-
-        <section>
-            <h2><i class="fa-solid fa-laptop-code"></i> Labs &amp; Practical Exercises</h2>
-            <ul class="labs-list">
-                <li>Git workflow exercises with branching and merging</li>
-                <li>Setting up automated testing within a build pipeline</li>
-                <li>Configuring a CI/CD tool (Jenkins, GitLab CI, or GitHub Actions)</li>
-                <li>Capstone: Design and implement a complete CI/CD pipeline for a sample project</li>
-            </ul>
         </section>
 
     </div>

--- a/syllabi/data-literacy.html
+++ b/syllabi/data-literacy.html
@@ -308,7 +308,6 @@ code {
     <div class="page">
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
-        <div class="review-banner"><i class="fa-solid fa-triangle-exclamation"></i> This syllabus is auto-generated and needs review</div>
         <div class="header">
             <h1>Syllabus: Data Fundamentals — Data Literacy</h1>
             <div class="header-meta">
@@ -406,7 +405,7 @@ code {
                         <li>Types of cognitive bias in analysis</li>
                         <li>How human thinking affects data interpretation</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Statistical Bias</div>
+                    <div class="lesson-heading">Lesson: Statistical Biases</div>
                     <ul class="topic-list">
                         <li>Systematic errors in data collection and analysis</li>
                         <li>Mitigating statistical bias</li>

--- a/syllabi/infrastructure-as-code.html
+++ b/syllabi/infrastructure-as-code.html
@@ -311,9 +311,9 @@ code {
         <div class="header">
             <h1>Syllabus: Infrastructure as Code Fundamentals</h1>
             <div class="header-meta">
-                <span><i class="fa-solid fa-layer-group"></i> Operations Support Specialist — Network</span>
+                <span><i class="fa-solid fa-layer-group"></i> Operations Support Specialist — Network (course 12)</span>
                 <span><i class="fa-regular fa-clock"></i> 22 hours</span>
-                <span class="badge">DRAFT</span>
+                <span class="badge">CURRENT</span>
             </div>
         </div>
         <section>
@@ -324,25 +324,90 @@ code {
         <hr class="divider">
 
         <section>
-            <h2><i class="fa-solid fa-trophy"></i> Summative Assessment: Multi-Environment Infrastructure Project</h2>
-            <div class="assessment-box">
-                <p>Learners will design and implement a complete infrastructure deployment using Terraform and Ansible across multiple environments. The assessment evaluates understanding of IaC concepts, proficiency with major tools, ability to design modular and maintainable infrastructure, and integration with CI/CD practices. Learners will document their infrastructure, demonstrate deployments, and explain design decisions.</p>
-            </div>
-        </section>
-
-        <hr class="divider">
-
-        <section>
             <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
             <ol class="outcomes">
-                <li>Explain the principles, benefits, and paradigms of Infrastructure as Code</li>
-                <li>Write and manage Terraform configurations for cloud provisioning</li>
-                <li>Manage state, modules, and variables in Terraform projects</li>
-                <li>Create and manage Ansible playbooks for configuration management</li>
-                <li>Implement infrastructure deployments on AWS, Azure, and Google Cloud</li>
-                <li>Apply testing and validation strategies to infrastructure code</li>
-                <li>Integrate infrastructure code into CI/CD pipelines</li>
-                <li>Detect and remediate configuration drift in managed infrastructure</li>
+                <li>Describe the pre-IaC operations world and the failure modes that motivated IaC.</li>
+                <li>Define Infrastructure as Code and state its four defining properties.</li>
+                <li>Distinguish provisioning, configuration management, and orchestration as categories of automation.</li>
+                <li>Explain where IaC sits in the broader DevOps lifecycle relative to CI/CD.</li>
+                <li>Identify the major tools in the IaC market and the niche each occupies.</li>
+                <li>Distinguish declarative and imperative approaches to automation with concrete code examples.</li>
+                <li>Define idempotency and explain why it matters for safe re-runs.</li>
+                <li>Describe what IaC state is, why a tool needs it, and the failure modes when it is lost or corrupted.</li>
+                <li>Explain configuration drift and how IaC tools detect it.</li>
+                <li>Read a basic execution plan and identify what an IaC tool intends to create, change, or destroy.</li>
+                <li>Explain why infrastructure code belongs in Git the same as application code.</li>
+                <li>Identify the entries that must appear in an IaC `.gitignore` and why each is excluded.</li>
+                <li>Describe what makes reviewing an IaC PR different from reviewing application code.</li>
+                <li>Install the Terraform CLI and verify the installation with `terraform version`.</li>
+                <li>Explain the provider concept and configure the AWS (or LocalStack) provider in a `.tf` file.</li>
+                <li>Author a `.tf` file that declares a single S3 bucket resource.</li>
+                <li>Execute the four-command Terraform workflow — `init`, `plan`, `apply`, `destroy` — against a real or local cloud.</li>
+                <li>Read `terraform plan` output and identify the meaning of `+`, `-`, and `~` symbols.</li>
+                <li>Identify the major HCL block types (`resource`, `variable`, `output`, `locals`, `data`) and the role of each.</li>
+                <li>Declare an input variable with a default value, type constraint, and description.</li>
+                <li>Declare an output value that surfaces a resource attribute after apply.</li>
+                <li>Use a `locals` block to compute reusable values inside a configuration.</li>
+                <li>State the variable precedence order across environment variables, `.tfvars` files, and CLI flags.</li>
+                <li>Recognize implicit dependencies that arise from resource references in expressions.</li>
+                <li>Declare an explicit dependency using `depends_on` and explain when it is needed.</li>
+                <li>Describe Terraform's dependency graph and what `terraform graph` output represents at a high level.</li>
+                <li>Apply `count` and `for_each` to provision multiple similar resources from a single block.</li>
+                <li>Diagnose a multi-resource configuration where dependencies are declared incorrectly or missing.</li>
+                <li>Explain what Terraform state is, what it contains, and why Terraform requires it.</li>
+                <li>Describe the limits of local state and the failure modes that motivate remote state for team work.</li>
+                <li>Configure a Terraform S3 backend with a DynamoDB lock table for remote state.</li>
+                <li>Explain how Terraform state locking prevents concurrent applies and recover from a stuck lock with `terraform force-unlock`.</li>
+                <li>Read and interpret state with `terraform show` and `terraform state list`.</li>
+                <li>Use `terraform state mv` and `terraform state rm` and explain when each is appropriate.</li>
+                <li>Identify how sensitive data leaks through state and apply mitigations (`sensitive = true`, backend encryption).</li>
+                <li>Define a Terraform module and explain how composition reduces duplication and clarifies infrastructure design.</li>
+                <li>Author a local module with the standard folder layout (`main.tf`, `variables.tf`, `outputs.tf`).</li>
+                <li>Call a module from a root configuration using `source`, `version`, and input arguments.</li>
+                <li>Find, evaluate, and use a community module from the Terraform Registry.</li>
+                <li>Apply module versioning conventions (semver pinning vs floating).</li>
+                <li>Decide when to make a module vs when to inline resources, recognizing the over-modularization anti-pattern.</li>
+                <li>Describe the typical branching strategy for Terraform PRs and how it differs from app-code branching.</li>
+                <li>Configure a CI workflow that runs `terraform plan` on a PR and posts the plan output as a PR comment.</li>
+                <li>Explain apply gates: who approves an apply, when, and against which environment.</li>
+                <li>Compare Terraform workspaces against directory-per-environment as strategies for managing multiple environments.</li>
+                <li>Describe drift detection as a scheduled-CI activity and what to do when drift is found.</li>
+                <li>Diagnose broken or missing Terraform state and choose an appropriate recovery path.</li>
+                <li>Recognize a `terraform plan` that contains destructive operations and refuse to apply it without escalation.</li>
+                <li>Identify dependency-induced destroy-and-recreate operations from plan output and explain why they happen.</li>
+                <li>Use `terraform refresh`, `terraform state list`, and `terraform state show` as a diagnostic toolkit.</li>
+                <li>Apply recovery moves: `terraform import` for rebuilding state, `terraform force-unlock` for stuck locks.</li>
+                <li>Distinguish provisioning and configuration management as categories of automation work.</li>
+                <li>Explain the "build immutable, configure mutable" philosophy at a survey level.</li>
+                <li>Identify when Terraform alone is sufficient and when configuration management adds value.</li>
+                <li>Describe where an OSS-Network apprentice is most likely to encounter Ansible on the job.</li>
+                <li>Describe Ansible's agentless model and the requirements it places on managed targets.</li>
+                <li>Identify the structure of a playbook: plays, tasks, modules, and handlers.</li>
+                <li>Differentiate static and dynamic inventory and explain when each is used.</li>
+                <li>Recognize idempotency in action by interpreting Ansible run output across repeated runs.</li>
+                <li>Describe a common Terraform + Ansible integration pattern.</li>
+                <li>Explain why hardcoded secrets in `.tf` files (and Git history) are a recurring breach vector.</li>
+                <li>Use environment variables and the `TF_VAR_` prefix to inject secrets into Terraform without committing them.</li>
+                <li>Identify the major vendor-native secret stores and their role in IaC workflows.</li>
+                <li>Mark variables and outputs as `sensitive` and explain what that does and does not protect.</li>
+                <li>Describe how state files become a secrets-leak vector and the mitigations.</li>
+                <li>Compare Terraform with CloudFormation, ARM/Bicep, and GCP Deployment Manager at a survey level.</li>
+                <li>Identify which cloud resource types incur cost even when idle, and estimate the cost meters for a small stack.</li>
+                <li>Explain the IaC-specific cost risk: easy to provision means easy to forget.</li>
+                <li>Apply `terraform destroy` as a first-class workflow operation, including handling failed-apply orphans.</li>
+                <li>Apply a cost-attribution tagging strategy (`Owner`, `Environment`, `CostCenter`, `AutoStop`) consistently across resources.</li>
+                <li>Describe where AWS Cost Explorer and Cost Allocation Tags fit in the IaC workflow.</li>
+                <li>Apply an IaC PR review checklist that distinguishes IaC review from app-code review.</li>
+                <li>Configure `terraform fmt` and `terraform validate` as pre-commit gates.</li>
+                <li>Describe `tflint` and policy-as-code (OPA / Sentinel) at a survey level.</li>
+                <li>Document a Terraform module using the README convention and `terraform-docs`.</li>
+                <li>Apply plan-output discipline when reviewing changes — recognizing when a "small" plan is actually a big change.</li>
+                <li>Author a Terraform configuration that provisions a working two-tier web stack via a single `terraform apply`.</li>
+                <li>Document the architecture in a README that explains the resource, network, and IAM choices behind the configuration.</li>
+                <li>Explain a `terraform plan` output in prose, identifying changing resources and the meaning of action symbols.</li>
+                <li>Diagnose and recover from at least two embedded failure scenarios drawn from L10 (broken state, destructive plan, stuck state lock).</li>
+                <li>Inventory the cost meters in the stack and execute a clean `terraform destroy` with no orphaned resources.</li>
+                <li>Reflect in writing on what could go wrong with the same stack in a long-lived production environment.</li>
             </ol>
         </section>
 
@@ -354,24 +419,35 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">1</span>
-                    <span class="module-title">Infrastructure as Code Principles and Concepts</span>
-                    <span class="module-hours">4 hours</span>
+                    <span class="module-title">Infrastructure as Code fundamentals</span>
+                    <span class="module-hours">3 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: What is Infrastructure as Code?</div>
+                    <div class="lesson-heading">Lesson: 1: What Is Infrastructure as Code? (1h)</div>
                     <ul class="topic-list">
-                        <li>IaC benefits and concepts</li>
-                        <li>Declarative vs. imperative</li>
+                        <li>The pre-IaC world: ClickOps, snowflake servers, configuration drift</li>
+                        <li>IaC definition and the four properties learners will hear repeatedly: declarative, idempotent, version-controlled, reproducible</li>
+                        <li>Provisioning vs. configuration management vs. orchestration — a vocabulary map</li>
+                        <li>Where IaC lives in the broader DevOps lifecycle (relationship to CI/CD from Course 11)</li>
+                        <li>The IaC market overview: Terraform, CloudFormation, Pulumi, Ansible, Bicep — what each is for</li>
+                        <li>Individual reading + discussion: a short pre-IaC vs. post-IaC scenario; learners identify the failure modes IaC eliminates</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: IaC Tools and Paradigms</div>
+                    <div class="lesson-heading">Lesson: 2: Declarative vs. Imperative, State, and Idempotency (1.5h)</div>
                     <ul class="topic-list">
-                        <li>Tool categories and selection</li>
-                        <li>Terraform, Ansible, CloudFormation, Pulumi</li>
+                        <li>Declarative ("what I want") vs. imperative ("how to get there") — concrete code comparisons</li>
+                        <li>Idempotency: the same code applied N times produces the same end state</li>
+                        <li>State: why an IaC tool needs to know what it created, and the failure modes when state is lost or corrupted</li>
+                        <li>Drift: when the real world diverges from the declared state</li>
+                        <li>Reading an execution plan before applying it (`terraform plan` preview, no install yet)</li>
+                        <li>Pair discussion: given three sample shell scripts and three sample Terraform snippets, classify each as declarative or imperative and explain why</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Best Practices</div>
+                    <div class="lesson-heading">Lesson: 3: Version Control for IaC — A Tour (0.5h)</div>
                     <ul class="topic-list">
-                        <li>Code organization</li>
-                        <li>GitOps principles</li>
+                        <li>Why infrastructure code lives in Git the same way application code does</li>
+                        <li>The IaC `.gitignore` essentials: state files, lockfiles, credentials, `.terraform/` directories</li>
+                        <li>What's different about reviewing IaC PRs vs. application-code PRs (state-affecting changes, blast radius, secrets) — brief tour, deeper PR-review treatment lands in M4 L13</li>
+                        <li>Repo layout patterns at a glance: monorepo vs. per-environment vs. per-component</li>
+                        <li>Quick demo + Q&amp;A: instructor shows the recommended IaC `.gitignore` and walks through one "what would you flag in this PR?" example</li>
                     </ul>
                 </div>
             </div>
@@ -379,29 +455,76 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">2</span>
-                    <span class="module-title">Terraform Fundamentals</span>
-                    <span class="module-hours">5 hours</span>
+                    <span class="module-title">Terraform fundamentals</span>
+                    <span class="module-hours">11 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Terraform Syntax and Providers</div>
+                    <div class="lesson-heading">Lesson: 4: Terraform Setup and First Resource (1.5h)</div>
                     <ul class="topic-list">
-                        <li>HCL structure</li>
-                        <li>Resource definition</li>
+                        <li>Installing the Terraform CLI; verifying with `terraform version` (OJL 3d)</li>
+                        <li>Provider concept and the AWS (or LocalStack) provider block</li>
+                        <li>Authoring a first `.tf` file: a single S3 bucket</li>
+                        <li>The Terraform workflow: `init`, `plan`, `apply`, `destroy`</li>
+                        <li>Reading the plan output and what each `+`, `-`, `~` symbol means</li>
+                        <li>Code-along: provision and destroy a single S3 bucket end-to-end; commit the `.tf` file but not the state</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: State Management</div>
+                    <div class="lesson-heading">Lesson: 5: HCL Syntax — Variables, Outputs, and Locals (1.5h)</div>
                     <ul class="topic-list">
-                        <li>State concept and backends</li>
-                        <li>Remote state handling</li>
+                        <li>HCL block structure: `resource`, `variable`, `output`, `locals`, `data` (OJL 3d)</li>
+                        <li>Input variables: declaration, default values, type constraints, `terraform.tfvars` files</li>
+                        <li>Output values: surfacing IDs, ARNs, and URLs after apply</li>
+                        <li>Locals: computed values used inside the configuration</li>
+                        <li>Variable precedence: env vars vs. tfvars vs. CLI flags</li>
+                        <li>Pair coding: parameterize the L4 bucket using a variable for `bucket_name` and an output for the bucket ARN</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Modules and Reusability</div>
+                    <div class="lesson-heading">Lesson: 6: Multiple Resources and Resource Dependencies (1.5h)</div>
                     <ul class="topic-list">
-                        <li>Creating modules</li>
-                        <li>Module composition</li>
+                        <li>Implicit dependencies (resource references in expressions) (OJL 3d)</li>
+                        <li>Explicit dependencies with `depends_on`</li>
+                        <li>The dependency graph; reading `terraform graph` output at a high level</li>
+                        <li>Worked example: an EC2 instance that depends on a security group that depends on a VPC reference</li>
+                        <li>`count` and `for_each` for creating sets of similar resources</li>
+                        <li>Individual: extend the L5 bucket configuration with a second bucket and an IAM policy that grants read on both, demonstrating implicit dependencies</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Variables and Outputs</div>
+                    <div class="lesson-heading">Lesson: 7: Terraform State (2h)</div>
                     <ul class="topic-list">
-                        <li>Input validation</li>
-                        <li>Environment management</li>
+                        <li>What state is and why Terraform needs it (OJL 3d)</li>
+                        <li>Local state (`terraform.tfstate`) — the default and its limits</li>
+                        <li>Remote state with an S3 backend + DynamoDB lock table</li>
+                        <li>State locking: what happens when two engineers run `apply` simultaneously</li>
+                        <li>Reading state with `terraform show` and `terraform state list`</li>
+                        <li>State surgery basics: `terraform state mv` and `terraform state rm` — what they do and when they're needed</li>
+                        <li>Sensitive data in state: never commit, mark outputs `sensitive = true`</li>
+                        <li>Code-along: migrate a project from local state to a remote S3 backend with locking, then trigger a deliberate lock conflict in a paired session</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 8: Modules — Reusable Terraform Components (2h)</div>
+                    <ul class="topic-list">
+                        <li>The module concept: composing infrastructure from parameterized building blocks (OJL 3d)</li>
+                        <li>Authoring a local module: required folder layout, `variables.tf`, `outputs.tf`, `main.tf`</li>
+                        <li>Calling a module: `source`, `version`, passing inputs, reading outputs</li>
+                        <li>The Terraform Registry: finding and using community modules; reading module docs</li>
+                        <li>Versioning modules; pinning vs. floating versions</li>
+                        <li>When to make a module vs. when to inline (the over-modularization anti-pattern)</li>
+                        <li>Individual: refactor the L6 multi-resource configuration into a `web-bucket` local module with two inputs and two outputs, then consume it from a root configuration</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 9: The Terraform Workflow in a Team Setting (1.5h)</div>
+                    <ul class="topic-list">
+                        <li>Branching strategy for IaC PRs (OJL 3d)</li>
+                        <li>Running `plan` in CI and posting the plan to a PR comment</li>
+                        <li>Apply gates: who pushes the button, when, and against which environment</li>
+                        <li>Workspaces (and why most teams use directory-per-environment instead)</li>
+                        <li>Drift detection: scheduled `plan` runs that flag uncommitted changes in the real world</li>
+                        <li>Pair coding: open a PR that changes the bucket configuration; another learner reviews the `plan` output and either approves or requests changes</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 10: Failure Modes and Debugging IaC (1h)</div>
+                    <ul class="topic-list">
+                        <li>The scenarios that distinguish supporting IaC in production from running `terraform apply` on the happy path (OJL 3d)</li>
+                        <li>Broken or missing Terraform state: lost state file, accidental deletion, state drift after out-of-band changes</li>
+                        <li>Incorrect dependencies that trigger destroy-and-recreate: when a small attribute change destroys a resource the team expected to be modified in place</li>
+                        <li>Reading a risky `terraform plan`: recognizing destructive changes, refusing to apply, escalating</li>
+                        <li>Diagnosing through `terraform plan`, `terraform refresh`, `terraform state list`, `terraform state show`</li>
+                        <li>Recovery moves: `terraform import` to rebuild state for an existing resource, releasing a stuck state lock, walking back a misapply</li>
+                        <li>Guided lab: instructor presents three broken-state scenarios (missing state file, attribute change that would destroy a database, stuck lock); learners diagnose each, explain in writing what would happen if they applied as-is, and execute the recovery</li>
                     </ul>
                 </div>
             </div>
@@ -409,24 +532,27 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">3</span>
-                    <span class="module-title">Configuration Management with Ansible</span>
-                    <span class="module-hours">4 hours</span>
+                    <span class="module-title">Configuration management with Ansible — concept + demo</span>
+                    <span class="module-hours">2 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Ansible Fundamentals</div>
+                    <div class="lesson-heading">Lesson: 11: Provisioning vs. Configuration Management (1h)</div>
                     <ul class="topic-list">
-                        <li>Playbooks and YAML</li>
-                        <li>Inventory management</li>
+                        <li>Provisioning (Terraform) vs. configuration management (Ansible, Chef, Puppet) — the distinction and where the boundary blurs</li>
+                        <li>The "build immutable, configure mutable" debate at a survey level</li>
+                        <li>When Terraform alone is enough; when Ansible adds value (post-provision software install, in-place patching)</li>
+                        <li>Why this distinction matters in modern IaC and on the OSS-Network apprentice's most likely encounters with Ansible on the job</li>
+                        <li>Group discussion: given three real-world infrastructure tasks, identify which is provisioning, which is configuration, and which is both</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Modules and Tasks</div>
+                    <div class="lesson-heading">Lesson: 12: Ansible at a Glance — Guided Demo (1h)</div>
                     <ul class="topic-list">
-                        <li>Common modules</li>
-                        <li>Handlers and conditionals</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Advanced Playbooks</div>
-                    <ul class="topic-list">
-                        <li>Roles and organization</li>
-                        <li>Template engine</li>
+                        <li>Instructor-led guided demo; students observe and ask questions, no individual hands-on</li>
+                        <li>Ansible's agentless model: SSH + Python on the target</li>
+                        <li>YAML and the playbook structure: plays, tasks, modules, handlers</li>
+                        <li>Inventory files: static vs. dynamic</li>
+                        <li>Walkthrough of a 3-task playbook against an EC2 target: install nginx, write a config file, start the service — narrating idempotency at each step</li>
+                        <li>When to glue Terraform + Ansible together vs. picking one</li>
+                        <li>Observation + Q&amp;A during the demo; learners record one question and one observation in their notes for later cohort discussion</li>
                     </ul>
                 </div>
             </div>
@@ -434,66 +560,42 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">4</span>
-                    <span class="module-title">Cloud-Specific IaC</span>
-                    <span class="module-hours">5 hours</span>
+                    <span class="module-title">Best practices for production-ready IaC</span>
+                    <span class="module-hours">3 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: AWS CloudFormation</div>
+                    <div class="lesson-heading">Lesson: 13: Secrets, Sensitive Data, and Cloud-Native IaC at a Glance (1h)</div>
                     <ul class="topic-list">
-                        <li>Template syntax</li>
-                        <li>Stacks and resources</li>
+                        <li>Why hardcoded secrets in `.tf` files (and Git history) are a recurring breach vector (OJL 3d)</li>
+                        <li>Environment variables and `TF_VAR_` prefix</li>
+                        <li>Vendor-native secret stores: AWS Secrets Manager, Azure Key Vault, HashiCorp Vault overview</li>
+                        <li>Sensitive variables and outputs (`sensitive = true`)</li>
+                        <li>State file as a secrets-leak vector — encryption at rest, access control on the backend bucket</li>
+                        <li>Brief landscape comparison (≈10 min): how CloudFormation, ARM/Bicep, and GCP DM handle the same secrets problem; when a team would deliberately choose a vendor-native tool over Terraform</li>
+                        <li>Individual: refactor a sample `.tf` file that contains a hardcoded password to read from a `TF_VAR_db_password` environment variable, and mark the corresponding output `sensitive`</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Azure and Google Cloud IaC</div>
+                    <div class="lesson-heading">Lesson: 14: Cost Awareness and Cleanup Discipline (1h)</div>
                     <ul class="topic-list">
-                        <li>ARM templates</li>
-                        <li>Multi-cloud considerations</li>
+                        <li>Cloud resources cost money even when "idle" — EC2 sitting at 0% CPU, RDS instances overnight, NAT gateways, NLBs, EIPs, unattached EBS volumes</li>
+                        <li>The IaC-specific risk: easy to provision means easy to forget — and forgotten infrastructure is billed forever</li>
+                        <li>`terraform destroy` as a first-class workflow operation, not an afterthought</li>
+                        <li>Avoiding orphaned resources from failed applies (resources created before the apply errored out)</li>
+                        <li>Tagging strategies for cost attribution: `Owner`, `Environment`, `CostCenter`, `AutoStop` patterns</li>
+                        <li>Where AWS Cost Explorer and Cost Allocation Tags fit in the IaC workflow</li>
+                        <li>Lab: provision a small Terraform stack (an EC2 instance plus an EBS volume plus an EIP), use AWS Pricing Calculator (or a provided rate sheet) to identify the cost meters, run `terraform destroy`, then verify in the AWS console that all three resources are gone — including the EIP, which often outlives an apply error</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Terraform for Multi-Cloud</div>
+                    <div class="lesson-heading">Lesson: 15: IaC Code Review, Testing, and Documentation (1h)</div>
                     <ul class="topic-list">
-                        <li>Multi-cloud provisioning</li>
-                        <li>CI/CD integration</li>
+                        <li>The IaC PR review checklist: what reviewers look for that's different from app-code review (OJL 3d)</li>
+                        <li>`terraform fmt` and `terraform validate` as pre-commit gates</li>
+                        <li>`tflint` and policy-as-code (OPA / Sentinel) at a survey level</li>
+                        <li>Documenting modules: the README convention (`terraform-docs` overview)</li>
+                        <li>Plan-output discipline: when a "small" plan is actually a big change (callback to L10 failure modes)</li>
+                        <li>Pair: review another learner's PR from L9 using a provided checklist; submit one approve/request-changes review with at least two specific comments</li>
                     </ul>
                 </div>
             </div>
 
-            <div class="module">
-                <div class="module-head">
-                    <span class="module-num">5</span>
-                    <span class="module-title">IaC Workflow and Operations</span>
-                    <span class="module-hours">4 hours</span>
-                </div>
-                <div class="module-body">
-                    <div class="lesson-heading">Lesson: Testing and Validation</div>
-                    <ul class="topic-list">
-                        <li>Static analysis and policy as code</li>
-                        <li>Integration testing</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: CI/CD for Infrastructure</div>
-                    <ul class="topic-list">
-                        <li>Pipeline design</li>
-                        <li>Automated testing and approval workflows</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Drift Detection and Operations</div>
-                    <ul class="topic-list">
-                        <li>Configuration drift detection</li>
-                        <li>Monitoring and remediation</li>
-                    </ul>
-                </div>
-            </div>
-
-        </section>
-
-        <hr class="divider">
-
-        <section>
-            <h2><i class="fa-solid fa-laptop-code"></i> Labs &amp; Practical Exercises</h2>
-            <ul class="labs-list">
-                <li>Setting up Terraform configurations and state management</li>
-                <li>Creating and deploying Ansible playbooks across multiple hosts</li>
-                <li>Building infrastructure on AWS, Azure, and Google Cloud</li>
-                <li>Implementing IaC testing with tflint and Sentinel</li>
-                <li>Capstone: Design and deploy a multi-environment infrastructure project with CI/CD integration</li>
-            </ul>
         </section>
 
     </div>

--- a/syllabi/productivity-tools-reporting.html
+++ b/syllabi/productivity-tools-reporting.html
@@ -313,7 +313,7 @@ code {
             <div class="header-meta">
                 <span><i class="fa-solid fa-layer-group"></i> Operations Support Specialist — Network</span>
                 <span><i class="fa-regular fa-clock"></i> 4 hours</span>
-                <span class="badge">DRAFT</span>
+                <span class="badge">CURRENT</span>
             </div>
         </div>
         <section>
@@ -324,9 +324,17 @@ code {
         <hr class="divider">
 
         <section>
-            <h2><i class="fa-solid fa-trophy"></i> Summative Assessment: Technical Report Project</h2>
+            <h2><i class="fa-solid fa-trophy"></i> Summative Assessment</h2>
             <div class="assessment-box">
-                <p>Learners will create an operational analysis project that includes an Excel dashboard analyzing relevant technical metrics and a PowerPoint presentation communicating findings and recommendations to stakeholders. The assessment evaluates ability to organize data, create effective visualizations, and communicate technical information clearly.</p>
+                <p>The summative assessment is integrated across the last activity in each module. No separate assessment hour is allocated.</p>
+                <p>Capstone deliverable:</p>
+                <p>1. An Excel workbook analyzing a provided operational dataset (incident log or capacity metrics) with at least one pivot table and one dashboard view</p>
+                <p>2. A 5–7 slide PowerPoint briefing that explains the findings and recommends an action</p>
+                <p>Evaluation rubric:</p>
+                <p>- Data handling: accuracy, appropriate formulas, clear structure</p>
+                <p>- Visualization: chart-type fit, readability, honesty (no misleading axes/scales)</p>
+                <p>- Presentation: logical structure, audience-appropriate depth, professional design</p>
+                <p>- Communication: clarity of recommendation, supporting evidence, Q&amp;A preparedness</p>
             </div>
         </section>
 
@@ -335,12 +343,27 @@ code {
         <section>
             <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
             <ol class="outcomes">
-                <li>Organize and analyze technical data effectively in Excel</li>
-                <li>Create formulas and calculations for operational metrics</li>
-                <li>Design dashboards that visualize key performance indicators</li>
-                <li>Structure technical presentations for diverse audiences</li>
-                <li>Create visual diagrams and flowcharts to clarify complex concepts</li>
-                <li>Present data-driven recommendations professionally</li>
+                <li>Organize operational data in Excel using appropriate worksheet structure, naming, and data types</li>
+                <li>Apply data validation and cleanup techniques to prepare raw operational exports for analysis</li>
+                <li>Use Excel formulas to calculate common technical metrics (MTTR, uptime %, ticket counts by severity)</li>
+                <li>Use Excel Tables and structured references to build spreadsheets that stay correct as data grows</li>
+                <li>Apply sorting, filtering, and conditional formatting to surface anomalies in operational data</li>
+                <li>Select the appropriate chart type for a given data-communication goal (comparison, trend, composition, distribution)</li>
+                <li>Create pivot tables and pivot charts to summarize operational data</li>
+                <li>Build a one-page operational dashboard combining KPI summaries, trends, and status indicators</li>
+                <li>Use conditional formatting as a lightweight visualization technique (heat maps, data bars, icon sets)</li>
+                <li>Export Excel charts and dashboards for use in documentation and presentations</li>
+                <li>Identify and fix misleading visualizations (truncated axes, chart-type mismatch, 3D distortion)</li>
+                <li>Structure a technical presentation using the problem → evidence → options → recommendation pattern</li>
+                <li>Apply slide design best practices (layout, hierarchy, typography, contrast) to improve readability</li>
+                <li>Use PowerPoint layouts, master slides, and themes to enforce consistency across a deck</li>
+                <li>Create technical diagrams (network topology, flow diagrams, architecture blocks) using shapes and SmartArt</li>
+                <li>Embed Excel charts and tables into slides without losing fidelity or linking incorrectly</li>
+                <li>Frame a set of findings as a data story tied to the audience's decision</li>
+                <li>Annotate charts and visuals to direct audience attention to the key takeaway</li>
+                <li>Adapt the same technical findings for different audiences (executive summary vs technical deep-dive)</li>
+                <li>Prepare for and handle Q&amp;A, including defending claims with data and capturing follow-ups</li>
+                <li>Use PowerPoint presenter tools (speaker notes, rehearse with timing, basic accessibility settings)</li>
             </ol>
         </section>
 
@@ -356,15 +379,27 @@ code {
                     <span class="module-hours">2 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Data Management and Analysis</div>
+                    <div class="lesson-heading">Lesson: 1: Data Management and Analysis in Excel (1h)</div>
                     <ul class="topic-list">
-                        <li>Spreadsheet design</li>
-                        <li>Technical metrics and formulas</li>
+                        <li>Spreadsheet design and organization for technical data (naming conventions, worksheet structure, data ranges)</li>
+                        <li>Data entry, validation, and cleanup (removing duplicates, handling missing values, data types)</li>
+                        <li>Formulas and functions for technical metrics (SUM, AVERAGE, COUNTIF, SUMIF, IF, VLOOKUP/XLOOKUP)</li>
+                        <li>Tables and structured references for maintainable spreadsheets</li>
+                        <li>Sorting, filtering, and conditional formatting to surface anomalies</li>
+                        <li>Common operational data sources: log exports, ticketing reports, monitoring CSVs</li>
+                        <li>Clean a provided log-export CSV and produce a sortable incident table</li>
+                        <li>Build a small KPI calculator (MTTR, uptime %, ticket volume by severity) from sample operations data</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Data Visualization</div>
+                    <div class="lesson-heading">Lesson: 2: Data Visualization and Operational Dashboards (1h)</div>
                     <ul class="topic-list">
-                        <li>Charts and dashboards</li>
-                        <li>KPI visualization</li>
+                        <li>Chart types and when to use them (column, bar, line, pie, scatter) — data visualization</li>
+                        <li>Pivot tables and pivot charts for summarizing technical data</li>
+                        <li>Building an operational dashboard: KPI tiles, trend lines, status indicators</li>
+                        <li>Conditional formatting for visual health checks (heat maps, data bars, icon sets)</li>
+                        <li>Exporting charts and dashboards for inclusion in presentations and documentation</li>
+                        <li>Avoiding misleading visualizations (truncated axes, 3D distortion, chart-type mismatch)</li>
+                        <li>Convert a flat KPI table into a pivot-driven dashboard with at least three visual elements</li>
+                        <li>Critique a set of sample charts and justify one fix per chart</li>
                     </ul>
                 </div>
             </div>
@@ -376,31 +411,31 @@ code {
                     <span class="module-hours">2 hours</span>
                 </div>
                 <div class="module-body">
-                    <div class="lesson-heading">Lesson: Presentation Design</div>
+                    <div class="lesson-heading">Lesson: 3: Presentation Design Principles (1h)</div>
                     <ul class="topic-list">
-                        <li>Structure and visual design</li>
-                        <li>Technical diagrams</li>
+                        <li>Structuring a technical presentation: problem → evidence → options → recommendation</li>
+                        <li>Slide design best practices: consistent layout, hierarchy, readable typography, contrast</li>
+                        <li>Using PowerPoint layouts, master slides, and themes for consistency</li>
+                        <li>Creating technical diagrams: network topology, architecture blocks, flow diagrams, sequence steps</li>
+                        <li>SmartArt and shape-based diagrams for process flows, runbook visualizations, and escalation paths</li>
+                        <li>Embedding and formatting Excel charts/tables inside slides without losing fidelity</li>
+                        <li>Rebuild a dense text-heavy slide into a structured, visual slide following design principles</li>
+                        <li>Create a network/system diagram for a provided operational scenario using shapes or SmartArt</li>
                     </ul>
-                    <div class="lesson-heading">Lesson: Presenting Data</div>
+                    <div class="lesson-heading">Lesson: 4: Presenting Data and Recommendations (1h)</div>
                     <ul class="topic-list">
-                        <li>Data visualization in presentations</li>
-                        <li>Communicating recommendations</li>
+                        <li>Telling a data story: framing findings around the audience's decision</li>
+                        <li>Choosing the right chart for the message (comparison, trend, distribution, composition)</li>
+                        <li>Annotating charts to direct attention (callouts, highlights, plain-language takeaways)</li>
+                        <li>Preparing for different audiences: executive summary vs technical deep-dive</li>
+                        <li>Handling Q&amp;A: backing up claims with data, admitting limits, capturing follow-ups</li>
+                        <li>Presenter tools: notes, rehearse-with-timing, and basic accessibility (alt text, contrast, reading order)</li>
+                        <li>Deliver a 5-minute technical briefing (incident review or capacity report) using a provided dataset</li>
+                        <li>Peer feedback on clarity, structure, and visual effectiveness</li>
                     </ul>
                 </div>
             </div>
 
-        </section>
-
-        <hr class="divider">
-
-        <section>
-            <h2><i class="fa-solid fa-laptop-code"></i> Labs &amp; Practical Exercises</h2>
-            <ul class="labs-list">
-                <li>Creating operational dashboards from sample data</li>
-                <li>Designing technical diagrams in PowerPoint</li>
-                <li>Presenting findings to technical and non-technical audiences</li>
-                <li>Capstone: Develop and present comprehensive technical report with dashboard and presentation</li>
-            </ul>
         </section>
 
     </div>


### PR DESCRIPTION
## Summary

Tracking updates for AI-Assisted CI/CD Pipelines onboarding (Row 5: Content Scaffolding Phase 0+1). References apprenti-org/design-documentation#532.

- Add `ai-assisted-cicd-pipelines` to `courses.json`: 2h, 1 module, 2 lessons, Software Developer (JVFD), design Complete / development In Progress
- Add `outlines/ai-assisted-cicd-pipelines.json` with module/lesson structure
- Add `syllabi/ai-assisted-cicd-pipelines.html` (generated from Phase 0 syllabus)
- Add syllabiMap entry in `js/shared/constants.js`
- Update `outlines/manifest.json` (new entry, re-sorted by course display name)
- Regenerate `courses.js`, `outlines.js`, `course-overview.js/json`
- Regenerate affected syllabi (cicd-pipeline-concepts, data-literacy, infrastructure-as-code, java-language-fundamentals, productivity-tools-reporting)
- **Also includes:** ai-assisted-coding-fundamentals `statusConfirmed → true`, note updated to reflect LMS upload complete (design-doc #486)

Course details:
- **Module 1:** AI-Assisted CI/CD Pipelines (2h)
  - Lesson 1: CI/CD Concepts and Generating Workflows with AI (1h)
  - Lesson 2: Building a Spring Application Pipeline with GitHub Actions (1h)
- RTI/OJL alignment deferred (JVFD curriculum design folder not yet created)

Meta: apprenti-org/design-documentation#525

## Test plan

- [ ] `ai-assisted-cicd-pipelines` appears in dashboard sidebar
- [ ] Course shows 2h, design Complete, development In Progress
- [ ] Syllabus link opens `syllabi/ai-assisted-cicd-pipelines.html`
- [ ] Outline view shows Module 1 with 2 lessons
- [ ] `AI-Assisted Coding Fundamentals` shows `statusConfirmed: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)