### PR TITLE
feat(705): add AI-Assisted IT Service Management to tracking dashboard

### DIFF
--- a/course-overview.js
+++ b/course-overview.js
@@ -246,6 +246,41 @@ var courseOverviewData = [
     }
   },
   {
+    "id": "ai-assisted-it-service-management",
+    "name": "AI-Assisted IT Service Management",
+    "hours": 4,
+    "outline": {
+      "exists": true,
+      "modules": 2,
+      "lessons": 5
+    },
+    "syllabus": true,
+    "source": {
+      "exists": false,
+      "folder": null,
+      "modules": 0
+    },
+    "coverage": 0,
+    "lessonsWithContent": 0,
+    "assets": {
+      "lessons": 0,
+      "slides": 0,
+      "quizzes": 0,
+      "activities": 0,
+      "demos": 0,
+      "caseStudies": 0,
+      "instructorGuides": 0,
+      "modIntros": 0,
+      "modRecaps": 0
+    },
+    "totalAssets": 0,
+    "deployment": {
+      "state": "Not Deployed",
+      "expected": 0,
+      "actual": 0
+    }
+  },
+  {
     "id": "ai-assisted-meeting-facilitation",
     "name": "AI-Assisted Meeting Facilitation",
     "hours": 1,

--- a/course-overview.json
+++ b/course-overview.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-05-27T11:54:54",
-  "courseCount": 74,
+  "generated": "2026-05-27T14:38:41",
+  "courseCount": 75,
   "courses": [
     {
       "id": "aba-banking-foundations",
@@ -245,6 +245,41 @@
         "state": "Complete",
         "expected": 3,
         "actual": 3
+      }
+    },
+    {
+      "id": "ai-assisted-it-service-management",
+      "name": "AI-Assisted IT Service Management",
+      "hours": 4,
+      "outline": {
+        "exists": true,
+        "modules": 2,
+        "lessons": 5
+      },
+      "syllabus": true,
+      "source": {
+        "exists": false,
+        "folder": null,
+        "modules": 0
+      },
+      "coverage": 0,
+      "lessonsWithContent": 0,
+      "assets": {
+        "lessons": 0,
+        "slides": 0,
+        "quizzes": 0,
+        "activities": 0,
+        "demos": 0,
+        "caseStudies": 0,
+        "instructorGuides": 0,
+        "modIntros": 0,
+        "modRecaps": 0
+      },
+      "totalAssets": 0,
+      "deployment": {
+        "state": "Not Deployed",
+        "expected": 0,
+        "actual": 0
       }
     },
     {

--- a/courses.js
+++ b/courses.js
@@ -104,6 +104,21 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "ai-assisted-it-service-management",
+    "name": "AI-Assisted IT Service Management",
+    "hours": 4,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Net-new 4h supplemental course for OSS Course 14 (above 560h RTI minimum). 1 module, 4 lessons: AI Tools for ITSM evaluation; Prompt Design for Ticket Triage and Acknowledgment; Generating Structured Resolution Summaries and Querying Historical Notes; Simplifying Complex Technical Documents with AI. OJL 5.c, 5.d. Onboarding meta apprenti-org/design-documentation#696.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "ai-assisted-meeting-facilitation",
     "name": "AI-Assisted Meeting Facilitation",
     "hours": 1,

--- a/courses.json
+++ b/courses.json
@@ -12,7 +12,7 @@
       "provider": "American Bankers Association",
       "syllabus": null,
       "outline": null,
-      "note": "External provider (American Bankers Association). Course details TBD \u2014 hours, syllabus URL, and RTI area coverage to be confirmed.",
+      "note": "External provider (American Bankers Association). Course details TBD — hours, syllabus URL, and RTI area coverage to be confirmed.",
       "driveFolder": null,
       "statusConfirmed": false
     },
@@ -26,7 +26,7 @@
       },
       "syllabus": "Syllabus: Advanced Python",
       "outline": "Course Outline: Advanced Python",
-      "note": "Outline and syllabus complete \u2014 awaiting manual review",
+      "note": "Outline and syllabus complete — awaiting manual review",
       "driveFolder": "https://drive.google.com/drive/folders/1-O-rT_oqlgdo1Qsz-7M0_p0MTblMTJ6v",
       "statusConfirmed": false
     },
@@ -40,7 +40,7 @@
       },
       "syllabus": "Syllabus: Agile Project Management with Scrum",
       "outline": "Course Outline: Agile Project Management with Scrum",
-      "note": "Outline and syllabus complete \u2014 awaiting manual review",
+      "note": "Outline and syllabus complete — awaiting manual review",
       "driveFolder": "https://drive.google.com/drive/folders/1roPHpPQD1LvTGz1xvWtbv-U-XFqr4VBo",
       "statusConfirmed": false
     },
@@ -82,7 +82,7 @@
       },
       "syllabus": "syllabi/ai-assisted-cicd-pipelines.html",
       "outline": true,
-      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Live in Absorb LMS 2026-05-19. RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: CI/CD Concepts and Generating Workflows with AI (1h); Building a Spring Application Pipeline with GitHub Actions (1h). GitHub Actions, Spring Boot TemperatureConverter, red/green build cycle, AI-assisted workflow YAML generation and build log interpretation. Live in Absorb LMS 2026-05-19. RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -97,9 +97,24 @@
       },
       "syllabus": "syllabi/ai-assisted-coding-fundamentals.html",
       "outline": true,
