### PR TITLE
chore(ai-assisted-cicd-pipelines): update note + flip statusConfirmed true

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -186,28 +186,28 @@ var courseOverviewData = [
     },
     "syllabus": true,
     "source": {
-      "exists": false,
-      "folder": null,
-      "modules": 0
+      "exists": true,
+      "folder": "ai-assisted-cicd-pipelines/deploy/content",
+      "modules": 1
     },
-    "coverage": 0,
-    "lessonsWithContent": 0,
+    "coverage": 67,
+    "lessonsWithContent": 2,
     "assets": {
-      "lessons": 0,
-      "slides": 0,
-      "quizzes": 0,
+      "lessons": 2,
+      "slides": 2,
+      "quizzes": 2,
       "activities": 0,
       "demos": 0,
       "caseStudies": 0,
-      "instructorGuides": 0,
+      "instructorGuides": 2,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0,
+    "totalAssets": 8,
     "deployment": {
-      "state": "Not Deployed",
+      "state": "Complete",
       "expected": 2,
-      "actual": 0
+      "actual": 2
     }
   },
   {
@@ -2386,33 +2386,33 @@ var courseOverviewData = [
     "hours": 4,
     "outline": {
       "exists": true,
-      "modules": 3,
-      "lessons": 5
+      "modules": 2,
+      "lessons": 4
     },
     "syllabus": true,
     "source": {
-      "exists": false,
-      "folder": null,
-      "modules": 0
+      "exists": true,
+      "folder": "technical-documentation/deploy/content",
+      "modules": 2
     },
     "coverage": 0,
     "lessonsWithContent": 0,
     "assets": {
-      "lessons": 0,
-      "slides": 0,
-      "quizzes": 0,
-      "activities": 0,
+      "lessons": 4,
+      "slides": 4,
+      "quizzes": 4,
+      "activities": 4,
       "demos": 0,
       "caseStudies": 0,
-      "instructorGuides": 0,
+      "instructorGuides": 4,
       "modIntros": 0,
       "modRecaps": 0
     },
-    "totalAssets": 0,
+    "totalAssets": 20,
     "deployment": {
-      "state": "Not Deployed",
-      "expected": 0,
-      "actual": 0
+      "state": "Complete",
+      "expected": 4,
+      "actual": 4
     }
   },
   {

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-18T13:53:49",
+  "generated": "2026-05-19T10:06:56",
   "courseCount": 71,
   "courses": [
     {
@@ -188,28 +188,28 @@
       },
       "syllabus": true,
       "source": {
-        "exists": false,
-        "folder": null,
-        "modules": 0
+        "exists": true,
+        "folder": "ai-assisted-cicd-pipelines/deploy/content",
+        "modules": 1
       },
-      "coverage": 0,
-      "lessonsWithContent": 0,
+      "coverage": 67,
+      "lessonsWithContent": 2,
       "assets": {
-        "lessons": 0,
-        "slides": 0,
-        "quizzes": 0,
+        "lessons": 2,
+        "slides": 2,
+        "quizzes": 2,
         "activities": 0,
         "demos": 0,
         "caseStudies": 0,
-        "instructorGuides": 0,
+        "instructorGuides": 2,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0,
+      "totalAssets": 8,
       "deployment": {
-        "state": "Not Deployed",
+        "state": "Complete",
         "expected": 2,
-        "actual": 0
+        "actual": 2
       }
     },
     {
@@ -2388,33 +2388,33 @@
       "hours": 4,
       "outline": {
         "exists": true,
-        "modules": 3,
-        "lessons": 5
+        "modules": 2,
+        "lessons": 4
       },
       "syllabus": true,
       "source": {
-        "exists": false,
-        "folder": null,
-        "modules": 0
+        "exists": true,
+        "folder": "technical-documentation/deploy/content",
+        "modules": 2
       },
       "coverage": 0,
       "lessonsWithContent": 0,
       "assets": {
-        "lessons": 0,
-        "slides": 0,
-        "quizzes": 0,
-        "activities": 0,
+        "lessons": 4,
+        "slides": 4,
+        "quizzes": 4,
+        "activities": 4,
         "demos": 0,
         "caseStudies": 0,
-        "instructorGuides": 0,
+        "instructorGuides": 4,
         "modIntros": 0,
         "modRecaps": 0
       },
-      "totalAssets": 0,
+      "totalAssets": 20,
       "deployment": {
-        "state": "Not Deployed",
-        "expected": 0,
-        "actual": 0
+        "state": "Complete",
+        "expected": 4,
+        "actual": 4
       }
     },
     {

--- a/courses.js
+++ b/courses.js
@@ -84,10 +84,10 @@ const courseData = [
     },
     "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
     "outline": true,
-    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content production complete through Row 7 (meta #525). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Rows 2–11 complete (meta #525); Row 12 LMS Upload open (#602). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
     "driveFolder": null,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation",
-    "statusConfirmed": false
+    "statusConfirmed": true
   },
   {
     "id": "ai-assisted-coding-fundamentals",

--- a/courses.json
+++ b/courses.json
@@ -82,10 +82,10 @@
       },
       "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
       "outline": true,
-      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Content production complete through Row 7 (meta #525). RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Rows 2\u201311 complete (meta #525); Row 12 LMS Upload open (#602). RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
-      "statusConfirmed": false
+      "statusConfirmed": true
     },
     {
       "id": "ai-assisted-coding-fundamentals",


### PR DESCRIPTION
## Summary

- Updates `note` field: was stale at "through Row 7"; now reflects rows 2–11 complete with Row 12 LMS Upload open (`design-documentation#602`)
- Flips `statusConfirmed: true`
- Regenerates `courses.js` and `course-overview.js/json`

## Context

Part of onboarding closure for `ai-assisted-cicd-pipelines` (meta `design-documentation#525`). All production rows are complete; LMS Upload (#602) is the only remaining step. `statusConfirmed` was the last tracking-side item outstanding before the LMS upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)