### PR TITLE
chore(technical-documentation): flip status to Complete — shipped to Absorb 2026-05-19 (#145)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -973,14 +973,15 @@ const courseData = [
     "name": "Technical Documentation",
     "hours": 4,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "Complete"
     },
     "syllabus": null,
-    "outline": null,
-    "note": "OSS Course 15, Area 4 — net-new microcourse covering technical documentation standards. 4h. Active dev pipeline — design work beginning soon. Audit confirms Not Started baseline (per #87).",
+    "outline": true,
+    "note": "Net-new 4h course for OSS Course 15, Area 4 (Security & Professional Skills). 2 modules, 4 lessons: Documentation Types and Purposes; Writing Clear and Audience-Appropriate Documentation; Runbooks and Troubleshooting Guides; Knowledge Management and Maintenance. Live in Absorb 2026-05-19 (4 SCORM 1.2 packages + 26 PDFs deployed; course published to learner catalog). Onboarding meta apprenti-org/design-documentation#561 closed. Slide decks (Row 8) deferred under apprenti-org/design-documentation#604 → #606 (slide-spec rework); course shipped without slides.",
     "driveFolder": null,
-    "statusConfirmed": true
+    "statusConfirmed": true,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
   },
   {
     "id": "troubleshooting-supporting-in-an-enterprise-environment",

--- a/courses.json
+++ b/courses.json
@@ -971,14 +971,15 @@
       "name": "Technical Documentation",
       "hours": 4,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "Complete"
       },
       "syllabus": null,
-      "outline": null,
-      "note": "OSS Course 15, Area 4 \u2014 net-new microcourse covering technical documentation standards. 4h. Active dev pipeline \u2014 design work beginning soon. Audit confirms Not Started baseline (per #87).",
+      "outline": true,
+      "note": "Net-new 4h course for OSS Course 15, Area 4 (Security & Professional Skills). 2 modules, 4 lessons: Documentation Types and Purposes; Writing Clear and Audience-Appropriate Documentation; Runbooks and Troubleshooting Guides; Knowledge Management and Maintenance. Live in Absorb 2026-05-19 (4 SCORM 1.2 packages + 26 PDFs deployed; course published to learner catalog). Onboarding meta apprenti-org/design-documentation#561 closed. Slide decks (Row 8) deferred under apprenti-org/design-documentation#604 \u2192 #606 (slide-spec rework); course shipped without slides.",
       "driveFolder": null,
-      "statusConfirmed": true
+      "statusConfirmed": true,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {
       "id": "troubleshooting-supporting-in-an-enterprise-environment",


### PR DESCRIPTION
## Summary

Closes #145. Updates the `technical-documentation` entry in `courses.json` to reflect the shipped state. Live in Absorb 2026-05-19 with 4 SCORM 1.2 packages + 26 PDFs deployed.

## Changes

`courses.json` (technical-documentation entry):

| Field | Before | After |
|---|---|---|
| `status.design` | `Not Started` | `Complete` |
| `status.development` | `Not Started` | `Complete` |
| `outline` | `null` | `true` |
| `sourceRepo` | (absent) | `https://github.com/apprenti-org/design-documentation` |
| `note` | Pre-build baseline | Shipped note (4h / 2 modules / 4 lessons / live 2026-05-19 / onboarding meta + slide-deck status referenced) |

`courses.js` regenerated via `node build.js` (one-line diff; matches the JSON change).

## Why no outline JSON?

Following the recent `ai-assisted-cicd-pipelines` precedent (`outline: true` without a backing JSON file). Outline JSON authoring is a separate housekeeping pass if needed; not gating this status update.

## Context

The original audit baseline (#87, PR #91 under META #63) ran 2026-04-26 before the course was built. The audit confirmed "Not Started" as accurate baseline at that time. Course was then built across:

- Content production (rows 7): apprenti-org/design-documentation #591, #596, #598, #600 — all merged
- SCORM packaging (row 9): apprenti-org/design-documentation #607 — closed
- Deployment (row 10): apprenti-org/design-documentation #609 — closed (PR #610 merged)
- LMS upload (row 12): completed 2026-05-19 by mvanderpool

Onboarding META (apprenti-org/design-documentation#561) closed 2026-05-19 with full row-status summary.

## Test plan

- [x] `courses.json` validates via `node build.js` (no errors)
- [x] `courses.js` regenerated and matches JSON
- [x] Dashboard render check: tech-doc should now appear with green "Complete" status in both design and development columns