-      "note": "Net-new 4h course for Software Developer (JVFD). 2 modules, 4 lessons: Your First AI-Assisted Program (1h), Prompting AI Effectively for Code (1h), Debugging and Refactoring with AI (1h), Reviewing AI-Generated Code for Security and Accuracy (1h). All 12 onboarding rows complete: content production (#476), SCORM packaging (#478), deployment (#479), starter asset audit (#480), LMS upload (#486). Student repo: apprenti-org/ai-assisted-coding-fundamentals-student. RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 4h course for Software Developer (JVFD). 2 modules, 4 lessons: Your First AI-Assisted Program (1h), Prompting AI Effectively for Code (1h), Debugging and Refactoring with AI (1h), Reviewing AI-Generated Code for Security and Accuracy (1h). All 12 onboarding rows complete: content production (#476), SCORM packaging (#478), deployment (#479), starter asset audit (#480), LMS upload (#486). Student repo: apprenti-org/ai-assisted-coding-fundamentals-student. RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "statusConfirmed": true
+    },
+    {
+      "id": "ai-assisted-it-service-management",
+      "name": "AI-Assisted IT Service Management",
+      "hours": 4,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Net-new 4h supplemental course for OSS Course 14 (above 560h RTI minimum). 1 module, 4 lessons: AI Tools for ITSM evaluation; Prompt Design for Ticket Triage and Acknowledgment; Generating Structured Resolution Summaries and Querying Historical Notes; Simplifying Complex Technical Documents with AI. OJL 5.c, 5.d. Onboarding meta apprenti-org/design-documentation#696.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {
       "id": "ai-assisted-meeting-facilitation",
@@ -126,7 +141,7 @@
       },
       "syllabus": null,
       "outline": true,
-      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: Red-Green-Refactor with AI (1h); Test Doubles, Mocks, and Coverage (1h). Both SCORM zips deployed to Absorb; starter/solution repos provisioned at apprenti-org/ai-assisted-test-driven-development-student and -instructor. RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 2h course for Software Developer (JVFD). 1 module, 2 lessons: Red-Green-Refactor with AI (1h); Test Doubles, Mocks, and Coverage (1h). Both SCORM zips deployed to Absorb; starter/solution repos provisioned at apprenti-org/ai-assisted-test-driven-development-student and -instructor. RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "statusConfirmed": true
     },
@@ -140,7 +155,7 @@
       },
       "syllabus": "syllabi/ai-assisted-user-communication-and-documentation.html",
       "outline": true,
-      "note": "Net-new 1h course for Software Developer (JVFD). 1 module, 2 lessons: Generating Professional Content with AI Prompts (0.5h); Tailoring Communication for Stakeholder Audiences (0.5h). Quiz only \u2014 no exercises or activities. RTI/OJL alignment deferred \u2014 JVFD curriculum design folder not yet created.",
+      "note": "Net-new 1h course for Software Developer (JVFD). 1 module, 2 lessons: Generating Professional Content with AI Prompts (0.5h); Tailoring Communication for Stakeholder Audiences (0.5h). Quiz only — no exercises or activities. RTI/OJL alignment deferred — JVFD curriculum design folder not yet created.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -170,7 +185,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: ASP.NET",
-      "note": "Outline extracted from C# Fundamentals Module 8 \u2014 awaiting manual review and hours estimation",
+      "note": "Outline extracted from C# Fundamentals Module 8 — awaiting manual review and hours estimation",
       "driveFolder": "https://drive.google.com/drive/folders/1SyzTnafr9h0VJCXjJyKCZe4FzuaWsdfQ",
       "statusConfirmed": false
     },
@@ -212,7 +227,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: C# Data Access",
-      "note": "Outline extracted from C# Fundamentals Module 7 \u2014 awaiting manual review and hours estimation",
+      "note": "Outline extracted from C# Fundamentals Module 7 — awaiting manual review and hours estimation",
       "driveFolder": "https://drive.google.com/drive/folders/1bejAPyvTFN5lhaPD_3Eoaa0alAxgZ6Cj",
       "statusConfirmed": false
     },
@@ -226,7 +241,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: C# Language Fundamentals",
-      "note": "Outline extracted from C# Fundamentals Module 2 \u2014 awaiting manual review and hours estimation",
+      "note": "Outline extracted from C# Fundamentals Module 2 — awaiting manual review and hours estimation",
       "driveFolder": "https://drive.google.com/drive/folders/187t9XrpPqtcHwhz2J6Jxt6xwqGjb5e0w",
       "statusConfirmed": false
     },
@@ -240,7 +255,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: C# OOP",
-      "note": "Outline extracted from C# Fundamentals Module 3 \u2014 awaiting manual review and hours estimation",
+      "note": "Outline extracted from C# Fundamentals Module 3 — awaiting manual review and hours estimation",
       "driveFolder": "https://drive.google.com/drive/folders/1LGCFMCWfYHOIoCz8rp5vNxR5JpZ8QQTd",
       "statusConfirmed": false
     },
@@ -254,7 +269,7 @@
       },
       "syllabus": "Syllabus: C++ Coding Booster Intensive",
       "outline": "Course Outline: C++ Coding Booster Intensive",
-      "note": "One-day intensive workshop for Visa apprentices \u2014 full syllabus and lesson plan available",
+      "note": "One-day intensive workshop for Visa apprentices — full syllabus and lesson plan available",
       "driveFolder": "https://drive.google.com/drive/folders/1JAebFnmxFdqk6_PtvtMHKyf8bi21EOqn",
       "statusConfirmed": false
     },
@@ -268,7 +283,7 @@
       },
       "syllabus": null,
       "outline": null,
