### PR TITLE
Add secure-llm-api-integration tracking record (CDA Phase 5)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -1051,6 +1051,21 @@ const courseData = [
     "statusConfirmed": false
   },
   {
+    "id": "secure-llm-api-integration",
+    "name": "Secure LLM API Integration (Cyber Developer Associate)",
+    "hours": 20,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate net-new 20h Phase 5 course. 3 modules, 8 lessons (L8 capstone). Design complete; content production (Row 7, apprenti-org/design-documentation#1023) and SCORM packaging (Row 9, #1026) complete; deployment pending (development flips to Complete at Pre-Upload Reconciliation per precedent). Security focus: consuming LLM APIs safely, defending the AI boundary against prompt injection and data leakage, and building a secure Python LLM microservice. OJL 1.c. Onboarding meta apprenti-org/design-documentation#1013.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "security-and-cybersecurity-fundamentals",
     "name": "Security and Cybersecurity Fundamentals",
     "hours": 220,

--- a/courses.json
+++ b/courses.json
@@ -1049,6 +1049,21 @@
       "statusConfirmed": false
     },
     {
+      "id": "secure-llm-api-integration",
+      "name": "Secure LLM API Integration (Cyber Developer Associate)",
+      "hours": 20,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate net-new 20h Phase 5 course. 3 modules, 8 lessons (L8 capstone). Design complete; content production (Row 7, apprenti-org/design-documentation#1023) and SCORM packaging (Row 9, #1026) complete; deployment pending (development flips to Complete at Pre-Upload Reconciliation per precedent). Security focus: consuming LLM APIs safely, defending the AI boundary against prompt injection and data leakage, and building a secure Python LLM microservice. OJL 1.c. Onboarding meta apprenti-org/design-documentation#1013.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "security-and-cybersecurity-fundamentals",
       "name": "Security and Cybersecurity Fundamentals",
       "hours": 220,


### PR DESCRIPTION
Fills the missing `courses.json` record for **secure-llm-api-integration**. The Row-5 registration (#198) added the outline (`outlines/secure-llm-api-integration.json`) but not the `courses.json` entry — this PR adds it so the Row-10 Deployment prerequisite (a tracking record for the course) is satisfied.

**State** mirrors the `docker-container-isolation` precedent at record-creation time:
- `status.design: Complete`, `status.development: "In Progress"` — development flips to `Complete` at Pre-Upload Reconciliation (Row 13), per the established sequence (docker deployed while still "In Progress" and flipped at reconciliation #196).
- `statusConfirmed: false`, `outline: true`, `hours: 20`, `sourceRepo: design-documentation`.

Content production (apprenti-org/design-documentation#1023) and SCORM packaging (#1026) are complete; deployment pending.

Record inserted in alphabetical-by-name order; `courses.js` bundle regenerated via `build.js` (validate passes). Outline bundle already current from #198, so unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)