### PR TITLE
Add introduction-to-github-secure tracking record (CDA, 6h)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -590,6 +590,21 @@ const courseData = [
     "statusConfirmed": false
   },
   {
+    "id": "introduction-to-github-secure",
+    "name": "Introduction to GitHub (Cyber Developer Associate)",
+    "hours": 6,
+    "status": {
+      "design": "Complete",
+      "development": "Not Started"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate condensed 6h edition of Introduction to GitHub (new -secure course, distinct from the shared introduction-to-github). 2 modules, 5 lessons: Git Background; GitHub for Individuals; GitHub for Groups; Resolving Merge Conflicts; Secrets and Credentials Hygiene. Design folder + 5 lesson outlines complete; Phase 1 scaffold built. Built from the migrated reference (course-design/intro-to-github/source/). Onboarding meta apprenti-org/design-documentation#834.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "introduction-to-html-and-css",
     "name": "Introduction to HTML & CSS",
     "hours": 40,
@@ -1237,8 +1252,8 @@ const curriculaData = [
         "note": "Phase 1",
         "courses": [
           {
-            "name": "Introduction to GitHub",
-            "hoursOverride": 6
+            "name": "Introduction to GitHub (Cyber Developer Associate)",
+            "id": "introduction-to-github-secure"
           },
           {
             "name": "AI Foundations and Ethics",

--- a/courses.json
+++ b/courses.json
@@ -588,6 +588,21 @@
       "statusConfirmed": false
     },
     {
+      "id": "introduction-to-github-secure",
+      "name": "Introduction to GitHub (Cyber Developer Associate)",
+      "hours": 6,
+      "status": {
+        "design": "Complete",
+        "development": "Not Started"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate condensed 6h edition of Introduction to GitHub (new -secure course, distinct from the shared introduction-to-github). 2 modules, 5 lessons: Git Background; GitHub for Individuals; GitHub for Groups; Resolving Merge Conflicts; Secrets and Credentials Hygiene. Design folder + 5 lesson outlines complete; Phase 1 scaffold built. Built from the migrated reference (course-design/intro-to-github/source/). Onboarding meta apprenti-org/design-documentation#834.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "introduction-to-html-and-css",
       "name": "Introduction to HTML & CSS",
       "hours": 40,
@@ -1209,7 +1224,7 @@
           "hours": 40,
           "note": "Phase 1",
           "courses": [
-            { "name": "Introduction to GitHub", "hoursOverride": 6 },
+            "introduction-to-github-secure",
             "ai-foundations",
             "ai-assisted-coding-fundamentals",
             "ai-driven-specifications",

--- a/outlines/introduction-to-github-secure.json
+++ b/outlines/introduction-to-github-secure.json
@@ -1,0 +1,47 @@
+{
+  "course": "Introduction to GitHub (Cyber Developer Associate)",
+  "totalHours": 6,
+  "totalLessons": 5,
+  "totalModules": 2,
+  "modules": [
+    {
+      "name": "Git and GitHub Basics",
+      "hours": 3,
+      "description": "The core of version control: what Git and GitHub are, and the everyday individual workflow of creating repositories, committing work, and synchronizing with a remote.",
+      "lessons": [
+        {
+          "title": "Git Background",
+          "hours": 1,
+          "topics": ["What Git and GitHub are; version control and why it matters", "Distributed vs. centralized version control", "Core vocabulary: repository, commit, branch, remote, clone, push, pull, merge", "Local vs. remote; installing and configuring Git and a GitHub account"]
+        },
+        {
+          "title": "GitHub for Individuals",
+          "hours": 2,
+          "topics": ["Initializing a repository; local and remote workflow", "Staging and committing; check in / check out", "Pushing to and pulling from upstream remotes; cloning", "Repository structure and README basics"]
+        }
+      ]
+    },
+    {
+      "name": "Collaboration and Secure Practices",
+      "hours": 3,
+      "description": "Working with others on a shared repository — branches, pull requests, and merge conflicts — plus keeping credentials out of version control.",
+      "lessons": [
+        {
+          "title": "GitHub for Groups",
+          "hours": 1.5,
+          "topics": ["Branching strategies for team work", "Pull requests and code review", "GitHub Issues and basic team collaboration workflow"]
+        },
+        {
+          "title": "Resolving Merge Conflicts",
+          "hours": 1,
+          "topics": ["What causes a merge conflict", "Resolving conflicts on GitHub and on the command line", "Reading diffs and verifying the resolved result"]
+        },
+        {
+          "title": "Secrets and Credentials Hygiene in Git",
+          "hours": 0.5,
+          "topics": ["Why secrets must never be committed (history is permanent and shareable)", ".gitignore for credentials and environment files", "Safe handling of tokens and keys", "Remediating a secret that was committed"]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -180,6 +180,11 @@
     "id": "introduction-to-github"
   },
   {
+    "file": "introduction-to-github-secure.json",
+    "course": "Introduction to GitHub (Cyber Developer Associate)",
+    "id": "introduction-to-github-secure"
+  },
+  {
     "file": "intro-to-html-css.json",
     "course": "Introduction to HTML & CSS",
     "id": "introduction-to-html-and-css"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -6173,6 +6173,76 @@ const courseOutlines = {
       ]
     }
   },
+  "Introduction to GitHub (Cyber Developer Associate)": {
+    "course": "Introduction to GitHub (Cyber Developer Associate)",
+    "totalHours": 6,
+    "totalLessons": 5,
+    "totalModules": 2,
+    "modules": [
+      {
+        "name": "Git and GitHub Basics",
+        "hours": 3,
+        "description": "The core of version control: what Git and GitHub are, and the everyday individual workflow of creating repositories, committing work, and synchronizing with a remote.",
+        "lessons": [
+          {
+            "title": "Git Background",
+            "hours": 1,
+            "topics": [
+              "What Git and GitHub are; version control and why it matters",
+              "Distributed vs. centralized version control",
+              "Core vocabulary: repository, commit, branch, remote, clone, push, pull, merge",
+              "Local vs. remote; installing and configuring Git and a GitHub account"
+            ]
+          },
+          {
+            "title": "GitHub for Individuals",
+            "hours": 2,
+            "topics": [
+              "Initializing a repository; local and remote workflow",
+              "Staging and committing; check in / check out",
+              "Pushing to and pulling from upstream remotes; cloning",
+              "Repository structure and README basics"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Collaboration and Secure Practices",
+        "hours": 3,
+        "description": "Working with others on a shared repository — branches, pull requests, and merge conflicts — plus keeping credentials out of version control.",
+        "lessons": [
+          {
+            "title": "GitHub for Groups",
+            "hours": 1.5,
+            "topics": [
+              "Branching strategies for team work",
+              "Pull requests and code review",
+              "GitHub Issues and basic team collaboration workflow"
+            ]
+          },
+          {
+            "title": "Resolving Merge Conflicts",
+            "hours": 1,
+            "topics": [
+              "What causes a merge conflict",
+              "Resolving conflicts on GitHub and on the command line",
+              "Reading diffs and verifying the resolved result"
+            ]
+          },
+          {
+            "title": "Secrets and Credentials Hygiene in Git",
+            "hours": 0.5,
+            "topics": [
+              "Why secrets must never be committed (history is permanent and shareable)",
+              ".gitignore for credentials and environment files",
+              "Safe handling of tokens and keys",
+              "Remediating a secret that was committed"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "Introduction to HTML & CSS": {
     "course": "Introduction to HTML & CSS",
     "totalHours": 40,


### PR DESCRIPTION
Adds the tracking record for the new **introduction-to-github-secure** course and wires it into the Cyber Developer Associate Phase 1 slot.

- New `courses.json` record: "Introduction to GitHub (Cyber Developer Associate)", 6h, design Complete / development Not Started, `statusConfirmed: false`
- CDA Phase 1 group: inline `{name: "Introduction to GitHub", hoursOverride: 6}` → slug `"introduction-to-github-secure"`
- New outline JSON (`outlines/introduction-to-github-secure.json`, 2 modules / 5 lessons / 6h) + manifest entry
- Regenerated bundles (courses.js, outlines.js, course-overview.js); build clean

The existing shared `introduction-to-github` record is **untouched** (verified additive-only diff). This is the Phase 0 tracking output for the course (extractor blocked by the workspace-not-git issue — design-documentation#832), done via the clone per the manual path.

Closes #179. Onboarding META: apprenti-org/design-documentation#834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)