-      "note": "OSS Course 11, Area 3 \u2014 GitHub-Actions-focused CI/CD course. 10h, 3 modules, 9 lessons (incl. 1.5h capstone). Design folder complete in apprenti-org/design-documentation (course outline + 8 lesson outlines + 9 lesson sources + standard alignment). Phase 3 production complete via #236: 60 production files (9 lessons \u00d7 6 artifacts + 3 module READMEs + 3 MODULE-REPORTs); 18/18 alignment passes per module; 0 permanent quarantines. Course-completion report at _COURSES Phase 1 - WORKING/courses/cicd-pipeline-concepts/_REVIEW/course-completion-report.md. Module review gates written, awaiting human sign-off. Per tracking #94.",
+      "note": "OSS Course 11, Area 3 — GitHub-Actions-focused CI/CD course. 10h, 3 modules, 9 lessons (incl. 1.5h capstone). Design folder complete in apprenti-org/design-documentation (course outline + 8 lesson outlines + 9 lesson sources + standard alignment). Phase 3 production complete via #236: 60 production files (9 lessons × 6 artifacts + 3 module READMEs + 3 MODULE-REPORTs); 18/18 alignment passes per module; 0 permanent quarantines. Course-completion report at _COURSES Phase 1 - WORKING/courses/cicd-pipeline-concepts/_REVIEW/course-completion-report.md. Module review gates written, awaiting human sign-off. Per tracking #94.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -283,7 +298,7 @@
       },
       "syllabus": "Syllabus: Client Technical Support Engineer Capstone",
       "outline": "Course Outline: Client Technical Support Engineer Capstone",
-      "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases \u2014 Discovery, Design, Build, Operate, Report. All content produced: content.md, instructor-guide.md, Capstone Deliverables checklist (quiz.md), and interactive.html for all 5 lessons. Course-completion report at _REVIEW/course-completion-report.md.",
+      "note": "Net-new integrative capstone (20h / 4 days). 5 modules / 5 lessons. Simulated scenario: students act as IT Support Lead to stand up a service desk from scratch across 5 phases — Discovery, Design, Build, Operate, Report. All content produced: content.md, instructor-guide.md, Capstone Deliverables checklist (quiz.md), and interactive.html for all 5 lessons. Course-completion report at _REVIEW/course-completion-report.md.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -312,7 +327,7 @@
       },
       "syllabus": null,
       "outline": null,
-      "note": "OSS Course 14, Area 4 \u2014 existing content to be migrated/refined for OSS Security & Professional Skills area. 4h. Active dev pipeline \u2014 design work beginning soon. Audit confirms Not Started baseline (per #86).",
+      "note": "OSS Course 14, Area 4 — existing content to be migrated/refined for OSS Security & Professional Skills area. 4h. Active dev pipeline — design work beginning soon. Audit confirms Not Started baseline (per #86).",
       "driveFolder": null,
       "statusConfirmed": true
     },
@@ -326,7 +341,7 @@
       },
       "syllabus": "Syllabus: Curriculum IT Support Professional",
       "outline": "Course Outline: CompTIA A+",
-      "note": "v0.4.2 \u2014 38/38 SCORM interactives complete. All modules 1-7 deployed. Content synced from review HTMLs, titles normalized.",
+      "note": "v0.4.2 — 38/38 SCORM interactives complete. All modules 1-7 deployed. Content synced from review HTMLs, titles normalized.",
       "driveFolder": "https://drive.google.com/drive/folders/1Sc6HPEa8bYFzm50IHccFEuLKBgqkU22o",
       "statusConfirmed": true
     },
@@ -346,56 +361,56 @@
     },
     {
       "id": "data-fundamentals-data-literacy",
-      "name": "Data Fundamentals \u2014 Data Literacy",
+      "name": "Data Fundamentals — Data Literacy",
       "hours": 25,
       "status": {
         "design": "Complete",
         "development": "Complete"
       },
       "syllabus": "data-literacy",
-      "outline": "Course Outline: Data Fundamentals \u2014 Data Literacy",
+      "outline": "Course Outline: Data Fundamentals — Data Literacy",
       "note": "7 modules, 24 lessons, 107 PDFs. Deploy repo: apprenti-org/data-literacy-deploy. PLE manifest integrated. Welcome interactive packaged as SCORM 1.2 (ready for Absorb upload).",
       "driveFolder": "https://drive.google.com/drive/folders/17-Ll0td-RhLRdvpzksoFHNX70AZX4ikQ",
       "statusConfirmed": false
     },
     {
       "id": "data-fundamentals-data-visualizations-and-power-bi",
-      "name": "Data Fundamentals \u2014 Data Visualizations and Power BI",
+      "name": "Data Fundamentals — Data Visualizations and Power BI",
       "hours": 50,
       "status": {
         "design": "Needs Review",
         "development": "Not Started"
       },
       "syllabus": null,
-      "outline": "Course Outline: Data Fundamentals \u2014 Data Visualizations and Power BI",
-      "note": "Existing content \u2014 full course outline, module folders, code-alongs, exercises, labs, and multi-part summative in Google Drive",
+      "outline": "Course Outline: Data Fundamentals — Data Visualizations and Power BI",
+      "note": "Existing content — full course outline, module folders, code-alongs, exercises, labs, and multi-part summative in Google Drive",
       "driveFolder": "https://drive.google.com/drive/folders/1PwOtz40wQ7-xcscKQTBMRqnVUjpkaM2f",
       "statusConfirmed": false
     },
     {
       "id": "data-fundamentals-excel-for-data-analysts",
-      "name": "Data Fundamentals \u2014 Excel for Data Analysts",
+      "name": "Data Fundamentals — Excel for Data Analysts",
       "hours": 50,
       "status": {
         "design": "Needs Review",
         "development": "Not Started"
       },
       "syllabus": null,
-      "outline": "Course Outline: Data Fundamentals \u2014 Excel for Data Analysts",
-      "note": "Existing content \u2014 full course outline, instructor guide, course overview, scenario, exercises with learner keys, and summative assessment in Google Drive",
+      "outline": "Course Outline: Data Fundamentals — Excel for Data Analysts",
+      "note": "Existing content — full course outline, instructor guide, course overview, scenario, exercises with learner keys, and summative assessment in Google Drive",
       "driveFolder": "https://drive.google.com/drive/folders/1RpKaf1sRrbX3F2s6as5fJn6MS1Aj8GB4",
       "statusConfirmed": false
     },
     {
       "id": "data-fundamentals-sql-for-data",
-      "name": "Data Fundamentals \u2014 SQL for Data",
+      "name": "Data Fundamentals — SQL for Data",
       "hours": 50,
       "status": {
         "design": "Complete",
         "development": "Not Started"
       },
       "syllabus": null,
-      "outline": "Course Outline: Data Fundamentals \u2014 SQL for Data",
+      "outline": "Course Outline: Data Fundamentals — SQL for Data",
       "note": null,
       "driveFolder": "https://drive.google.com/drive/folders/1brcOX4Cce5PKvje0ZTKBrHgF7alND39Z",
       "statusConfirmed": false
@@ -410,7 +425,7 @@
       },
       "syllabus": "Syllabus: Databases in Java",
       "outline": "Course Outline: Databases in Java",
