### PR TITLE
Backfill SCORM objects[] for python-infrastructure-automation (15 lessons)

### DIFF
--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -10402,7 +10402,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: File and System Operations",
-              "Assessment: Quiz: File and System Operations"
+              "Assessment: Quiz: File and System Operations",
+              "SCORM: Interactive — File and System Operations (scorm-lesson-01-file-and-system-operations.zip)"
             ]
           },
           {
@@ -10417,7 +10418,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Regular Expressions and Text Processing",
-              "Assessment: Quiz: Regular Expressions and Text Processing"
+              "Assessment: Quiz: Regular Expressions and Text Processing",
+              "SCORM: Interactive — Regular Expressions and Text Processing (scorm-lesson-02-regular-expressions-and-text-processing.zip)"
             ]
           },
           {
@@ -10432,7 +10434,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Network Programming Basics",
-              "Assessment: Quiz: Network Programming Basics"
+              "Assessment: Quiz: Network Programming Basics",
+              "SCORM: Interactive — Network Programming Basics (scorm-lesson-03-network-programming-basics.zip)"
             ]
           }
         ]
@@ -10453,7 +10456,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Configuration Management Scripts",
-              "Assessment: Quiz: Configuration Management Scripts"
+              "Assessment: Quiz: Configuration Management Scripts",
+              "SCORM: Interactive — Configuration Management Scripts (scorm-lesson-04-configuration-management-scripts.zip)"
             ]
           },
           {
@@ -10468,7 +10472,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Monitoring and Alerting Scripts",
-              "Assessment: Quiz: Monitoring and Alerting Scripts"
+              "Assessment: Quiz: Monitoring and Alerting Scripts",
+              "SCORM: Interactive — Monitoring and Alerting Scripts (scorm-lesson-05-monitoring-and-alerting-scripts.zip)"
             ]
           },
           {
@@ -10483,7 +10488,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Backup and Disaster Recovery Automation",
-              "Assessment: Quiz: Backup and Disaster Recovery Automation"
+              "Assessment: Quiz: Backup and Disaster Recovery Automation",
+              "SCORM: Interactive — Backup and Disaster Recovery Automation (scorm-lesson-06-backup-and-disaster-recovery-automation.zip)"
             ]
           },
           {
@@ -10498,7 +10504,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Deployment and Provisioning Scripts",
-              "Assessment: Quiz: Deployment and Provisioning Scripts"
+              "Assessment: Quiz: Deployment and Provisioning Scripts",
+              "SCORM: Interactive — Deployment and Provisioning Scripts (scorm-lesson-07-deployment-and-provisioning-scripts.zip)"
             ]
           }
         ]
@@ -10519,7 +10526,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: RESTful APIs and Cloud SDKs",
-              "Assessment: Quiz: RESTful APIs and Cloud SDKs"
+              "Assessment: Quiz: RESTful APIs and Cloud SDKs",
+              "SCORM: Interactive — RESTful APIs and Cloud SDKs (scorm-lesson-08-restful-apis-and-cloud-sdks.zip)"
             ]
           },
           {
@@ -10534,7 +10542,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Infrastructure as Code with Python",
-              "Assessment: Quiz: Infrastructure as Code with Python"
+              "Assessment: Quiz: Infrastructure as Code with Python",
+              "SCORM: Interactive — Infrastructure as Code with Python (scorm-lesson-09-infrastructure-as-code-with-python.zip)"
             ]
           },
           {
@@ -10549,7 +10558,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Monitoring and Logging Integration",
-              "Assessment: Quiz: Monitoring and Logging Integration"
+              "Assessment: Quiz: Monitoring and Logging Integration",
+              "SCORM: Interactive — Monitoring and Logging Integration (scorm-lesson-10-monitoring-and-logging-integration.zip)"
             ]
           },
           {
@@ -10564,7 +10574,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Continuous Integration with Python",
-              "Assessment: Quiz: Continuous Integration with Python"
+              "Assessment: Quiz: Continuous Integration with Python",
+              "SCORM: Interactive — Continuous Integration with Python (scorm-lesson-11-continuous-integration-with-python.zip)"
             ]
           }
         ]
