### PR TITLE
feat(ai-assisted-cicd-pipelines): development status Complete — Row 7

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -206,7 +206,7 @@ var courseOverviewData = [
     "totalAssets": 0,
     "deployment": {
       "state": "Not Deployed",
-      "expected": 0,
+      "expected": 2,
       "actual": 0
     }
   },

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-18T11:17:18",
+  "generated": "2026-05-18T13:53:49",
   "courseCount": 71,
   "courses": [
     {
@@ -208,7 +208,7 @@
       "totalAssets": 0,
       "deployment": {
         "state": "Not Deployed",
-        "expected": 0,
+        "expected": 2,
         "actual": 0
       }
     },

--- a/courses.js
+++ b/courses.js
@@ -80,11 +80,11 @@ const courseData = [
     "hours": 2,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
     "outline": true,
-    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content scaffolding in progress (Phase 0 + 1 complete, Row 5 of onboarding — meta #525). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content production complete through Row 7 (meta #525). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
     "driveFolder": null,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation",
     "statusConfirmed": false

--- a/courses.json
+++ b/courses.json
@@ -78,11 +78,11 @@
       "hours": 2,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
       "outline": true,
-      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content scaffolding in progress (Phase 0 + 1 complete, Row 5 of onboarding \u2014 meta #525). RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content production complete through Row 7 (meta #525). RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": false


### PR DESCRIPTION
## Summary

- Flips `status.development` from `"In Progress"` to `"Complete"` for `ai-assisted-cicd-pipelines`
- Updates `note` field to reflect Row 7 content production completion
- Rebuilds `courses.js` and `course-overview.js` bundles

## What's complete (Rows 6–7)

**Row 6 (Code Migration):** Four Spring Boot Maven project variants authored — student + instructor trees for `temperature-converter` (Lesson 2 code-along) and `order-status-checker` (lab assessment). V1–V8 verification pass. Staging trees in `deploy/repo-student-ai-assisted-cicd-pipelines/` and `deploy/repo-instructor-ai-assisted-cicd-pipelines/`. Closed design-doc #535.

**Row 7 (Content Production):** Both lessons have complete instructor-guide.md (timing, CSQs, facilitation tips), quiz.md (5 questions each: 3 MC/1 MS/1 TF), and interactive.html (17-slide HTML deck with dark/light theme and knowledge checks). design-doc #549.

## Pending rows

Rows 8–12: Slide Deck Production → SCORM → Deployment → Starter Asset Audit → LMS Upload

Tracking: meta #525 in `apprenti-org/design-documentation`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)