-      "note": "Rich source content \u2014 10 content modules, 23 lesson docs, 17 code-alongs, 13 exercises, 4 install guides, 1 lab, summative assessment. INCOMPLETE folder has 4 unfinished modules (Database Programming, BigDecimal, JDBC Template, Advanced JDBC Template). Slides and instructor guides available.",
+      "note": "Rich source content — 10 content modules, 23 lesson docs, 17 code-alongs, 13 exercises, 4 install guides, 1 lab, summative assessment. INCOMPLETE folder has 4 unfinished modules (Database Programming, BigDecimal, JDBC Template, Advanced JDBC Template). Slides and instructor guides available.",
       "driveFolder": "https://drive.google.com/drive/folders/1g22pGVb41S-Wzdp-04rB7r5iP7KVid0d",
       "statusConfirmed": false
     },
@@ -424,7 +439,7 @@
       },
       "syllabus": "Syllabus: Helpdesk Software Fundamentals",
       "outline": "Course Outline: Helpdesk Software Fundamentals",
-      "note": "Rich source content \u2014 7 lesson docs, 7 quizzes, 6 hands-on activities, slides folder in Google Drive. Covers ITSM fundamentals, helpdesk platforms (Zendesk, Freshdesk, ServiceNow), ticket lifecycle, knowledge management, automation, reporting, and best practices.",
+      "note": "Rich source content — 7 lesson docs, 7 quizzes, 6 hands-on activities, slides folder in Google Drive. Covers ITSM fundamentals, helpdesk platforms (Zendesk, Freshdesk, ServiceNow), ticket lifecycle, knowledge management, automation, reporting, and best practices.",
       "driveFolder": "https://drive.google.com/drive/folders/1vcee5L9CWraXObjJQwi2KwF-7NTGDdTJ",
       "statusConfirmed": true
     },
@@ -438,7 +453,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: HTTP Services",
-      "note": "No formal course outline doc \u2014 outline constructed from two lesson documents in Google Drive. Related to Java M07 JDBC/HTTP Services module.",
+      "note": "No formal course outline doc — outline constructed from two lesson documents in Google Drive. Related to Java M07 JDBC/HTTP Services module.",
       "driveFolder": "https://drive.google.com/drive/folders/1VzQcpugiLw18KakVlxRROUW4hOuWcKwG",
       "statusConfirmed": false
     },
@@ -452,7 +467,7 @@
       },
       "syllabus": null,
       "outline": "infrastructure-as-code-fundamentals",
-      "note": "OSS Course 12, Area 3 \u2014 net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h, 5 modules, 16 lessons (incl. M5 capstone \u2014 first lesson authored against capstone-design-process.md v0.2.0; CBR + evidence-map locked as canonical templates). Live in Absorb 2026-05-06 (97 PDFs + 16 SCORM zips uploaded; course published to learner catalog). Apprenti-org code repos: infrastructure-as-code-student + infrastructure-as-code-instructor. Onboarding meta apprenti-org/design-documentation#281.",
+      "note": "OSS Course 12, Area 3 — net-new course covering Terraform, Ansible, and cloud-native IaC fundamentals. 22h, 5 modules, 16 lessons (incl. M5 capstone — first lesson authored against capstone-design-process.md v0.2.0; CBR + evidence-map locked as canonical templates). Live in Absorb 2026-05-06 (97 PDFs + 16 SCORM zips uploaded; course published to learner catalog). Apprenti-org code repos: infrastructure-as-code-student + infrastructure-as-code-instructor. Onboarding meta apprenti-org/design-documentation#281.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -467,7 +482,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Instructor Onboarding",
-      "note": "Existing content \u2014 course info doc, full course text, and large combined doc in Google Drive. Originally designed for Java Bootcamp instructor prep, broadly applicable. 2020 draft.",
+      "note": "Existing content — course info doc, full course text, and large combined doc in Google Drive. Originally designed for Java Bootcamp instructor prep, broadly applicable. 2020 draft.",
       "driveFolder": "https://drive.google.com/drive/folders/1KehRfpSrrS4gOyhoLgGiGx6SpxAqJbL3",
       "statusConfirmed": false
     },
