### PR TITLE
Register python-threat-modeling-assignment (CDA P2 capstone, 8h)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -992,6 +992,21 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "python-threat-modeling-assignment",
+    "name": "Python Threat Modeling Assignment (Cyber Developer Associate)",
+    "hours": 8,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate net-new 8h Phase 2 course-level capstone. 1 module, 1 capstone lesson: apprentices threat-model a software architecture diagram (identify threat actors, attack vectors, vulnerabilities) and write a Python LogParser (class + lambda filters) to mine system logs for corroborating evidence, producing a CIA-mapped threat analysis, an apprentice evidence map, and a reflection. Delivers the A-31 Phase 2 'Python Threat Modeling' assignment line. OJL 2.a (primary) + 3.d (OOP/lambda portion). Assessed by a Competency-Based Rubric (no quiz). Design complete (course outline + lesson outline + lesson source); development in progress (Content Scaffolding, Phase 0+1). Onboarding meta apprenti-org/design-documentation#874.",
+    "driveFolder": null,
+    "statusConfirmed": true,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "react",
     "name": "React",
     "hours": 40,

--- a/courses.json
+++ b/courses.json
@@ -990,6 +990,21 @@
       "statusConfirmed": true
     },
     {
+      "id": "python-threat-modeling-assignment",
+      "name": "Python Threat Modeling Assignment (Cyber Developer Associate)",
+      "hours": 8,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate net-new 8h Phase 2 course-level capstone. 1 module, 1 capstone lesson: apprentices threat-model a software architecture diagram (identify threat actors, attack vectors, vulnerabilities) and write a Python LogParser (class + lambda filters) to mine system logs for corroborating evidence, producing a CIA-mapped threat analysis, an apprentice evidence map, and a reflection. Delivers the A-31 Phase 2 'Python Threat Modeling' assignment line. OJL 2.a (primary) + 3.d (OOP/lambda portion). Assessed by a Competency-Based Rubric (no quiz). Design complete (course outline + lesson outline + lesson source); development in progress (Content Scaffolding, Phase 0+1). Onboarding meta apprenti-org/design-documentation#874.",
+      "driveFolder": null,
+      "statusConfirmed": true,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "react",
       "name": "React",
       "hours": 40,

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -310,6 +310,11 @@
     "id": "python-infrastructure-automation"
   },
   {
+    "file": "python-threat-modeling-assignment.json",
+    "course": "Python Threat Modeling Assignment",
+    "id": "python-threat-modeling-assignment"
+  },
+  {
     "file": "react.json",
     "course": "React",
     "id": "react"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -10642,6 +10642,34 @@ const courseOutlines = {
       }
     ]
   },
+  "Python Threat Modeling Assignment": {
+    "course": "Python Threat Modeling Assignment",
+    "totalHours": 8,
+    "totalModules": 1,
+    "totalLessons": 1,
+    "modules": [
+      {
+        "name": "Capstone — Python Threat Modeling",
+        "hours": 8,
+        "lessons": [
+          {
+            "title": "Capstone — Python Threat Modeling",
+            "hours": 8,
+            "topics": [
+              "Threat-model a software architecture diagram: identify threat actors, attack vectors, and vulnerabilities (OJL 2.a)",
+              "Build a Python log parser — a `LogParser` class with lambda filters — to surface corroborating evidence (OJL 3.d)",
+              "Synthesize a CIA-mapped threat analysis separating confirmed from hypothetical findings",
+              "Author the apprentice evidence map and submit the deliverable set through GitHub"
+            ],
+            "objects": [
+              "Object: Lesson: Capstone — Python Threat Modeling",
+              "Assessment: Quiz: Capstone — Python Threat Modeling"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "React": {
     "course": "React",
     "totalHours": 40,

--- a/outlines/python-threat-modeling-assignment.json
+++ b/outlines/python-threat-modeling-assignment.json
@@ -1,0 +1,28 @@
+{
+  "course": "Python Threat Modeling Assignment",
+  "totalHours": 8,
+  "totalModules": 1,
+  "totalLessons": 1,
+  "modules": [
+    {
+      "name": "Capstone — Python Threat Modeling",
+      "hours": 8,
+      "lessons": [
+        {
+          "title": "Capstone — Python Threat Modeling",
+          "hours": 8,
+          "topics": [
+            "Threat-model a software architecture diagram: identify threat actors, attack vectors, and vulnerabilities (OJL 2.a)",
+            "Build a Python log parser — a `LogParser` class with lambda filters — to surface corroborating evidence (OJL 3.d)",
+            "Synthesize a CIA-mapped threat analysis separating confirmed from hypothetical findings",
+            "Author the apprentice evidence map and submit the deliverable set through GitHub"
+          ],
+          "objects": [
+            "Object: Lesson: Capstone — Python Threat Modeling",
+            "Assessment: Quiz: Capstone — Python Threat Modeling"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Registers the net-new **Python Threat Modeling Assignment** — the first per-course tracking record for the Cyber Developer Associate curriculum (which was registered structure-only in #178). Content Scaffolding (row 5) of onboarding meta `apprenti-org/design-documentation#874` (sub-issue #882).

## Changes
- `courses.json` — new entry: 8h, CDA Phase 2, status **design Complete / development In Progress**, `statusConfirmed: true`, sourceRepo design-documentation.
- `outlines/python-threat-modeling-assignment.json` — generated outline (1 module, 1 capstone lesson, 8h).
- `outlines/manifest.json` — manifest entry.
- `courses.js`, `outlines/outlines.js`, `course-overview.js` — regenerated bundles (`node build.js`).

Net-new course-level capstone: threat-model a software architecture diagram + write a Python `LogParser` to mine system logs for corroborating evidence. OJL 2.a (primary) + 3.d (OOP/lambda). Assessed by a Competency-Based Rubric (no quiz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)