### PR TITLE
chore(ai-assisted-cicd-pipelines): mark live in Absorb 2026-05-19

### DIFF
--- a/course-overview.json
+++ b/course-overview.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-19T10:06:56",
+  "generated": "2026-05-19T10:10:42",
   "courseCount": 71,
   "courses": [
     {

--- a/courses.js
+++ b/courses.js
@@ -84,7 +84,7 @@ const courseData = [
     },
     "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
     "outline": true,
-    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Rows 2–11 complete (meta #525); Row 12 LMS Upload open (#602). RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
+    "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Live in Absorb LMS 2026-05-19. RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
     "driveFolder": null,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation",
     "statusConfirmed": true

--- a/courses.json
+++ b/courses.json
@@ -82,7 +82,7 @@
       },
       "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
       "outline": true,
-      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Rows 2\u201311 complete (meta #525); Row 12 LMS Upload open (#602). RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Live in Absorb LMS 2026-05-19. RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true


### PR DESCRIPTION
## Summary

- Updates `note` to reflect course is live in Absorb LMS as of 2026-05-19
- Removes in-progress row tracking reference from the note field
- Regenerates `courses.js` and `course-overview.js/json`

All onboarding rows complete. Meta-issue `apprenti-org/design-documentation#525` closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)