@@ -481,7 +496,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Introduction to Advanced Concepts in Java",
-      "note": "Rich source content \u2014 2 content modules, 16 lesson docs, 3 code-alongs, 10 exercises, 1 lab, 1 module assessment, 2 summative assessments (Sustainable Foraging, Airport Terminal Management System). Covers File I/O, design patterns (repository, domain, MVC), dependency injection, Spring DI (XML and annotations), BigDecimal, temporal types, lambdas, and streams.",
+      "note": "Rich source content — 2 content modules, 16 lesson docs, 3 code-alongs, 10 exercises, 1 lab, 1 module assessment, 2 summative assessments (Sustainable Foraging, Airport Terminal Management System). Covers File I/O, design patterns (repository, domain, MVC), dependency injection, Spring DI (XML and annotations), BigDecimal, temporal types, lambdas, and streams.",
       "driveFolder": "https://drive.google.com/drive/folders/1XRc60zapZP8beSVim2PUVsuCBNGYZzkF",
       "statusConfirmed": false
     },
@@ -495,7 +510,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Introduction to AWS Cloud Platform",
-      "note": "Existing content \u2014 full course folder with 10 module subfolders and lesson docs in Google Drive. Very large combined doc also available. Referenced as 16h in Cloud Ops Specialist syllabus.",
+      "note": "Existing content — full course folder with 10 module subfolders and lesson docs in Google Drive. Very large combined doc also available. Referenced as 16h in Cloud Ops Specialist syllabus.",
       "driveFolder": "https://drive.google.com/drive/folders/1X_LKRkFbjrWvAtFVipSL6LNOyu9NWBzM",
       "statusConfirmed": false
     },
@@ -509,7 +524,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Introduction to Cloud Technology",
-      "note": "Existing content \u2014 full course outline, course intro, lesson docs, and demos (AWS/Azure/GCP portals) in Google Drive. Referenced as 'Introduction to Cloud' in SWD Java and Cloud Ops syllabi.",
+      "note": "Existing content — full course outline, course intro, lesson docs, and demos (AWS/Azure/GCP portals) in Google Drive. Referenced as 'Introduction to Cloud' in SWD Java and Cloud Ops syllabi.",
       "driveFolder": "https://drive.google.com/drive/folders/1JuELDVAwsj5-uOzNh1KXJ5aBTpc5vj4Q",
       "statusConfirmed": false
     },
@@ -523,7 +538,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Introduction to GitHub",
-      "note": "Existing content \u2014 course intro with 12 outcomes, detailed instructor guide with lesson structure, 4 lessons, 5 code-alongs, 1 exercise, quizzes. 8\u201316h per SWD Java syllabus.",
+      "note": "Existing content — course intro with 12 outcomes, detailed instructor guide with lesson structure, 4 lessons, 5 code-alongs, 1 exercise, quizzes. 8–16h per SWD Java syllabus.",
       "driveFolder": "https://drive.google.com/drive/folders/1UR0Q77PdzDRYnaOC_Stu6Je80Z6zdpkN",
       "statusConfirmed": false
     },
@@ -537,7 +552,7 @@
       },
       "syllabus": "Syllabus: Introduction to HTML & CSS",
       "outline": "Course Outline: Introduction to HTML & CSS",
-      "note": "Existing content \u2014 full syllabus with 3 modules, 40 hours, 16 lessons, 13 code-alongs, 4 exercises, and summative assessment. Part of Software Development Java curriculum as 'HTML & CSS'.",
+      "note": "Existing content — full syllabus with 3 modules, 40 hours, 16 lessons, 13 code-alongs, 4 exercises, and summative assessment. Part of Software Development Java curriculum as 'HTML & CSS'.",
       "driveFolder": "https://drive.google.com/drive/folders/16UVQpNFHouifMNadvQzr98pdin5jRgtB",
       "statusConfirmed": false
     },
@@ -551,7 +566,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Introduction to Microsoft Teams",
-      "note": "Existing content \u2014 2 lesson docs with instructor guides covering Teams overview and creating/managing Teams & Channels. No formal syllabus. Related to Microsoft 365 Fundamentals track.",
+      "note": "Existing content — 2 lesson docs with instructor guides covering Teams overview and creating/managing Teams & Channels. No formal syllabus. Related to Microsoft 365 Fundamentals track.",
       "driveFolder": "https://drive.google.com/drive/folders/1l0w-W4C0m05BkrSuZ67L_kF-8lT1vbmW",
       "statusConfirmed": false
     },
@@ -610,7 +625,7 @@
       },
       "syllabus": "Syllabus: Java Coding Booster Intensive",
       "outline": "Course Outline: Java Coding Booster Intensive",
-      "note": "Existing content \u2014 full syllabus, 2-day outline, course intro/conclusion, software requirements, 8 module folders in Google Drive. 16h over 2 days. Visa SWD apprentice intensive with 85% AI-assisted mandate.",
+      "note": "Existing content — full syllabus, 2-day outline, course intro/conclusion, software requirements, 8 module folders in Google Drive. 16h over 2 days. Visa SWD apprentice intensive with 85% AI-assisted mandate.",
       "driveFolder": "https://drive.google.com/drive/folders/1SH-jSBKboZwxiLQVFaFfcLbGR4gEsh84",
       "statusConfirmed": false
     },
@@ -667,7 +682,7 @@
       },
       "syllabus": "Syllabus: JavaScript Coding Booster Intensive",
       "outline": "Course Outline: JavaScript Coding Booster Intensive",
-      "note": "Existing content \u2014 full syllabus, course outline, course intro/conclusion, software requirements, 4 module folders in Google Drive. 8h one-day intensive. Visa SWD apprentice front-end simulation with 85% AI-assisted mandate. Dynamics 365 focus.",
+      "note": "Existing content — full syllabus, course outline, course intro/conclusion, software requirements, 4 module folders in Google Drive. 8h one-day intensive. Visa SWD apprentice front-end simulation with 85% AI-assisted mandate. Dynamics 365 focus.",
       "driveFolder": "https://drive.google.com/drive/folders/1LeMbVEU2XbZjzjjilc4W-fxEa66rvWJa",
       "statusConfirmed": false
     },