@@ -10585,7 +10596,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Error Handling and Resilience",
-              "Assessment: Quiz: Error Handling and Resilience"
+              "Assessment: Quiz: Error Handling and Resilience",
+              "SCORM: Interactive — Error Handling and Resilience (scorm-lesson-12-error-handling-and-resilience.zip)"
             ]
           },
           {
@@ -10600,7 +10612,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Concurrency and Parallel Processing",
-              "Assessment: Quiz: Concurrency and Parallel Processing"
+              "Assessment: Quiz: Concurrency and Parallel Processing",
+              "SCORM: Interactive — Concurrency and Parallel Processing (scorm-lesson-13-concurrency-and-parallel-processing.zip)"
             ]
           },
           {
@@ -10615,7 +10628,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Security and Secret Management",
-              "Assessment: Quiz: Security and Secret Management"
+              "Assessment: Quiz: Security and Secret Management",
+              "SCORM: Interactive — Security and Secret Management (scorm-lesson-14-security-and-secret-management.zip)"
             ]
           },
           {
@@ -10630,7 +10644,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Production Automation Patterns",
-              "Assessment: Quiz: Production Automation Patterns"
+              "Assessment: Quiz: Production Automation Patterns",
+              "SCORM: Interactive — Production Automation Patterns (scorm-lesson-15-production-automation-patterns.zip)"
             ]
           }
         ]

--- a/outlines/python-infrastructure-automation.json
+++ b/outlines/python-infrastructure-automation.json
@@ -20,7 +20,8 @@
           ],
           "objects": [
             "Object: Lesson: File and System Operations",
-            "Assessment: Quiz: File and System Operations"
+            "Assessment: Quiz: File and System Operations",
+            "SCORM: Interactive — File and System Operations (scorm-lesson-01-file-and-system-operations.zip)"
           ]
         },
         {
@@ -35,7 +36,8 @@
           ],
           "objects": [
             "Object: Lesson: Regular Expressions and Text Processing",
-            "Assessment: Quiz: Regular Expressions and Text Processing"
+            "Assessment: Quiz: Regular Expressions and Text Processing",
+            "SCORM: Interactive — Regular Expressions and Text Processing (scorm-lesson-02-regular-expressions-and-text-processing.zip)"
           ]
         },
         {
@@ -50,7 +52,8 @@
           ],
           "objects": [
             "Object: Lesson: Network Programming Basics",
-            "Assessment: Quiz: Network Programming Basics"
+            "Assessment: Quiz: Network Programming Basics",
+            "SCORM: Interactive — Network Programming Basics (scorm-lesson-03-network-programming-basics.zip)"
           ]
         }
       ]
@@ -71,7 +74,8 @@
           ],
           "objects": [
             "Object: Lesson: Configuration Management Scripts",
-            "Assessment: Quiz: Configuration Management Scripts"
+            "Assessment: Quiz: Configuration Management Scripts",
+            "SCORM: Interactive — Configuration Management Scripts (scorm-lesson-04-configuration-management-scripts.zip)"
           ]
         },
         {
@@ -86,7 +90,8 @@
           ],
           "objects": [
             "Object: Lesson: Monitoring and Alerting Scripts",
-            "Assessment: Quiz: Monitoring and Alerting Scripts"
+            "Assessment: Quiz: Monitoring and Alerting Scripts",
+            "SCORM: Interactive — Monitoring and Alerting Scripts (scorm-lesson-05-monitoring-and-alerting-scripts.zip)"
           ]
         },
         {
@@ -101,7 +106,8 @@
           ],
           "objects": [
             "Object: Lesson: Backup and Disaster Recovery Automation",
-            "Assessment: Quiz: Backup and Disaster Recovery Automation"
+            "Assessment: Quiz: Backup and Disaster Recovery Automation",
+            "SCORM: Interactive — Backup and Disaster Recovery Automation (scorm-lesson-06-backup-and-disaster-recovery-automation.zip)"
           ]
         },
         {
@@ -116,7 +122,8 @@
           ],
           "objects": [
             "Object: Lesson: Deployment and Provisioning Scripts",
-            "Assessment: Quiz: Deployment and Provisioning Scripts"
+            "Assessment: Quiz: Deployment and Provisioning Scripts",
+            "SCORM: Interactive — Deployment and Provisioning Scripts (scorm-lesson-07-deployment-and-provisioning-scripts.zip)"
           ]
         }
       ]
