### PR TITLE
Add outline JSON: spring-mvc-secure-coding (CDA Phase 5)

### DIFF
--- a/outlines/spring-mvc-secure-coding.json
+++ b/outlines/spring-mvc-secure-coding.json
@@ -1,0 +1,104 @@
+{
+  "course": "Spring MVC Secure Coding",
+  "totalHours": 10,
+  "totalModules": 3,
+  "totalLessons": 6,
+  "modules": [
+    {
+      "name": "Spring MVC Foundations",
+      "hours": 3,
+      "lessons": [
+        {
+          "title": "HTTP, JSON, and the Spring MVC Request Lifecycle",
+          "hours": 1.5,
+          "topics": [
+            "The request lifecycle: from `DispatcherServlet` through handler mapping to the controller",
+            "How HTTP bodies and JSON bind to method parameters and DTOs",
+            "Where untrusted input enters — the attack surface of a Spring endpoint"
+          ],
+          "objects": [
+            "Object: Lesson: HTTP, JSON, and the Spring MVC Request Lifecycle",
+            "Assessment: Quiz: HTTP, JSON, and the Spring MVC Request Lifecycle"
+          ]
+        },
+        {
+          "title": "Controllers, Request Mapping, and Input Validation",
+          "hours": 1.5,
+          "topics": [
+            "`@RestController`, request mapping, and DTO-based request binding",
+            "Bean Validation (`@Valid`, constraint annotations) to enforce shape and bounds",
+            "Rejecting malformed or hostile requests before they reach business logic"
+          ],
+          "objects": [
+            "Object: Lesson: Controllers, Request Mapping, and Input Validation",
+            "Assessment: Quiz: Controllers, Request Mapping, and Input Validation"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Securing the Endpoints",
+      "hours": 4,
+      "lessons": [
+        {
+          "title": "Secure REST Endpoint Design — Headers, CSRF, and CORS",
+          "hours": 1.5,
+          "topics": [
+            "Security response headers and why they matter for an API",
+            "CSRF protection: when it applies to REST endpoints and how Spring enforces it",
+            "Configuring CORS as a least-privilege allow-list, not a wildcard"
+          ],
+          "objects": [
+            "Object: Lesson: Secure REST Endpoint Design — Headers, CSRF, and CORS",
+            "Assessment: Quiz: Secure REST Endpoint Design — Headers, CSRF, and CORS"
+          ]
+        },
+        {
+          "title": "Spring Security Essentials — Authentication and Authorization",
+          "hours": 1.5,
+          "topics": [
+            "The Spring Security filter chain and where it sits in the request lifecycle",
+            "Authentication primitives: establishing who is calling",
+            "Authorization primitives: protecting endpoints by role and least privilege"
+          ],
+          "objects": [
+            "Object: Lesson: Spring Security Essentials — Authentication and Authorization",
+            "Assessment: Quiz: Spring Security Essentials — Authentication and Authorization"
+          ]
+        },
+        {
+          "title": "Secure Error Handling — No Stack-Trace Leakage",
+          "hours": 1,
+          "topics": [
+            "How default error responses leak stack traces, types, and system internals",
+            "Centralized exception handling (`@ControllerAdvice` / `@ExceptionHandler`) for safe responses",
+            "Returning useful, non-revealing error payloads and correct status codes"
+          ],
+          "objects": [
+            "Object: Lesson: Secure Error Handling — No Stack-Trace Leakage",
+            "Assessment: Quiz: Secure Error Handling — No Stack-Trace Leakage"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Secure-Endpoint Capstone",
+      "hours": 3,
+      "lessons": [
+        {
+          "title": "Secure-Endpoint Capstone Lab",
+          "hours": 3,
+          "topics": [
+            "Build a REST endpoint that validates input, authenticates and authorizes callers, sets correct headers/CSRF/CORS, and handles errors safely",
+            "Audit the endpoint against the course's secure-coding controls",
+            "Demonstrate the endpoint resists a scripted set of attacks (bad input, unauthorized access, error-leak probes)"
+          ],
+          "objects": [
+            "Object: Lesson: Secure-Endpoint Capstone Lab",
+            "Assessment: Quiz: Secure-Endpoint Capstone Lab"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Row 5 (Content Scaffolding, Phase 0) of onboarding meta `apprenti-org/design-documentation#1051`.

Adds `outlines/spring-mvc-secure-coding.json` (generated by the content-dev extractor Phase 0) — Spring MVC Secure Coding, 10h / 3 modules / 6 lessons.

`outlines/manifest.json` entry, `courses.json` record, and bundle regeneration are deferred to **Row 13 Pre-Upload Reconciliation**, matching the XSS precedent (a net-new CDA course is not registered on the dashboard until its content is built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)