### PR TITLE
itil-specialist-4: Phase 0 tracking reconciliation

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -638,12 +638,12 @@ const courseData = [
     "name": "ITIL Specialist 4",
     "hours": 16,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "In Progress"
     },
     "syllabus": null,
-    "outline": null,
-    "note": "Net New",
+    "outline": true,
+    "note": "Design complete (outline + standard-alignment + 12 lesson sources merged); 12-lesson tree scaffolded via Phase 0+1. Content production (row 7) pending.",
     "driveFolder": null,
     "statusConfirmed": false
   },

--- a/courses.json
+++ b/courses.json
@@ -636,12 +636,12 @@
       "name": "ITIL Specialist 4",
       "hours": 16,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "In Progress"
       },
       "syllabus": null,
-      "outline": null,
-      "note": "Net New",
+      "outline": true,
+      "note": "Design complete (outline + standard-alignment + 12 lesson sources merged); 12-lesson tree scaffolded via Phase 0+1. Content production (row 7) pending.",
       "driveFolder": null,
       "statusConfirmed": false
     },

--- a/outlines/itil-specialist-4.json
+++ b/outlines/itil-specialist-4.json
@@ -1,0 +1,201 @@
+{
+  "course": "ITIL Specialist 4",
+  "totalHours": 16,
+  "totalModules": 4,
+  "totalLessons": 12,
+  "modules": [
+    {
+      "name": "Monitoring, Observability & Event Management",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "Observability Principles: Metrics, Logs, and Traces",
+          "hours": 1.5,
+          "topics": [
+            "The three pillars of observability (metrics, logs, distributed traces) and what each answers",
+            "Monitoring vs. observability — when predefined checks are insufficient",
+            "White-box vs. black-box telemetry; cardinality and signal cost",
+            "*Activities:* Code-along (instrument a service / read a telemetry dashboard), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Observability Principles: Metrics, Logs, and Traces",
+            "Assessment: Quiz: Observability Principles: Metrics, Logs, and Traces"
+          ]
+        },
+        {
+          "title": "Monitoring & Event Management in Operation",
+          "hours": 1.5,
+          "topics": [
+            "The ITIL monitoring & event management practice applied to a running service",
+            "Event classification: informational, warning, exception",
+            "Health checks, synthetic monitoring, and golden signals (latency, traffic, errors, saturation)",
+            "*Activities:* Lab (configure monitoring against a sample service), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Monitoring & Event Management in Operation",
+            "Assessment: Quiz: Monitoring & Event Management in Operation"
+          ]
+        },
+        {
+          "title": "Alerting, Signal Quality & an Introduction to AIOps",
+          "hours": 1,
+          "topics": [
+            "Designing actionable alerts; thresholds, alert fatigue, and on-call sustainability",
+            "Event correlation and noise reduction",
+            "AIOps intro: ML-assisted detection, correlation, and event grouping (e.g., Datadog intelligent monitoring / PagerDuty ML event correlation) to reduce alert fatigue",
+            "*Activities:* Demo (AIOps correlation walkthrough), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Alerting, Signal Quality & an Introduction to AIOps",
+            "Assessment: Quiz: Alerting, Signal Quality & an Introduction to AIOps"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Operational Incident & Problem Management",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "Incident Handling, Severity & Escalation",
+          "hours": 1.5,
+          "topics": [
+            "The incident lifecycle: detect, log, categorize, prioritize, diagnose, resolve, close",
+            "Severity/priority matrices (impact × urgency) and SLA-driven response targets",
+            "Functional vs. hierarchical escalation and the incident bridge",
+            "*Activities:* Lab (triage and escalate a simulated incident), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Incident Handling, Severity & Escalation",
+            "Assessment: Quiz: Incident Handling, Severity & Escalation"
+          ]
+        },
+        {
+          "title": "Problem Management & Root Cause Analysis",
+          "hours": 1.5,
+          "topics": [
+            "Reactive vs. proactive problem management",
+            "RCA techniques (5 Whys, fishbone/Ishikawa, fault-tree); evidence and timeline reconstruction",
+            "Known-error records, workarounds, and the link back to incidents",
+            "*Activities:* Lab (perform an RCA on a worked incident), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Problem Management & Root Cause Analysis",
+            "Assessment: Quiz: Problem Management & Root Cause Analysis"
+          ]
+        },
+        {
+          "title": "Knowledge, Runbooks & Incident Response Documentation",
+          "hours": 1,
+          "topics": [
+            "Runbook structure and the operational knowledge lifecycle",
+            "Blameless post-incident reviews and capturing follow-up actions",
+            "Documentation-as-restoration-asset: keeping runbooks current and discoverable",
+            "*Activities:* Code-along (author a runbook from an incident), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Knowledge, Runbooks & Incident Response Documentation",
+            "Assessment: Quiz: Knowledge, Runbooks & Incident Response Documentation"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Change Enablement, Release & Deployment in Operations",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "Change Enablement & Impact / Risk Assessment",
+          "hours": 1.5,
+          "topics": [
+            "Change types: standard (pre-authorized — e.g., a recurring, pre-approved patch), normal (assessed — e.g., a DB upgrade routed through the CAB), emergency (e.g., a 3am production-outage fix)",
+            "Impact and risk assessment; the change authority and the CAB/ECAB",
+            "Change schedules, freeze windows, and backout planning",
+            "*Activities:* Lab (assess and classify a proposed production change), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Change Enablement & Impact / Risk Assessment",
+            "Assessment: Quiz: Change Enablement & Impact / Risk Assessment"
+          ]
+        },
+        {
+          "title": "Release & Deployment Management",
+          "hours": 1.5,
+          "topics": [
+            "Release packaging, phasing, and rollout patterns (big-bang, phased, blue/green, canary)",
+            "Deployment management vs. release management in practice",
+            "Rollback, feature flags, and validating a release in production",
+            "*Activities:* Code-along (plan a phased release with a rollback path), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Release & Deployment Management",
+            "Assessment: Quiz: Release & Deployment Management"
+          ]
+        },
+        {
+          "title": "CI/CD-Adjacent Controls & Change/Release Governance",
+          "hours": 1,
+          "topics": [
+            "Operational controls layered on automated CI/CD delivery (approvals, gates, audit trail)",
+            "Separation of duties, change records, and traceability",
+            "Governance, post-implementation review, and continuous improvement of the change flow",
+            "*Activities:* Demo (governance/audit-trail walkthrough), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: CI/CD-Adjacent Controls & Change/Release Governance",
+            "Assessment: Quiz: CI/CD-Adjacent Controls & Change/Release Governance"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Reliability Engineering — HA, Resiliency, SLOs & Error Budgets",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "High Availability, Redundancy & Fault Tolerance",
+          "hours": 1.5,
+          "topics": [
+            "HA architectures: redundancy, failover, clustering, load balancing",
+            "Fault tolerance, graceful degradation, and self-healing patterns",
+            "Availability math: MTTR/MTBF, the \"nines,\" and single points of failure",
+            "*Activities:* Lab (analyze a topology for SPOFs and add redundancy), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: High Availability, Redundancy & Fault Tolerance",
+            "Assessment: Quiz: High Availability, Redundancy & Fault Tolerance"
+          ]
+        },
+        {
+          "title": "SRE, SLIs/SLOs/SLAs/OLAs & Error Budgets",
+          "hours": 1.5,
+          "topics": [
+            "Site reliability engineering and the SLI → SLO → SLA → OLA chain",
+            "Error budgets: defining, spending, and using them to balance reliability vs. feature velocity",
+            "Meeting uptime targets and reporting against operational service levels",
+            "Scope boundary: this course covers *operating to* SLAs/SLOs (meeting targets, computing error budgets, escalating breaches); SLA *negotiation/design* is out of scope (Strategist tier / customer-engagement)",
+            "*Activities:* Lab (define SLIs/SLOs and compute an error budget), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: SRE, SLIs/SLOs/SLAs/OLAs & Error Budgets",
+            "Assessment: Quiz: SRE, SLIs/SLOs/SLAs/OLAs & Error Budgets"
+          ]
+        },
+        {
+          "title": "Chaos Engineering, Service Continuity & Disaster Recovery",
+          "hours": 1,
+          "topics": [
+            "Chaos engineering: hypothesis-driven failure injection to verify resilience",
+            "Service continuity management; RTO/RPO and continuity planning",
+            "Backup, disaster recovery, and DR testing",
+            "*Activities:* Demo (chaos experiment walkthrough), exercise"
+          ],
+          "objects": [
+            "Object: Lesson: Chaos Engineering, Service Continuity & Disaster Recovery",
+            "Assessment: Quiz: Chaos Engineering, Service Continuity & Disaster Recovery"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -195,6 +195,11 @@
     "id": "itil-foundations"
   },
   {
+    "file": "itil-specialist-4.json",
+    "course": "ITIL Specialist 4",
+    "id": "itil-specialist-4"
+  },
+  {
     "file": "java-coding-booster.json",
     "course": "Java Coding Booster Intensive",
     "id": "java-coding-booster-intensive"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -6965,6 +6965,207 @@ const courseOutlines = {
       }
     ]
   },
+  "ITIL Specialist 4": {
+    "course": "ITIL Specialist 4",
+    "totalHours": 16,
+    "totalModules": 4,
+    "totalLessons": 12,
+    "modules": [
+      {
+        "name": "Monitoring, Observability & Event Management",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "Observability Principles: Metrics, Logs, and Traces",
+            "hours": 1.5,
+            "topics": [
+              "The three pillars of observability (metrics, logs, distributed traces) and what each answers",
+              "Monitoring vs. observability — when predefined checks are insufficient",
+              "White-box vs. black-box telemetry; cardinality and signal cost",
+              "*Activities:* Code-along (instrument a service / read a telemetry dashboard), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Observability Principles: Metrics, Logs, and Traces",
+              "Assessment: Quiz: Observability Principles: Metrics, Logs, and Traces"
+            ]
+          },
+          {
+            "title": "Monitoring & Event Management in Operation",
+            "hours": 1.5,
+            "topics": [
+              "The ITIL monitoring & event management practice applied to a running service",
+              "Event classification: informational, warning, exception",
+              "Health checks, synthetic monitoring, and golden signals (latency, traffic, errors, saturation)",
+              "*Activities:* Lab (configure monitoring against a sample service), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Monitoring & Event Management in Operation",
+              "Assessment: Quiz: Monitoring & Event Management in Operation"
+            ]
+          },
+          {
+            "title": "Alerting, Signal Quality & an Introduction to AIOps",
+            "hours": 1,
+            "topics": [
+              "Designing actionable alerts; thresholds, alert fatigue, and on-call sustainability",
+              "Event correlation and noise reduction",
+              "AIOps intro: ML-assisted detection, correlation, and event grouping (e.g., Datadog intelligent monitoring / PagerDuty ML event correlation) to reduce alert fatigue",
+              "*Activities:* Demo (AIOps correlation walkthrough), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Alerting, Signal Quality & an Introduction to AIOps",
+              "Assessment: Quiz: Alerting, Signal Quality & an Introduction to AIOps"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Operational Incident & Problem Management",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "Incident Handling, Severity & Escalation",
+            "hours": 1.5,
+            "topics": [
+              "The incident lifecycle: detect, log, categorize, prioritize, diagnose, resolve, close",
+              "Severity/priority matrices (impact × urgency) and SLA-driven response targets",
+              "Functional vs. hierarchical escalation and the incident bridge",
+              "*Activities:* Lab (triage and escalate a simulated incident), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Incident Handling, Severity & Escalation",
+              "Assessment: Quiz: Incident Handling, Severity & Escalation"
+            ]
+          },
+          {
+            "title": "Problem Management & Root Cause Analysis",
+            "hours": 1.5,
+            "topics": [
+              "Reactive vs. proactive problem management",
+              "RCA techniques (5 Whys, fishbone/Ishikawa, fault-tree); evidence and timeline reconstruction",
+              "Known-error records, workarounds, and the link back to incidents",
+              "*Activities:* Lab (perform an RCA on a worked incident), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Problem Management & Root Cause Analysis",
+              "Assessment: Quiz: Problem Management & Root Cause Analysis"
+            ]
+          },
+          {
+            "title": "Knowledge, Runbooks & Incident Response Documentation",
+            "hours": 1,
+            "topics": [
+              "Runbook structure and the operational knowledge lifecycle",
+              "Blameless post-incident reviews and capturing follow-up actions",
+              "Documentation-as-restoration-asset: keeping runbooks current and discoverable",
+              "*Activities:* Code-along (author a runbook from an incident), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Knowledge, Runbooks & Incident Response Documentation",
+              "Assessment: Quiz: Knowledge, Runbooks & Incident Response Documentation"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Change Enablement, Release & Deployment in Operations",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "Change Enablement & Impact / Risk Assessment",
+            "hours": 1.5,
+            "topics": [
+              "Change types: standard (pre-authorized — e.g., a recurring, pre-approved patch), normal (assessed — e.g., a DB upgrade routed through the CAB), emergency (e.g., a 3am production-outage fix)",
+              "Impact and risk assessment; the change authority and the CAB/ECAB",
+              "Change schedules, freeze windows, and backout planning",
+              "*Activities:* Lab (assess and classify a proposed production change), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Change Enablement & Impact / Risk Assessment",
+              "Assessment: Quiz: Change Enablement & Impact / Risk Assessment"
+            ]
+          },
+          {
+            "title": "Release & Deployment Management",
+            "hours": 1.5,
+            "topics": [
+              "Release packaging, phasing, and rollout patterns (big-bang, phased, blue/green, canary)",
+              "Deployment management vs. release management in practice",
+              "Rollback, feature flags, and validating a release in production",
+              "*Activities:* Code-along (plan a phased release with a rollback path), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Release & Deployment Management",
+              "Assessment: Quiz: Release & Deployment Management"
+            ]
+          },
+          {
+            "title": "CI/CD-Adjacent Controls & Change/Release Governance",
+            "hours": 1,
+            "topics": [
+              "Operational controls layered on automated CI/CD delivery (approvals, gates, audit trail)",
+              "Separation of duties, change records, and traceability",
+              "Governance, post-implementation review, and continuous improvement of the change flow",
+              "*Activities:* Demo (governance/audit-trail walkthrough), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: CI/CD-Adjacent Controls & Change/Release Governance",
+              "Assessment: Quiz: CI/CD-Adjacent Controls & Change/Release Governance"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Reliability Engineering — HA, Resiliency, SLOs & Error Budgets",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "High Availability, Redundancy & Fault Tolerance",
+            "hours": 1.5,
+            "topics": [
+              "HA architectures: redundancy, failover, clustering, load balancing",
+              "Fault tolerance, graceful degradation, and self-healing patterns",
+              "Availability math: MTTR/MTBF, the \"nines,\" and single points of failure",
+              "*Activities:* Lab (analyze a topology for SPOFs and add redundancy), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: High Availability, Redundancy & Fault Tolerance",
+              "Assessment: Quiz: High Availability, Redundancy & Fault Tolerance"
+            ]
+          },
+          {
+            "title": "SRE, SLIs/SLOs/SLAs/OLAs & Error Budgets",
+            "hours": 1.5,
+            "topics": [
+              "Site reliability engineering and the SLI → SLO → SLA → OLA chain",
+              "Error budgets: defining, spending, and using them to balance reliability vs. feature velocity",
+              "Meeting uptime targets and reporting against operational service levels",
+              "Scope boundary: this course covers *operating to* SLAs/SLOs (meeting targets, computing error budgets, escalating breaches); SLA *negotiation/design* is out of scope (Strategist tier / customer-engagement)",
+              "*Activities:* Lab (define SLIs/SLOs and compute an error budget), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: SRE, SLIs/SLOs/SLAs/OLAs & Error Budgets",
+              "Assessment: Quiz: SRE, SLIs/SLOs/SLAs/OLAs & Error Budgets"
+            ]
+          },
+          {
+            "title": "Chaos Engineering, Service Continuity & Disaster Recovery",
+            "hours": 1,
+            "topics": [
+              "Chaos engineering: hypothesis-driven failure injection to verify resilience",
+              "Service continuity management; RTO/RPO and continuity planning",
+              "Backup, disaster recovery, and DR testing",
+              "*Activities:* Demo (chaos experiment walkthrough), exercise"
+            ],
+            "objects": [
+              "Object: Lesson: Chaos Engineering, Service Continuity & Disaster Recovery",
+              "Assessment: Quiz: Chaos Engineering, Service Continuity & Disaster Recovery"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "Java Coding Booster Intensive": {
     "course": "Java Coding Booster Intensive",
     "totalHours": 16,


### PR DESCRIPTION
Reflects ITIL Specialist 4 row-5 Phase 0 (content scaffolding) into tracking. Applied cleanly in a fresh clone (the Drive `tracking/repo` working tree had unrelated drift, so not committed from there).

- **Add** `outlines/itil-specialist-4.json` (generated by the extractor: 4 modules / 12 lessons).
- **Register** it in `outlines/manifest.json` (sorted).
- **courses.json** `itil-specialist-4`: `status.design` Not Started → **Complete**, `status.development` Not Started → **In Progress**, `outline` → true, descriptive note. (`statusConfirmed` left false — tracking audit later.)
- **Rebuild** bundles (`courses.js`, `outlines/outlines.js`, `course-overview.js`).

Part of `apprenti-org/design-documentation` meta #739 / row-5 #758. Companion design-doc PR #783 (outline bullet-layout reformat).

**Deferred to the deployment row:** syllabus HTML generation (`syllabi/itil-specialist-4.html`) + syllabiMap update + retiring the old draft `itil-specialist.html` — needs the syllabus source and is owned by deployment.