### PR TITLE
Fix convert-syllabi.js hardcoded sandbox paths

### DIFF
--- a/convert-syllabi.js
+++ b/convert-syllabi.js
@@ -1,8 +1,21 @@
 const fs = require('fs');
 const path = require('path');
+const { resolveSyllabiDirs } = require('./resolve-syllabi-dirs');
 
-const coursesDir = '/sessions/busy-relaxed-dirac/mnt/Curriculum for Training Operations/_COURSES Phase 1 - WORKING/courses';
-const syllabiDir = '/sessions/busy-relaxed-dirac/mnt/Curriculum for Training Operations/_COURSES Phase 1 - WORKING/tracking/repo/syllabi';
+// syllabiDir is repo-relative (this tracking repo); coursesDir comes from
+// --workspace=<path> or the SYLLABI_WORKSPACE env var. No hardcoded paths.
+const { coursesDir, syllabiDir } = resolveSyllabiDirs({
+  argv: process.argv,
+  env: process.env,
+  scriptDir: __dirname,
+});
+
+if (!coursesDir) {
+  console.error('ERROR: course source directory not set.');
+  console.error('Pass --workspace=<path to the workspace root> (the folder containing "_COURSES Phase 1 - WORKING/"), or set SYLLABI_WORKSPACE.');
+  console.error('Example: node convert-syllabi.js --workspace="/path/to/Curriculum for Training Operations Code Repository"');
+  process.exit(1);
+}
 
 // CSS from the existing template
 const CSS = `

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node build.js",
     "build:watch": "node build.js --watch",
     "validate": "node build.js --validate",
-    "build:verbose": "node build.js --verbose"
+    "build:verbose": "node build.js --verbose",
+    "test": "node --test"
   }
 }

--- a/resolve-syllabi-dirs.js
+++ b/resolve-syllabi-dirs.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+/**
+ * Resolve the input (courses) and output (syllabi) directories for
+ * convert-syllabi.js without any hardcoded machine/sandbox paths.
+ *
+ * - `syllabiDir` lives inside this tracking repo, so it is derived from the
+ *   script's own directory (repo-relative).
+ * - `coursesDir` lives in the workspace (the Drive folder, separate from this
+ *   repo), so it must come from `--workspace=<path>` or the SYLLABI_WORKSPACE
+ *   env var. When neither is given it is `null` and the caller must error with a
+ *   clear usage message — never fall back to a stale absolute path.
+ *
+ * @param {object} options
+ * @param {string[]} options.argv - process.argv (or any arg array)
+ * @param {object} options.env - process.env (or any env-like object)
+ * @param {string} options.scriptDir - directory of convert-syllabi.js (__dirname)
+ * @returns {{ coursesDir: string|null, syllabiDir: string, workspace: string|null }}
+ */
+function resolveSyllabiDirs({ argv = [], env = {}, scriptDir }) {
+  const syllabiDir = path.join(scriptDir, 'syllabi');
+
+  let workspace = null;
+  const wsArg = argv.find((a) => typeof a === 'string' && a.startsWith('--workspace='));
+  if (wsArg) {
+    workspace = wsArg.slice('--workspace='.length);
+  } else if (env.SYLLABI_WORKSPACE) {
+    workspace = env.SYLLABI_WORKSPACE;
+  }
+
+  const coursesDir = workspace
+    ? path.join(workspace, '_COURSES Phase 1 - WORKING', 'courses')
+    : null;
+
+  return { coursesDir, syllabiDir, workspace };
+}
+
+module.exports = { resolveSyllabiDirs };

--- a/resolve-syllabi-dirs.test.js
+++ b/resolve-syllabi-dirs.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const { resolveSyllabiDirs } = require('./resolve-syllabi-dirs');
+
+test('syllabiDir is always derived from the script dir (this tracking repo)', () => {
+  const { syllabiDir } = resolveSyllabiDirs({ argv: [], env: {}, scriptDir: '/repo' });
+  assert.strictEqual(syllabiDir, path.join('/repo', 'syllabi'));
+});
+
+test('coursesDir is derived from a --workspace= argument', () => {
+  const { coursesDir } = resolveSyllabiDirs({
+    argv: ['--workspace=/ws'],
+    env: {},
+    scriptDir: '/repo',
+  });
+  assert.strictEqual(coursesDir, path.join('/ws', '_COURSES Phase 1 - WORKING', 'courses'));
+});
+
+test('coursesDir falls back to the SYLLABI_WORKSPACE env var', () => {
+  const { coursesDir } = resolveSyllabiDirs({
+    argv: [],
+    env: { SYLLABI_WORKSPACE: '/envws' },
+    scriptDir: '/repo',
+  });
+  assert.strictEqual(coursesDir, path.join('/envws', '_COURSES Phase 1 - WORKING', 'courses'));
+});
+
+test('--workspace= takes precedence over the env var', () => {
+  const { coursesDir } = resolveSyllabiDirs({
+    argv: ['--workspace=/argws'],
+    env: { SYLLABI_WORKSPACE: '/envws' },
+    scriptDir: '/repo',
+  });
+  assert.strictEqual(coursesDir, path.join('/argws', '_COURSES Phase 1 - WORKING', 'courses'));
+});
+
+test('coursesDir is null when no workspace is provided (caller must error, not ENOENT a stale path)', () => {
+  const { coursesDir } = resolveSyllabiDirs({ argv: [], env: {}, scriptDir: '/repo' });
+  assert.strictEqual(coursesDir, null);
+});
+
+test('no hardcoded sandbox path leaks through', () => {
+  const r = resolveSyllabiDirs({ argv: ['--workspace=/ws'], env: {}, scriptDir: '/repo' });
+  assert.ok(!r.syllabiDir.includes('busy-relaxed-dirac'));
+  assert.ok(!String(r.coursesDir).includes('busy-relaxed-dirac'));
+});


### PR DESCRIPTION
Fixes apprenti-org/design-documentation#844.

`convert-syllabi.js` hardcoded `coursesDir`/`syllabiDir` to a stale sandbox path (`/sessions/busy-relaxed-dirac/...`), throwing ENOENT anywhere else with no override — so regenerating any syllabus HTML (Course Ingestion step 11 / Pre-Upload Reconciliation R4) required hand-patching the script.

## Fix
- New **`resolve-syllabi-dirs.js`** — a pure resolver: `syllabiDir` is repo-relative (script dir); `coursesDir` comes from `--workspace=<path>` or `SYLLABI_WORKSPACE`, and is `null` (with a clear usage error) when neither is given — never a stale absolute path.
- Wired into `convert-syllabi.js` (the only change there: the two hardcoded constants + a usage guard).
- **6 `node:test` unit tests** (no new deps) + an npm `test` script.

## Verified
- Unit tests 6/6 green.
- Real `--workspace` run regenerates syllabi with no ENOENT.
- Bogus `--workspace` errors on the **derived** path, not `busy-relaxed-dirac`.