### PR TITLE
introduction-to-github-secure: live in Absorb (2026-06-15)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -599,7 +599,7 @@ const courseData = [
     },
     "syllabus": null,
     "outline": true,
-    "note": "Cyber Developer Associate condensed 6h edition of Introduction to GitHub (new -secure course, distinct from the shared introduction-to-github). 2 modules, 5 lessons: Git Background; GitHub for Individuals; GitHub for Groups; Resolving Merge Conflicts; Secrets and Credentials Hygiene. Content + interactive.html + SCORM + deploy repos (content/instructor/student) + instructor guides & pacing all complete. Slides deferred (#606). Built from the migrated reference (course-design/intro-to-github/source/). Onboarding meta apprenti-org/design-documentation#834.",
+    "note": "Cyber Developer Associate condensed 6h edition of Introduction to GitHub (new -secure course, distinct from the shared introduction-to-github). 2 modules, 5 lessons: Git Background; GitHub for Individuals; GitHub for Groups; Resolving Merge Conflicts; Secrets and Credentials Hygiene. Content + interactive.html + SCORM + deploy repos (content/instructor/student) + instructor guides & pacing all complete. Slides deferred (#606). Built from the migrated reference (course-design/intro-to-github/source/). Onboarding meta apprenti-org/design-documentation#834. Live in Absorb 2026-06-15.",
     "driveFolder": null,
     "statusConfirmed": true,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"

--- a/courses.json
+++ b/courses.json
@@ -597,7 +597,7 @@
       },
       "syllabus": null,
       "outline": true,
-      "note": "Cyber Developer Associate condensed 6h edition of Introduction to GitHub (new -secure course, distinct from the shared introduction-to-github). 2 modules, 5 lessons: Git Background; GitHub for Individuals; GitHub for Groups; Resolving Merge Conflicts; Secrets and Credentials Hygiene. Content + interactive.html + SCORM + deploy repos (content/instructor/student) + instructor guides & pacing all complete. Slides deferred (#606). Built from the migrated reference (course-design/intro-to-github/source/). Onboarding meta apprenti-org/design-documentation#834.",
+      "note": "Cyber Developer Associate condensed 6h edition of Introduction to GitHub (new -secure course, distinct from the shared introduction-to-github). 2 modules, 5 lessons: Git Background; GitHub for Individuals; GitHub for Groups; Resolving Merge Conflicts; Secrets and Credentials Hygiene. Content + interactive.html + SCORM + deploy repos (content/instructor/student) + instructor guides & pacing all complete. Slides deferred (#606). Built from the migrated reference (course-design/intro-to-github/source/). Onboarding meta apprenti-org/design-documentation#834. Live in Absorb 2026-06-15.",
       "driveFolder": null,
       "statusConfirmed": true,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"


### PR DESCRIPTION
Records the LMS publish of `introduction-to-github-secure` (Cyber Developer Associate, 6h) in its course note. Status was already Complete/Complete/confirmed (set at Deployment #842); this is the publish-date record. Onboarding meta apprenti-org/design-documentation#834 closing alongside.