@@ -751,7 +766,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Microsoft 365 Endpoint Administrator",
-      "note": "Rich source content \u2014 11 modules (10 with content, 1 capstone placeholder), 10 lesson docs, 10 quizzes, 10 activities, 9 demos, 4 case studies, slides folder in Google Drive.",
+      "note": "Rich source content — 11 modules (10 with content, 1 capstone placeholder), 10 lesson docs, 10 quizzes, 10 activities, 9 demos, 4 case studies, slides folder in Google Drive.",
       "driveFolder": "https://drive.google.com/drive/folders/1uB-40aGxQOQYt5Jb-61LrFFcsBnxWwSU",
       "statusConfirmed": false
     },
@@ -765,7 +780,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Microsoft 365 Fundamentals",
-      "note": "Rich source content \u2014 4 modules, 8 lesson docs, 8 quizzes, 7 activities, 1 case study in Google Drive. Modules: Cloud Concepts, Productivity and Teamwork, Security and Compliance, Licensing and Support.",
+      "note": "Rich source content — 4 modules, 8 lesson docs, 8 quizzes, 7 activities, 1 case study in Google Drive. Modules: Cloud Concepts, Productivity and Teamwork, Security and Compliance, Licensing and Support.",
       "driveFolder": "https://drive.google.com/drive/folders/1m6xk7KPhOgBuLGOXYfPbf5PinBx5Ir3z",
       "statusConfirmed": false
     },
@@ -799,15 +814,15 @@
     },
     {
       "id": "oss-capstone",
-      "name": "OSS Capstone \u2014 Ops Incident Simulation",
+      "name": "OSS Capstone — Ops Incident Simulation",
       "hours": 40,
       "status": {
         "design": "Complete",
         "development": "Complete"
       },
       "syllabus": "syllabi/oss-capstone.html",
-      "outline": "Course Outline: OSS Capstone \u2014 Ops Incident Simulation",
-      "note": "OSS Course 18, Capstone Assessment area (supplemental to 560h RTI). Net-new curriculum-level capstone \u2014 5 modules / 11 lessons / 40h ops-incident simulation. Forward CBR (apprenti-org/design-documentation#643) authored before course; Phase 1 (#669) added course to OSS curriculum and transitioned CBR to active. Phase 2 onboarding META: apprenti-org/design-documentation#670.",
+      "outline": "Course Outline: OSS Capstone — Ops Incident Simulation",
+      "note": "OSS Course 18, Capstone Assessment area (supplemental to 560h RTI). Net-new curriculum-level capstone — 5 modules / 11 lessons / 40h ops-incident simulation. Forward CBR (apprenti-org/design-documentation#643) authored before course; Phase 1 (#669) added course to OSS curriculum and transitioned CBR to active. Phase 2 onboarding META: apprenti-org/design-documentation#670.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -851,7 +866,7 @@
       },
       "syllabus": null,
       "outline": null,
-      "note": "OSS Course 17, Area 4 \u2014 content to be extracted from CompTIA A+ for OSS Security & Professional Skills area. 4h. Active dev pipeline \u2014 design work beginning soon. Audit confirms Not Started baseline (per #88).",
+      "note": "OSS Course 17, Area 4 — content to be extracted from CompTIA A+ for OSS Security & Professional Skills area. 4h. Active dev pipeline — design work beginning soon. Audit confirms Not Started baseline (per #88).",
       "driveFolder": null,
       "statusConfirmed": true
     },
@@ -894,7 +909,7 @@
       },
       "syllabus": "python-infrastructure-automation",
       "outline": true,
-      "note": "OSS Area 3 (Programming, Automation & CI/CD). 32h, 5 modules, 15 lessons + 2h capstone. Net-new course designed from scratch against DOL A-28 standard. Phase 3 content production complete \u2014 all 15 lessons authored, alignment-passing, SCORM-packaged, and deployed (95 PDFs + 15 SCORM zips in deploy tree). Meta-issue #101; sub-issues #103, #129, #134, #144, #149, #152, #155, #156 all closed.",
+      "note": "OSS Area 3 (Programming, Automation & CI/CD). 32h, 5 modules, 15 lessons + 2h capstone. Net-new course designed from scratch against DOL A-28 standard. Phase 3 content production complete — all 15 lessons authored, alignment-passing, SCORM-packaged, and deployed (95 PDFs + 15 SCORM zips in deploy tree). Meta-issue #101; sub-issues #103, #129, #134, #144, #149, #152, #155, #156 all closed.",
       "driveFolder": null,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",
       "statusConfirmed": true
@@ -909,7 +924,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: React",
-      "note": "Standalone React course \u2014 SPAs, hooks, routing, MUI, testing",
+      "note": "Standalone React course — SPAs, hooks, routing, MUI, testing",
       "driveFolder": "https://drive.google.com/drive/folders/1G3WGrajgwCOyaHmLpj31kT85xki_nWLA",
       "statusConfirmed": false
     },
@@ -965,7 +980,7 @@
       },
       "syllabus": "SQL Coding Booster Intensive Syllabus",
       "outline": "Course Outline: SQL Coding Booster Intensive",
-      "note": "One-day Scrum simulation \u2014 ETL, data migration, Dynamics 365",
+      "note": "One-day Scrum simulation — ETL, data migration, Dynamics 365",
       "driveFolder": "https://drive.google.com/drive/folders/1V82NKMLAb1kQCR7TjlYqPGmA0Sbe7OG_",
       "statusConfirmed": false
     },
