### PR TITLE
Register llm-history-and-capabilities (CDA Phase 1, scaffolding)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -805,6 +805,21 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "llm-history-and-capabilities",
+    "name": "LLM History & Capabilities Deep Dive (Cyber Developer Associate)",
+    "hours": 8,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate net-new 8h Phase 1 course. 2 modules, 5 lessons: A Brief History of AI and Machine Learning; What LLMs Can and Cannot Do; How LLMs Work (Tokens, Context Windows, Inference); LLM Failure Modes (Hallucination, Drift, Boundary Conditions); LLM Limitations and Secure Software Development. Design complete (course outline + standard-alignment report + 5 lesson outlines + 5 lesson sources). Development in progress (Content Scaffolding, Phase 0+1). Onboarding meta apprenti-org/design-documentation#849.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "macos-administration-fundamentals",
     "name": "macOS Administration Fundamentals",
     "hours": 24,

--- a/courses.json
+++ b/courses.json
@@ -803,6 +803,21 @@
       "statusConfirmed": true
     },
     {
+      "id": "llm-history-and-capabilities",
+      "name": "LLM History & Capabilities Deep Dive (Cyber Developer Associate)",
+      "hours": 8,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate net-new 8h Phase 1 course. 2 modules, 5 lessons: A Brief History of AI and Machine Learning; What LLMs Can and Cannot Do; How LLMs Work (Tokens, Context Windows, Inference); LLM Failure Modes (Hallucination, Drift, Boundary Conditions); LLM Limitations and Secure Software Development. Design complete (course outline + standard-alignment report + 5 lesson outlines + 5 lesson sources). Development in progress (Content Scaffolding, Phase 0+1). Onboarding meta apprenti-org/design-documentation#849.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "macos-administration-fundamentals",
       "name": "macOS Administration Fundamentals",
       "hours": 24,

--- a/outlines/llm-history-and-capabilities.json
+++ b/outlines/llm-history-and-capabilities.json
@@ -1,0 +1,97 @@
+{
+  "course": "LLM History & Capabilities Deep Dive (Cyber Developer Associate)",
+  "totalHours": 8,
+  "totalLessons": 5,
+  "totalModules": 2,
+  "modules": [
+    {
+      "name": "Foundations and How LLMs Work",
+      "hours": 4,
+      "description": "How artificial intelligence arrived at the large language model, what those models can and cannot do, and the mechanics underneath — tokens, context windows, and inference.",
+      "lessons": [
+        {
+          "title": "A Brief History of AI and Machine Learning",
+          "hours": 1.5,
+          "topics": [
+            "From symbolic AI and expert systems to statistical machine learning",
+            "The shift to neural networks and deep learning",
+            "The transformer breakthrough and the rise of large language models",
+            "Why this history matters: each shift changed what could be automated, and what could go wrong"
+          ],
+          "objects": [
+            "Object: Lesson: A Brief History of AI and Machine Learning",
+            "Assessment: Quiz: A Brief History of AI and Machine Learning",
+            "SCORM: scorm-lesson-01-a-brief-history-of-ai-and-machine-learning"
+          ]
+        },
+        {
+          "title": "What LLMs Can and Cannot Do",
+          "hours": 1.5,
+          "topics": [
+            "Genuine capabilities: language generation, summarization, translation, code assistance",
+            "Hard limits: no ground truth, no real-time knowledge, no reasoning guarantees",
+            "Capability vs. misconception — separating what models do from what people assume they do",
+            "Setting realistic expectations for an AI assistant"
+          ],
+          "objects": [
+            "Object: Lesson: What LLMs Can and Cannot Do",
+            "Assessment: Quiz: What LLMs Can and Cannot Do",
+            "SCORM: scorm-lesson-02-what-llms-can-and-cannot-do"
+          ]
+        },
+        {
+          "title": "How LLMs Work — Tokens, Context Windows, and Inference",
+          "hours": 1,
+          "topics": [
+            "Tokens: how text is broken into units a model processes",
+            "The context window: what the model can see at once, and what falls out of it",
+            "Inference: next-token prediction and why output is probabilistic, not retrieved",
+            "How these mechanics explain everyday model behavior"
+          ],
+          "objects": [
+            "Object: Lesson: How LLMs Work — Tokens, Context Windows, and Inference",
+            "Assessment: Quiz: How LLMs Work — Tokens, Context Windows, and Inference",
+            "SCORM: scorm-lesson-03-how-llms-work-tokens-context-windows-and-inference"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Failure Modes and Secure Implications",
+      "hours": 4,
+      "description": "Where large language models break down, how to recognize unreliable output, and what their limitations mean for writing secure software with AI assistance.",
+      "lessons": [
+        {
+          "title": "LLM Failure Modes — Hallucination, Drift, and Boundary Conditions",
+          "hours": 2,
+          "topics": [
+            "Hallucination: confident, fluent, and wrong — why it happens",
+            "Drift: how output degrades across long contexts and conversations",
+            "Boundary conditions: prompts at the edges of training and context limits",
+            "Recognizing the signals that an output should not be trusted as-is"
+          ],
+          "objects": [
+            "Object: Lesson: LLM Failure Modes — Hallucination, Drift, and Boundary Conditions",
+            "Assessment: Quiz: LLM Failure Modes — Hallucination, Drift, and Boundary Conditions",
+            "SCORM: scorm-lesson-04-llm-failure-modes-hallucination-drift-and-boundary-conditions"
+          ]
+        },
+        {
+          "title": "LLM Limitations and Secure Software Development",
+          "hours": 2,
+          "topics": [
+            "Why AI-generated code can be insecure, outdated, or subtly wrong",
+            "Treating model output as a draft to verify, never as authoritative",
+            "Where human review is non-negotiable: secrets, input validation, dependencies, logic",
+            "A habit of verification: turning the limitations from the rest of the course into working practice"
+          ],
+          "objects": [
+            "Object: Lesson: LLM Limitations and Secure Software Development",
+            "Assessment: Quiz: LLM Limitations and Secure Software Development",
+            "SCORM: scorm-lesson-05-llm-limitations-and-secure-software-development"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -250,6 +250,11 @@
     "id": "linux-foundations"
   },
   {
+    "file": "llm-history-and-capabilities.json",
+    "course": "LLM History & Capabilities Deep Dive (Cyber Developer Associate)",
+    "id": "llm-history-and-capabilities"
+  },
+  {
     "file": "macos-administration.json",
     "course": "macOS Administration Fundamentals",
     "id": "macos-administration-fundamentals"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -8701,6 +8701,103 @@ const courseOutlines = {
       ]
     }
   },
+  "LLM History & Capabilities Deep Dive (Cyber Developer Associate)": {
+    "course": "LLM History & Capabilities Deep Dive (Cyber Developer Associate)",
+    "totalHours": 8,
+    "totalLessons": 5,
+    "totalModules": 2,
+    "modules": [
+      {
+        "name": "Foundations and How LLMs Work",
+        "hours": 4,
+        "description": "How artificial intelligence arrived at the large language model, what those models can and cannot do, and the mechanics underneath — tokens, context windows, and inference.",
+        "lessons": [
+          {
+            "title": "A Brief History of AI and Machine Learning",
+            "hours": 1.5,
+            "topics": [
+              "From symbolic AI and expert systems to statistical machine learning",
+              "The shift to neural networks and deep learning",
+              "The transformer breakthrough and the rise of large language models",
+              "Why this history matters: each shift changed what could be automated, and what could go wrong"
+            ],
+            "objects": [
+              "Object: Lesson: A Brief History of AI and Machine Learning",
+              "Assessment: Quiz: A Brief History of AI and Machine Learning",
+              "SCORM: scorm-lesson-01-a-brief-history-of-ai-and-machine-learning"
+            ]
+          },
+          {
+            "title": "What LLMs Can and Cannot Do",
+            "hours": 1.5,
+            "topics": [
+              "Genuine capabilities: language generation, summarization, translation, code assistance",
+              "Hard limits: no ground truth, no real-time knowledge, no reasoning guarantees",
+              "Capability vs. misconception — separating what models do from what people assume they do",
+              "Setting realistic expectations for an AI assistant"
+            ],
+            "objects": [
+              "Object: Lesson: What LLMs Can and Cannot Do",
+              "Assessment: Quiz: What LLMs Can and Cannot Do",
+              "SCORM: scorm-lesson-02-what-llms-can-and-cannot-do"
+            ]
+          },
+          {
+            "title": "How LLMs Work — Tokens, Context Windows, and Inference",
+            "hours": 1,
+            "topics": [
+              "Tokens: how text is broken into units a model processes",
+              "The context window: what the model can see at once, and what falls out of it",
+              "Inference: next-token prediction and why output is probabilistic, not retrieved",
+              "How these mechanics explain everyday model behavior"
+            ],
+            "objects": [
+              "Object: Lesson: How LLMs Work — Tokens, Context Windows, and Inference",
+              "Assessment: Quiz: How LLMs Work — Tokens, Context Windows, and Inference",
+              "SCORM: scorm-lesson-03-how-llms-work-tokens-context-windows-and-inference"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Failure Modes and Secure Implications",
+        "hours": 4,
+        "description": "Where large language models break down, how to recognize unreliable output, and what their limitations mean for writing secure software with AI assistance.",
+        "lessons": [
+          {
+            "title": "LLM Failure Modes — Hallucination, Drift, and Boundary Conditions",
+            "hours": 2,
+            "topics": [
+              "Hallucination: confident, fluent, and wrong — why it happens",
+              "Drift: how output degrades across long contexts and conversations",
+              "Boundary conditions: prompts at the edges of training and context limits",
+              "Recognizing the signals that an output should not be trusted as-is"
+            ],
+            "objects": [
+              "Object: Lesson: LLM Failure Modes — Hallucination, Drift, and Boundary Conditions",
+              "Assessment: Quiz: LLM Failure Modes — Hallucination, Drift, and Boundary Conditions",
+              "SCORM: scorm-lesson-04-llm-failure-modes-hallucination-drift-and-boundary-conditions"
+            ]
+          },
+          {
+            "title": "LLM Limitations and Secure Software Development",
+            "hours": 2,
+            "topics": [
+              "Why AI-generated code can be insecure, outdated, or subtly wrong",
+              "Treating model output as a draft to verify, never as authoritative",
+              "Where human review is non-negotiable: secrets, input validation, dependencies, logic",
+              "A habit of verification: turning the limitations from the rest of the course into working practice"
+            ],
+            "objects": [
+              "Object: Lesson: LLM Limitations and Secure Software Development",
+              "Assessment: Quiz: LLM Limitations and Secure Software Development",
+              "SCORM: scorm-lesson-05-llm-limitations-and-secure-software-development"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "macOS Administration Fundamentals": {
     "course": "macOS Administration Fundamentals",
     "totalHours": 24,


### PR DESCRIPTION
Registers the net-new 8h Cyber Developer Associate course **LLM History & Capabilities Deep Dive** in tracking, at Content Scaffolding (Phase 0). Onboarding meta: `apprenti-org/design-documentation#849` (row 5).

- **courses.json:** `llm-history-and-capabilities`, 8h, `status.design: Complete` / `status.development: In Progress`, `outline: true`, `syllabus: null` (HTML deferred to pre-upload reconciliation, per the introduction-to-github-secure precedent), `statusConfirmed: false`, `sourceRepo: design-documentation`. Inserted alphabetically (between linux-foundations and macos).
- **outlines/llm-history-and-capabilities.json:** 2 modules / 5 lessons with topics and planned SCORM objects (`scorm-lesson-NN-<slug>`, so R3 reconciliation resolves at row 13).
- **outlines/manifest.json:** registered alphabetically.
- **courses.js + outlines/outlines.js:** regenerated via `build.js`.

Design (outline + standard-alignment + 5 lesson outlines + 5 lesson sources) is complete and merged in design-documentation (#851/#853/#855/#856). Development begins with this scaffolding step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)