### PR TITLE
llm-history-and-capabilities: live in Absorb (2026-06-15)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -814,7 +814,7 @@ const courseData = [
     },
     "syllabus": null,
     "outline": true,
-    "note": "Cyber Developer Associate net-new 8h Phase 1 course. 2 modules, 5 lessons: A Brief History of AI and Machine Learning; What LLMs Can and Cannot Do; How LLMs Work (Tokens, Context Windows, Inference); LLM Failure Modes (Hallucination, Drift, Boundary Conditions); LLM Limitations and Secure Software Development. Design complete (course outline + standard-alignment report + 5 lesson outlines + 5 lesson sources). Development in progress (Content Scaffolding, Phase 0+1). Onboarding meta apprenti-org/design-documentation#849.",
+    "note": "Cyber Developer Associate net-new 8h Phase 1 course. 2 modules, 5 lessons: A Brief History of AI and Machine Learning; What LLMs Can and Cannot Do; How LLMs Work (Tokens, Context Windows, Inference); LLM Failure Modes (Hallucination, Drift, Boundary Conditions); LLM Limitations and Secure Software Development. Design complete (course outline + standard-alignment report + 5 lesson outlines + 5 lesson sources). Development complete (full lifecycle through deploy + SCORM). Onboarding meta apprenti-org/design-documentation#849. Live in Absorb 2026-06-15.",
     "driveFolder": null,
     "statusConfirmed": true,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"

--- a/courses.json
+++ b/courses.json
@@ -812,7 +812,7 @@
       },
       "syllabus": null,
       "outline": true,
-      "note": "Cyber Developer Associate net-new 8h Phase 1 course. 2 modules, 5 lessons: A Brief History of AI and Machine Learning; What LLMs Can and Cannot Do; How LLMs Work (Tokens, Context Windows, Inference); LLM Failure Modes (Hallucination, Drift, Boundary Conditions); LLM Limitations and Secure Software Development. Design complete (course outline + standard-alignment report + 5 lesson outlines + 5 lesson sources). Development in progress (Content Scaffolding, Phase 0+1). Onboarding meta apprenti-org/design-documentation#849.",
+      "note": "Cyber Developer Associate net-new 8h Phase 1 course. 2 modules, 5 lessons: A Brief History of AI and Machine Learning; What LLMs Can and Cannot Do; How LLMs Work (Tokens, Context Windows, Inference); LLM Failure Modes (Hallucination, Drift, Boundary Conditions); LLM Limitations and Secure Software Development. Design complete (course outline + standard-alignment report + 5 lesson outlines + 5 lesson sources). Development complete (full lifecycle through deploy + SCORM). Onboarding meta apprenti-org/design-documentation#849. Live in Absorb 2026-06-15.",
       "driveFolder": null,
       "statusConfirmed": true,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"


### PR DESCRIPTION
Records the LMS publish of the CDA Phase-1 net-new course `llm-history-and-capabilities` and corrects the stale 'development in progress' note (status was already Complete/Complete/confirmed at Deployment #864). Onboarding meta apprenti-org/design-documentation#849 closing alongside.