@@ -993,7 +1008,7 @@
       },
       "syllabus": null,
       "outline": null,
-      "note": "OSS Course 10, Area 3. Derived from sql-for-data (50h Data Analyst) \u2014 24h ops-flavored variant. 13 lessons, 9 modules. Live in Absorb 2026-05-18. See apprenti-org/design-documentation#361 onboarding meta.",
+      "note": "OSS Course 10, Area 3. Derived from sql-for-data (50h Data Analyst) — 24h ops-flavored variant. 13 lessons, 9 modules. Live in Absorb 2026-05-18. See apprenti-org/design-documentation#361 onboarding meta.",
       "driveFolder": null,
       "statusConfirmed": true
     },
@@ -1007,7 +1022,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Student Onboarding",
-      "note": "Success manual for all incoming apprentices \u2014 learning philosophy, strategies, tools setup, policies",
+      "note": "Success manual for all incoming apprentices — learning philosophy, strategies, tools setup, policies",
       "driveFolder": "https://drive.google.com/drive/folders/1-M5hN2HXwRJs-mg4WpiyQMHMxfY7gUeG",
       "statusConfirmed": false
     },
@@ -1021,7 +1036,7 @@
       },
       "syllabus": null,
       "outline": true,
-      "note": "Net-new 4h course for OSS Course 15, Area 4 (Security & Professional Skills). 2 modules, 4 lessons: Documentation Types and Purposes; Writing Clear and Audience-Appropriate Documentation; Runbooks and Troubleshooting Guides; Knowledge Management and Maintenance. Live in Absorb 2026-05-19 (4 SCORM 1.2 packages + 26 PDFs deployed; course published to learner catalog). Onboarding meta apprenti-org/design-documentation#561 closed. Slide decks (Row 8) deferred under apprenti-org/design-documentation#604 \u2192 #606 (slide-spec rework); course shipped without slides.",
+      "note": "Net-new 4h course for OSS Course 15, Area 4 (Security & Professional Skills). 2 modules, 4 lessons: Documentation Types and Purposes; Writing Clear and Audience-Appropriate Documentation; Runbooks and Troubleshooting Guides; Knowledge Management and Maintenance. Live in Absorb 2026-05-19 (4 SCORM 1.2 packages + 26 PDFs deployed; course published to learner catalog). Onboarding meta apprenti-org/design-documentation#561 closed. Slide decks (Row 8) deferred under apprenti-org/design-documentation#604 → #606 (slide-spec rework); course shipped without slides.",
       "driveFolder": null,
       "statusConfirmed": true,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"
@@ -1036,7 +1051,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Troubleshooting/Supporting in an Enterprise Environment",
-      "note": "Rich source content \u2014 7 modules, 12 lesson docs, 12 quizzes, 12 activities, 12 demos, 10 case studies in Google Drive. Covers troubleshooting methodology, startup/recovery, Group Policy, hardware/performance, network/remote connectivity, logon/access/security, and OS/applications.",
+      "note": "Rich source content — 7 modules, 12 lesson docs, 12 quizzes, 12 activities, 12 demos, 10 case studies in Google Drive. Covers troubleshooting methodology, startup/recovery, Group Policy, hardware/performance, network/remote connectivity, logon/access/security, and OS/applications.",
       "driveFolder": "https://drive.google.com/drive/folders/1toy5qGCgyjMgT1k8ZkGxQvs-dRtK26J7",
       "statusConfirmed": false
     },
@@ -1050,7 +1065,7 @@
       },
       "syllabus": null,
       "outline": "Course Outline: Web Development with JavaScript",
-      "note": "Pre-design-doc-workflow course; source content lives in Drive folder. Tracking outline JSON (web-dev-javascript-react.json) and syllabus HTML reconstructed from source \u2014 40h / 8 modules / 17 lessons. No working folder or design-doc folder yet (no Phase 0 reconciliation done). Used in OSS Course 9, Area 3.",
+      "note": "Pre-design-doc-workflow course; source content lives in Drive folder. Tracking outline JSON (web-dev-javascript-react.json) and syllabus HTML reconstructed from source — 40h / 8 modules / 17 lessons. No working folder or design-doc folder yet (no Phase 0 reconciliation done). Used in OSS Course 9, Area 3.",
       "driveFolder": "https://drive.google.com/drive/folders/1sgXBEFNAIVxqU5fj2Z6KA8NGQDjeMXRv",
       "statusConfirmed": true
     }
