### PR TITLE
feat(ai-assisted-meeting-facilitation): add to tracking

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -246,6 +246,41 @@ var courseOverviewData = [
     }
   },
   {
+    "id": "ai-assisted-meeting-facilitation",
+    "name": "AI-Assisted Meeting Facilitation",
+    "hours": 1,
+    "outline": {
+      "exists": true,
+      "modules": 2,
+      "lessons": 3
+    },
+    "syllabus": true,
+    "source": {
+      "exists": false,
+      "folder": null,
+      "modules": 0
+    },
+    "coverage": 0,
+    "lessonsWithContent": 0,
+    "assets": {
+      "lessons": 0,
+      "slides": 0,
+      "quizzes": 0,
+      "activities": 0,
+      "demos": 0,
+      "caseStudies": 0,
+      "instructorGuides": 0,
+      "modIntros": 0,
+      "modRecaps": 0
+    },
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Complete",
+      "expected": 0,
+      "actual": 0
+    }
+  },
+  {
     "id": "ai-assisted-test-driven-development",
     "name": "AI-Assisted Test Driven Development",
     "hours": 2,
@@ -1919,6 +1954,41 @@ var courseOverviewData = [
       "modRecaps": 0
     },
     "totalAssets": 42,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
+  },
+  {
+    "id": "oss-capstone",
+    "name": "OSS Capstone — Ops Incident Simulation",
+    "hours": 40,
+    "outline": {
+      "exists": false,
+      "modules": 0,
+      "lessons": 0
+    },
+    "syllabus": false,
+    "source": {
+      "exists": false,
+      "folder": null,
+      "modules": 0
+    },
+    "coverage": null,
+    "lessonsWithContent": 0,
+    "assets": {
+      "lessons": 0,
+      "slides": 0,
+      "quizzes": 0,
+      "activities": 0,
+      "demos": 0,
+      "caseStudies": 0,
+      "instructorGuides": 0,
+      "modIntros": 0,
+      "modRecaps": 0
+    },
+    "totalAssets": 0,
     "deployment": {
       "state": "Not Deployed",
       "expected": 0,

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-05-20T09:35:04",
-  "courseCount": 72,
+  "generated": "2026-05-21T08:59:55",
+  "courseCount": 74,
   "courses": [
     {
       "id": "aba-banking-foundations",
@@ -245,6 +245,41 @@
         "state": "Complete",
         "expected": 3,
         "actual": 3
+      }
+    },
+    {
+      "id": "ai-assisted-meeting-facilitation",
+      "name": "AI-Assisted Meeting Facilitation",
+      "hours": 1,
+      "outline": {
+        "exists": true,
+        "modules": 2,
+        "lessons": 3
+      },
+      "syllabus": true,
+      "source": {
+        "exists": false,
+        "folder": null,
+        "modules": 0
+      },
+      "coverage": 0,
+      "lessonsWithContent": 0,
+      "assets": {
+        "lessons": 0,
+        "slides": 0,
+        "quizzes": 0,
+        "activities": 0,
+        "demos": 0,
+        "caseStudies": 0,
+        "instructorGuides": 0,
+        "modIntros": 0,
+        "modRecaps": 0
+      },
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Complete",
+        "expected": 0,
+        "actual": 0
       }
     },
     {
@@ -1921,6 +1956,41 @@
         "modRecaps": 0
       },
       "totalAssets": 42,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
+      }
+    },
+    {
+      "id": "oss-capstone",
+      "name": "OSS Capstone \u2014 Ops Incident Simulation",
+      "hours": 40,
+      "outline": {
+        "exists": false,
+        "modules": 0,
+        "lessons": 0
+      },
+      "syllabus": false,
+      "source": {
+        "exists": false,
+        "folder": null,
+        "modules": 0
+      },
+      "coverage": null,
+      "lessonsWithContent": 0,
+      "assets": {
+        "lessons": 0,
+        "slides": 0,
+        "quizzes": 0,
+        "activities": 0,
+        "demos": 0,
+        "caseStudies": 0,
+        "instructorGuides": 0,
+        "modIntros": 0,
+        "modRecaps": 0
+      },
+      "totalAssets": 0,
       "deployment": {
         "state": "Not Deployed",
         "expected": 0,

--- a/courses.js
+++ b/courses.js
@@ -104,6 +104,21 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "ai-assisted-meeting-facilitation",
+    "name": "AI-Assisted Meeting Facilitation",
+    "hours": 1,
+    "status": {
+      "design": "Complete",
+      "development": "Complete"
+    },
+    "syllabus": "syllabi/ai-assisted-meeting-facilitation.html",
+    "outline": true,
+    "note": "Net-new 1h course. 1 module, 2 lessons: Summarizing and Extracting Insights from Transcripts (0.5h); Generating Structured Follow-Up Communication with AI (0.5h). Quiz + SCORM interactive per lesson. No code activities.",
+    "driveFolder": null,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+    "statusConfirmed": true
+  },
+  {
     "id": "ai-assisted-test-driven-development",
     "name": "AI-Assisted Test Driven Development",
     "hours": 2,

--- a/courses.json
+++ b/courses.json
@@ -102,6 +102,21 @@
       "statusConfirmed": true
     },
     {
+      "id": "ai-assisted-meeting-facilitation",
+      "name": "AI-Assisted Meeting Facilitation",
+      "hours": 1,
+      "status": {
+        "design": "Complete",
+        "development": "Complete"
+      },
+      "syllabus": "syllabi/ai-assisted-meeting-facilitation.html",
+      "outline": true,
+      "note": "Net-new 1h course. 1 module, 2 lessons: Summarizing and Extracting Insights from Transcripts (0.5h); Generating Structured Follow-Up Communication with AI (0.5h). Quiz + SCORM interactive per lesson. No code activities.",
+      "driveFolder": null,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation",
+      "statusConfirmed": true
+    },
+    {
       "id": "ai-assisted-test-driven-development",
       "name": "AI-Assisted Test Driven Development",
       "hours": 2,

--- a/js/shared/constants.js
+++ b/js/shared/constants.js
@@ -37,6 +37,7 @@ var syllabiMap = {
     'AI-Assisted CI/CD Pipelines': 'ai-assisted-cicd-pipelines.html',
     'AI-Assisted Coding Fundamentals': 'ai-assisted-coding-fundamentals.html',
     'AI-Assisted Learning and Study Skills': 'ai-assisted-learning-and-study-skills.html',
+    'AI-Assisted Meeting Facilitation': 'ai-assisted-meeting-facilitation.html',
     'AI-Assisted Test Driven Development': 'ai-assisted-test-driven-development.html',
     'AI-Assisted User Communication and Documentation': 'ai-assisted-user-communication-and-documentation.html',
     'AI-Driven Specifications: The Blueprint Method': 'ai-driven-specifications.html',

--- a/outlines/ai-assisted-meeting-facilitation.json
+++ b/outlines/ai-assisted-meeting-facilitation.json
@@ -1,0 +1,44 @@
+{
+  "course": "AI-Assisted Meeting Facilitation",
+  "totalHours": 1,
+  "totalModules": 1,
+  "totalLessons": 2,
+  "modules": [
+    {
+      "name": "AI-Assisted Meeting Facilitation",
+      "hours": 1,
+      "lessons": [
+        {
+          "title": "Summarizing and Extracting Insights from Transcripts",
+          "hours": 0.5,
+          "topics": [
+            "**Why unstructured communication is hard to process manually (8 min)**",
+            "**Prompt design for summarization (10 min)**",
+            "**Distinguishing confirmed facts from assumptions (9 min)**",
+            "**Wrap-Up and Reflection (3 min)**"
+          ],
+          "objects": [
+            "Object: Lesson: Summarizing and Extracting Insights from Transcripts",
+            "Assessment: Quiz: Summarizing and Extracting Insights from Transcripts",
+            "SCORM: scorm-lesson-01-summarizing-and-extracting-insights-from-transcripts.zip"
+          ]
+        },
+        {
+          "title": "Generating Structured Follow-Up Communication with AI",
+          "hours": 0.5,
+          "topics": [
+            "**Common post-meeting artifacts and their prompt requirements (9 min)**",
+            "**Prompt design for structured professional output (9 min)**",
+            "**Responsible use and human review (9 min)**",
+            "**Wrap-Up and Reflection (3 min)**"
+          ],
+          "objects": [
+            "Object: Lesson: Generating Structured Follow-Up Communication with AI",
+            "Assessment: Quiz: Generating Structured Follow-Up Communication with AI",
+            "SCORM: scorm-lesson-02-generating-structured-follow-up-communication-with-ai.zip"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -30,6 +30,11 @@
     "id": "ai-assisted-coding-fundamentals"
   },
   {
+    "file": "ai-assisted-meeting-facilitation.json",
+    "course": "AI-Assisted Meeting Facilitation",
+    "id": "ai-assisted-meeting-facilitation"
+  },
+  {
     "file": "ai-assisted-test-driven-development.json",
     "course": "AI-Assisted Test Driven Development",
     "id": "ai-assisted-test-driven-development"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -939,6 +939,50 @@ const courseOutlines = {
       }
     ]
   },
+  "AI-Assisted Meeting Facilitation": {
+    "course": "AI-Assisted Meeting Facilitation",
+    "totalHours": 1,
+    "totalModules": 1,
+    "totalLessons": 2,
+    "modules": [
+      {
+        "name": "AI-Assisted Meeting Facilitation",
+        "hours": 1,
+        "lessons": [
+          {
+            "title": "Summarizing and Extracting Insights from Transcripts",
+            "hours": 0.5,
+            "topics": [
+              "**Why unstructured communication is hard to process manually (8 min)**",
+              "**Prompt design for summarization (10 min)**",
+              "**Distinguishing confirmed facts from assumptions (9 min)**",
+              "**Wrap-Up and Reflection (3 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: Summarizing and Extracting Insights from Transcripts",
+              "Assessment: Quiz: Summarizing and Extracting Insights from Transcripts",
+              "SCORM: scorm-lesson-01-summarizing-and-extracting-insights-from-transcripts.zip"
+            ]
+          },
+          {
+            "title": "Generating Structured Follow-Up Communication with AI",
+            "hours": 0.5,
+            "topics": [
+              "**Common post-meeting artifacts and their prompt requirements (9 min)**",
+              "**Prompt design for structured professional output (9 min)**",
+              "**Responsible use and human review (9 min)**",
+              "**Wrap-Up and Reflection (3 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: Generating Structured Follow-Up Communication with AI",
+              "Assessment: Quiz: Generating Structured Follow-Up Communication with AI",
+              "SCORM: scorm-lesson-02-generating-structured-follow-up-communication-with-ai.zip"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "AI-Assisted Test Driven Development": {
     "course": "AI-Assisted Test Driven Development",
     "totalHours": 2,

--- a/syllabi/ai-assisted-meeting-facilitation.html
+++ b/syllabi/ai-assisted-meeting-facilitation.html
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Syllabus: AI-Assisted Meeting Facilitation</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+:root[data-theme="dark"] {
+    --bg: #111117;
+    --surface: #1A1B23;
+    --surface-raised: #22232D;
+    --border: #2E2F3A;
+    --border-subtle: #23242E;
+    --text-primary: #F0F0EC;
+    --text-secondary: #C8C9CE;
+    --text-muted: #8B8D98;
+    --sky-blue: #8ECAE6;
+    --blue-green: #219EBC;
+    --deep-space: #023047;
+    --amber: #FFB703;
+    --tiger: #FB8500;
+    --link: #219EBC;
+    --link-hover: #8ECAE6;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+.page {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px 32px 120px;
+}
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--link);
+    text-decoration: none;
+    font-size: 13px;
+    margin-bottom: 24px;
+}
+.back-link:hover { color: var(--link-hover); }
+.header {
+    margin-bottom: 32px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+}
+.header h1 {
+    font-size: 26px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.header-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+.header-meta span {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: rgba(255, 183, 3, 0.12);
+    color: var(--amber);
+}
+section { margin-bottom: 32px; }
+section h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+section h2 i { opacity: 0.6; font-size: 15px; }
+p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+}
+.divider {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: 28px 0;
+}
+.outcomes {
+    list-style: none;
+    counter-reset: outcome;
+}
+.outcomes li {
+    counter-increment: outcome;
+    font-size: 14px;
+    color: var(--text-secondary);
+    padding: 6px 0;
+    display: flex;
+    gap: 10px;
+}
+.outcomes li::before {
+    content: counter(outcome) ".";
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 24px;
+    text-align: right;
+}
+.module {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    margin-bottom: 12px;
+    overflow: hidden;
+}
+.module-head {
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.module-num {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 20px;
+}
+.module-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    flex: 1;
+}
+.module-hours {
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+.module-body {
+    padding: 0 16px 14px;
+    border-top: 1px solid var(--border-subtle);
+}
+.lesson-heading {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 12px 0 6px;
+}
+.topic-list {
+    list-style: none;
+    padding-left: 12px;
+}
+.topic-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.topic-list li::before {
+    content: "\2022";
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.activities {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: var(--surface-raised);
+    border-radius: 6px;
+}
+.activities-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+.activities ul {
+    list-style: none;
+    padding: 0;
+}
+.activities li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+.activities li::before {
+    content: "\f0eb";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 400;
+    font-size: 10px;
+    color: var(--amber);
+    flex-shrink: 0;
+}
+.assessment-box {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 16px;
+}
+.assessment-box p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+.assessment-box ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 8px;
+}
+.assessment-box li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.assessment-box li::before {
+    content: "\f00c";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: #3fb950;
+}
+.software-list {
+    list-style: none;
+    padding: 0;
+}
+.software-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.software-list li::before {
+    content: "\f019";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--text-muted);
+}
+.labs-list {
+    list-style: none;
+    padding: 0;
+}
+.labs-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.labs-list li::before {
+    content: "\f120";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--sky-blue);
+}
+code {
+    background: var(--surface-raised);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+    color: var(--sky-blue);
+}
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
+    </style>
+</head>
+<body>
+    <div class="page">
+        <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
+
+        <div class="header">
+            <h1>Syllabus: AI-Assisted Meeting Facilitation</h1>
+            <div class="header-meta">
+                <span><i class="fa-solid fa-layer-group"></i> Software Developer (JVFD)</span>
+                <span><i class="fa-regular fa-clock"></i> 1 hours</span>
+                <span class="badge">CURRENT</span>
+            </div>
+        </div>
+        <section>
+            <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
+            <p>Course description pending.</p>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
+            <ol class="outcomes">
+                <li>Identify types of unstructured communication artifacts (call transcripts, chat logs) that benefit from AI-assisted summarization in a professional context.</li>
+                <li>Construct summarization prompts that extract key decisions, action items, and open questions from a meeting transcript.</li>
+                <li>Apply fact-extraction techniques to distinguish confirmed information from assumptions in unstructured meeting records.</li>
+                <li>Design structured prompts that translate raw meeting notes into formatted professional output (follow-up emails, action item lists, decision logs).</li>
+                <li>Evaluate AI-generated communication materials for accuracy, completeness, and appropriate professional tone before distributing them.</li>
+                <li>Apply responsible use principles when using generative AI for ideation and professional communication in a workplace context.</li>
+            </ol>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-sitemap"></i> Course Outline</h2>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">1</span>
+                    <span class="module-title">AI-Assisted Meeting Facilitation</span>
+                    <span class="module-hours">1 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 1: Summarizing and Extracting Insights from Transcripts (0.5h)</div>
+                    <ul class="topic-list">
+                        <li>Why unstructured communication is hard to process manually (8 min)</li>
+                        <li>Prompt design for summarization (10 min)</li>
+                        <li>Distinguishing confirmed facts from assumptions (9 min)</li>
+                        <li>Wrap-Up and Reflection (3 min)</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 2: Generating Structured Follow-Up Communication with AI (0.5h)</div>
+                    <ul class="topic-list">
+                        <li>Common post-meeting artifacts and their prompt requirements (9 min)</li>
+                        <li>Prompt design for structured professional output (9 min)</li>
+                        <li>Responsible use and human review (9 min)</li>
+                        <li>Wrap-Up and Reflection (3 min)</li>
+                    </ul>
+                </div>
+            </div>
+
+        </section>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add `courses.json` entry: 1h, `status.design: Complete`, `status.development: Complete`, `statusConfirmed: true`
- Add `outlines/ai-assisted-meeting-facilitation.json` with SCORM zip entries for both lessons
- Add `outlines/manifest.json` entry (sorted after `ai-assisted-coding-fundamentals`)
- Add `syllabi/ai-assisted-meeting-facilitation.html`
- Update `js/shared/constants.js` syllabiMap with AI-Assisted Meeting Facilitation entry
- Rebuild `courses.js`, `outlines/outlines.js`, `course-overview.js` bundles via `node build.js`

Pre-upload reconciliation validator passed 7/7 checks (READY). Fixes were:
- R2: `courses.json` entry missing → added
- R3: SCORM zip entries absent from outlines JSON → added with filename format
- R4: Syllabus HTML missing → generated via convert-syllabi.js
- R5 (validator bug fix in design-doc repo): r5-bundles.js was looking for `outlines.js` at repo root; it lives at `outlines/outlines.js` — fixed in the validator
- R2 (validator bug fix): r2-courses-json.js looked up by `c.slug` only; courses.json uses `c.id` — fixed to also check `c.id`

**Refs:** apprenti-org/design-documentation#676 (Pre-Upload Reconciliation sub-issue)
**Meta:** apprenti-org/design-documentation#648 (Row 12 of onboarding chain)

## Test plan

- [ ] `node build.js` ran clean (only 6 legacy-name-ref warnings, all pre-existing)
- [ ] Validator exits 0: `node tools/content-dev/reconcile/check-deploy-tree.js --course-slug=ai-assisted-meeting-facilitation` → READY (7/7)
- [ ] ai-assisted-meeting-facilitation appears in dashboard sidebar
- [ ] Syllabus link opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)