@@ -137,7 +144,8 @@
           ],
           "objects": [
             "Object: Lesson: RESTful APIs and Cloud SDKs",
-            "Assessment: Quiz: RESTful APIs and Cloud SDKs"
+            "Assessment: Quiz: RESTful APIs and Cloud SDKs",
+            "SCORM: Interactive — RESTful APIs and Cloud SDKs (scorm-lesson-08-restful-apis-and-cloud-sdks.zip)"
           ]
         },
         {
@@ -152,7 +160,8 @@
           ],
           "objects": [
             "Object: Lesson: Infrastructure as Code with Python",
-            "Assessment: Quiz: Infrastructure as Code with Python"
+            "Assessment: Quiz: Infrastructure as Code with Python",
+            "SCORM: Interactive — Infrastructure as Code with Python (scorm-lesson-09-infrastructure-as-code-with-python.zip)"
           ]
         },
         {
@@ -167,7 +176,8 @@
           ],
           "objects": [
             "Object: Lesson: Monitoring and Logging Integration",
-            "Assessment: Quiz: Monitoring and Logging Integration"
+            "Assessment: Quiz: Monitoring and Logging Integration",
+            "SCORM: Interactive — Monitoring and Logging Integration (scorm-lesson-10-monitoring-and-logging-integration.zip)"
           ]
         },
         {
@@ -182,7 +192,8 @@
           ],
           "objects": [
             "Object: Lesson: Continuous Integration with Python",
-            "Assessment: Quiz: Continuous Integration with Python"
+            "Assessment: Quiz: Continuous Integration with Python",
+            "SCORM: Interactive — Continuous Integration with Python (scorm-lesson-11-continuous-integration-with-python.zip)"
           ]
         }
       ]
@@ -203,7 +214,8 @@
           ],
           "objects": [
             "Object: Lesson: Error Handling and Resilience",
-            "Assessment: Quiz: Error Handling and Resilience"
+            "Assessment: Quiz: Error Handling and Resilience",
+            "SCORM: Interactive — Error Handling and Resilience (scorm-lesson-12-error-handling-and-resilience.zip)"
           ]
         },
         {
@@ -218,7 +230,8 @@
           ],
           "objects": [
             "Object: Lesson: Concurrency and Parallel Processing",
-            "Assessment: Quiz: Concurrency and Parallel Processing"
+            "Assessment: Quiz: Concurrency and Parallel Processing",
+            "SCORM: Interactive — Concurrency and Parallel Processing (scorm-lesson-13-concurrency-and-parallel-processing.zip)"
           ]
         },
         {
@@ -233,7 +246,8 @@
           ],
           "objects": [
             "Object: Lesson: Security and Secret Management",
-            "Assessment: Quiz: Security and Secret Management"
+            "Assessment: Quiz: Security and Secret Management",
+            "SCORM: Interactive — Security and Secret Management (scorm-lesson-14-security-and-secret-management.zip)"
           ]
         },
         {
@@ -248,7 +262,8 @@
           ],
           "objects": [
             "Object: Lesson: Production Automation Patterns",
-            "Assessment: Quiz: Production Automation Patterns"
+            "Assessment: Quiz: Production Automation Patterns",
+            "SCORM: Interactive — Production Automation Patterns (scorm-lesson-15-production-automation-patterns.zip)"
           ]
         }
       ]


### PR DESCRIPTION
Registers the 15 re-cut PIA SCORM interactives in each lesson's `objects[]` (was empty), under the current `scorm-lesson-NN-<slug>.zip` naming. Satisfies Pre-Upload Reconciliation R3.

Context: the PIA QA remediation re-aligned all 15 interactives (knowledge-check option length + distractor bias + LO markup), then re-cut the 15 SCORMs under the tool's current naming convention. This registers them.

Regenerated `outlines/outlines.js` via `node build.js`.

Part of apprenti-org/design-documentation#946 (umbrella #942, LMS update #948).

🤖 Generated with [Claude Code](https://claude.com/claude-code)