@@ -1172,7 +1187,7 @@
       ]
     },
     {
-      "name": "Operations Support Specialist \u2014 Network",
+      "name": "Operations Support Specialist — Network",
       "slug": "operations-support-specialist",
       "standard": {
         "appendix": "A-28",

--- a/js/shared/constants.js
+++ b/js/shared/constants.js
@@ -36,6 +36,7 @@ var syllabiMap = {
     'Agile Project Management with Scrum': 'agile-project-management.html',
     'AI-Assisted CI/CD Pipelines': 'ai-assisted-cicd-pipelines.html',
     'AI-Assisted Coding Fundamentals': 'ai-assisted-coding-fundamentals.html',
+    'AI-Assisted IT Service Management': 'ai-assisted-it-service-management.html',
     'AI-Assisted Learning and Study Skills': 'ai-assisted-learning-and-study-skills.html',
     'AI-Assisted Meeting Facilitation': 'ai-assisted-meeting-facilitation.html',
     'AI-Assisted Test Driven Development': 'ai-assisted-test-driven-development.html',

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -30,6 +30,11 @@
     "id": "ai-assisted-coding-fundamentals"
   },
   {
+    "file": "ai-assisted-it-service-management.json",
+    "course": "AI-Assisted IT Service Management",
+    "id": "ai-assisted-it-service-management"
+  },
+  {
     "file": "ai-assisted-meeting-facilitation.json",
     "course": "AI-Assisted Meeting Facilitation",
     "id": "ai-assisted-meeting-facilitation"
@@ -101,17 +106,17 @@
   },
   {
     "file": "data-literacy.json",
-    "course": "Data Fundamentals \u2014 Data Literacy",
+    "course": "Data Fundamentals — Data Literacy",
     "id": "data-fundamentals-data-literacy"
   },
   {
     "file": "data-viz-power-bi.json",
-    "course": "Data Fundamentals \u2014 Data Visualizations and Power BI",
+    "course": "Data Fundamentals — Data Visualizations and Power BI",
     "id": "data-fundamentals-data-visualizations-and-power-bi"
   },
   {
     "file": "excel-for-data-analysts.json",
-    "course": "Data Fundamentals \u2014 Excel for Data Analysts",
+    "course": "Data Fundamentals — Excel for Data Analysts",
     "id": "data-fundamentals-excel-for-data-analysts"
   },
   {
@@ -246,7 +251,7 @@
   },
   {
     "file": "oss-capstone.json",
-    "course": "OSS Capstone \u2014 Ops Incident Simulation",
+    "course": "OSS Capstone — Ops Incident Simulation",
     "id": "oss-capstone"
   },
   {

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -939,6 +939,80 @@ const courseOutlines = {
       }
     ]
   },
+  "AI-Assisted IT Service Management": {
+    "course": "AI-Assisted IT Service Management",
+    "totalHours": 4,
+    "totalModules": 1,
+    "totalLessons": 4,
+    "modules": [
+      {
+        "name": "AI-Assisted IT Service Management",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "AI Tools for ITSM — Evaluation and Selection",
+            "hours": 1,
+            "topics": [
+              "Landscape of AI-enhanced ITSM tools: CRM systems, ticketing platforms (e.g., ServiceNow, Jira Service Management), and prioritization engines",
+              "Criteria for evaluating AI tools: accuracy, integration requirements, auditability, and cost",
+              "How AI prioritization algorithms work and how to manage AI-enhanced ticket queues",
+              "Risks and human oversight requirements: bias in prioritization, over-automation, escalation paths",
+              "**Wrap-Up and Reflection (5 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: AI Tools for ITSM — Evaluation and Selection",
+              "Assessment: Quiz: AI Tools for ITSM — Evaluation and Selection"
+            ]
+          },
+          {
+            "title": "Prompt Design for Ticket Triage and Acknowledgment",
+            "hours": 1,
+            "topics": [
+              "Why unstructured client emails and tickets are hard to process consistently",
+              "Prompt structures for extracting key fields from unstructured ticket text: category, urgency, affected system, and requested action",
+              "Designing prompts to generate professional, consistent ticket acknowledgment messages",
+              "Iterating prompts: identifying when outputs are vague, off-tone, or inaccurate and how to refine",
+              "**Wrap-Up and Reflection (5 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: Prompt Design for Ticket Triage and Acknowledgment",
+              "Assessment: Quiz: Prompt Design for Ticket Triage and Acknowledgment"
+            ]
+          },
+          {
+            "title": "Generating Structured Resolution Summaries and Querying Historical Notes",
+            "hours": 1,
+            "topics": [
+              "Components of a resolution summary: symptom, root cause, resolution steps, verification, and follow-up actions",
+              "Prompting AI to produce structured resolution summaries from unstructured technician notes",
+              "Using LLMs to query and synthesize information from a corpus of past resolution notes (retrieval patterns, semantic search concepts)",
+              "Accuracy and attribution: fact-checking AI-synthesized content against source records",
+              "**Wrap-Up and Reflection (5 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: Generating Structured Resolution Summaries and Querying Historical Notes",
+              "Assessment: Quiz: Generating Structured Resolution Summaries and Querying Historical Notes"
+            ]
+          },
+          {
+            "title": "Simplifying Complex Technical Documents with AI",
+            "hours": 1,
+            "topics": [
+              "When technical documents need simplification: runbooks for non-technical stakeholders, escalation guides, KB articles",
+              "Prompting AI to rewrite or summarize complex technical content for a specified audience",
+              "Generating knowledge base entries from resolved ticket data",
+              "Responsible use in ITSM: audit trails, human review gates, and attribution standards",
+              "**Wrap-Up and Reflection (5 min)**"
+            ],
+            "objects": [
+              "Object: Lesson: Simplifying Complex Technical Documents with AI",
+              "Assessment: Quiz: Simplifying Complex Technical Documents with AI"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "AI-Assisted Meeting Facilitation": {
     "course": "AI-Assisted Meeting Facilitation",
     "totalHours": 1.5,


### PR DESCRIPTION
## Summary

- `courses.json`: new entry for `ai-assisted-it-service-management` (4h, OSS supplemental, design Complete, development In Progress)
- `outlines/manifest.json`: new entry pointing to `ai-assisted-it-service-management.json`
- `js/shared/constants.js`: syllabiMap entry for AI-Assisted IT Service Management
- `outlines/outlines.js`, `courses.js`, `course-overview.*`: regenerated

Part of Row 5 Content Scaffolding (#705 in apprenti-org/design-documentation). Meta-issue: apprenti-org/design-documentation#696.

## Test plan

- [ ] Course appears in curriculum tracking dashboard sidebar under OSS — Network
- [ ] Outline panel loads with 1 module / 4 lessons
- [ ] Syllabus link resolves to `ai-assisted-it-service-management.html`
- [ ] Status shows design Complete / development In Progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)