### PR TITLE
Register spring-mvc-secure-coding for upload (Row 13)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -1108,6 +1108,21 @@ const courseData = [
     "statusConfirmed": false
   },
   {
+    "id": "spring-mvc-secure-coding",
+    "name": "Spring MVC Secure Coding (Cyber Developer Associate)",
+    "hours": 10,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": "Syllabus: Spring MVC Secure Coding",
+    "outline": true,
+    "note": "Cyber Developer Associate net-new 10h Phase 5 course. 3 modules, 6 lessons (L6 capstone). Covers the 'Spring MVC with secure coding' clause of the shared Advanced Java RTI topic; teaches Spring MVC through a security lens — input validation, secure transport (headers/CSRF/CORS), Spring Security authn/authz, and safe error handling. Design + content (Row 7, apprenti-org/design-documentation#1063) + SCORM (Row 9, #1064) + deployment (Row 10, #1065) + instructor/pacing guide (Row 11, #1066) + starter asset audit (Row 12, #1067) complete; LMS upload (Row 14) pending. No OJL claimed (topic-coverage course; consistent with the 15/15-verified curriculum mapping). Onboarding meta #1051.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "sql-coding-booster-intensive",
     "name": "SQL Coding Booster Intensive",
     "hours": 8,

--- a/courses.json
+++ b/courses.json
@@ -1106,6 +1106,21 @@
       "statusConfirmed": false
     },
     {
+      "id": "spring-mvc-secure-coding",
+      "name": "Spring MVC Secure Coding (Cyber Developer Associate)",
+      "hours": 10,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": "Syllabus: Spring MVC Secure Coding",
+      "outline": true,
+      "note": "Cyber Developer Associate net-new 10h Phase 5 course. 3 modules, 6 lessons (L6 capstone). Covers the 'Spring MVC with secure coding' clause of the shared Advanced Java RTI topic; teaches Spring MVC through a security lens — input validation, secure transport (headers/CSRF/CORS), Spring Security authn/authz, and safe error handling. Design + content (Row 7, apprenti-org/design-documentation#1063) + SCORM (Row 9, #1064) + deployment (Row 10, #1065) + instructor/pacing guide (Row 11, #1066) + starter asset audit (Row 12, #1067) complete; LMS upload (Row 14) pending. No OJL claimed (topic-coverage course; consistent with the 15/15-verified curriculum mapping). Onboarding meta #1051.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "sql-coding-booster-intensive",
       "name": "SQL Coding Booster Intensive",
       "hours": 8,

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -350,6 +350,11 @@
   "id": "software-development-lifecycle"
  },
  {
+  "file": "spring-mvc-secure-coding.json",
+  "course": "Spring MVC Secure Coding",
+  "id": "spring-mvc-secure-coding"
+ },
+ {
   "file": "sql-coding-booster.json",
   "course": "SQL Coding Booster Intensive",
   "id": "sql-coding-booster-intensive"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -11653,6 +11653,116 @@ const courseOutlines = {
       }
     ]
   },
+  "Spring MVC Secure Coding": {
+    "course": "Spring MVC Secure Coding",
+    "totalHours": 10,
+    "totalModules": 3,
+    "totalLessons": 6,
+    "modules": [
+      {
+        "name": "Spring MVC Foundations",
+        "hours": 3,
+        "lessons": [
+          {
+            "title": "HTTP, JSON, and the Spring MVC Request Lifecycle",
+            "hours": 1.5,
+            "topics": [
+              "The request lifecycle: from `DispatcherServlet` through handler mapping to the controller",
+              "How HTTP bodies and JSON bind to method parameters and DTOs",
+              "Where untrusted input enters — the attack surface of a Spring endpoint"
+            ],
+            "objects": [
+              "Object: Lesson: HTTP, JSON, and the Spring MVC Request Lifecycle",
+              "Assessment: Quiz: HTTP, JSON, and the Spring MVC Request Lifecycle",
+              "SCORM: Interactive — HTTP, JSON, and the Spring MVC Request Lifecycle (scorm-lesson-01-http-json-and-the-spring-mvc-request-lifecycle.zip)"
+            ]
+          },
+          {
+            "title": "Controllers, Request Mapping, and Input Validation",
+            "hours": 1.5,
+            "topics": [
+              "`@RestController`, request mapping, and DTO-based request binding",
+              "Bean Validation (`@Valid`, constraint annotations) to enforce shape and bounds",
+              "Rejecting malformed or hostile requests before they reach business logic"
+            ],
+            "objects": [
+              "Object: Lesson: Controllers, Request Mapping, and Input Validation",
+              "Assessment: Quiz: Controllers, Request Mapping, and Input Validation",
+              "SCORM: Interactive — Controllers, Request Mapping, and Input Validation (scorm-lesson-02-controllers-request-mapping-and-input-validation.zip)"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Securing the Endpoints",
+        "hours": 4,
+        "lessons": [
+          {
+            "title": "Secure REST Endpoint Design — Headers, CSRF, and CORS",
+            "hours": 1.5,
+            "topics": [
+              "Security response headers and why they matter for an API",
+              "CSRF protection: when it applies to REST endpoints and how Spring enforces it",
+              "Configuring CORS as a least-privilege allow-list, not a wildcard"
+            ],
+            "objects": [
+              "Object: Lesson: Secure REST Endpoint Design — Headers, CSRF, and CORS",
+              "Assessment: Quiz: Secure REST Endpoint Design — Headers, CSRF, and CORS",
+              "SCORM: Interactive — Secure REST Endpoint Design — Headers, CSRF, and CORS (scorm-lesson-03-secure-rest-endpoint-design-headers-csrf-cors.zip)"
+            ]
+          },
+          {
+            "title": "Spring Security Essentials — Authentication and Authorization",
+            "hours": 1.5,
+            "topics": [
+              "The Spring Security filter chain and where it sits in the request lifecycle",
+              "Authentication primitives: establishing who is calling",
+              "Authorization primitives: protecting endpoints by role and least privilege"
+            ],
+            "objects": [
+              "Object: Lesson: Spring Security Essentials — Authentication and Authorization",
+              "Assessment: Quiz: Spring Security Essentials — Authentication and Authorization",
+              "SCORM: Interactive — Spring Security Essentials — Authentication and Authorization (scorm-lesson-04-spring-security-essentials-authentication-and-authorization.zip)"
+            ]
+          },
+          {
+            "title": "Secure Error Handling — No Stack-Trace Leakage",
+            "hours": 1,
+            "topics": [
+              "How default error responses leak stack traces, types, and system internals",
+              "Centralized exception handling (`@ControllerAdvice` / `@ExceptionHandler`) for safe responses",
+              "Returning useful, non-revealing error payloads and correct status codes"
+            ],
+            "objects": [
+              "Object: Lesson: Secure Error Handling — No Stack-Trace Leakage",
+              "Assessment: Quiz: Secure Error Handling — No Stack-Trace Leakage",
+              "SCORM: Interactive — Secure Error Handling — No Stack-Trace Leakage (scorm-lesson-05-secure-error-handling-no-stack-trace-leakage.zip)"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Secure-Endpoint Capstone",
+        "hours": 3,
+        "lessons": [
+          {
+            "title": "Secure-Endpoint Capstone Lab",
+            "hours": 3,
+            "topics": [
+              "Build a REST endpoint that validates input, authenticates and authorizes callers, sets correct headers/CSRF/CORS, and handles errors safely",
+              "Audit the endpoint against the course's secure-coding controls",
+              "Demonstrate the endpoint resists a scripted set of attacks (bad input, unauthorized access, error-leak probes)"
+            ],
+            "objects": [
+              "Object: Lesson: Secure-Endpoint Capstone Lab",
+              "Assessment: Quiz: Secure-Endpoint Capstone Lab",
+              "SCORM: Interactive — Secure-Endpoint Capstone Lab (scorm-lesson-06-secure-endpoint-capstone-lab.zip)"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "SQL Coding Booster Intensive": {
     "course": "SQL Coding Booster Intensive",
     "totalHours": 8,

--- a/syllabi/spring-mvc-secure-coding.html
+++ b/syllabi/spring-mvc-secure-coding.html
@@ -1,0 +1,428 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Syllabus: Spring MVC Secure Coding</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+:root[data-theme="dark"] {
+    --bg: #111117;
+    --surface: #1A1B23;
+    --surface-raised: #22232D;
+    --border: #2E2F3A;
+    --border-subtle: #23242E;
+    --text-primary: #F0F0EC;
+    --text-secondary: #C8C9CE;
+    --text-muted: #8B8D98;
+    --sky-blue: #8ECAE6;
+    --blue-green: #219EBC;
+    --deep-space: #023047;
+    --amber: #FFB703;
+    --tiger: #FB8500;
+    --link: #219EBC;
+    --link-hover: #8ECAE6;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+.page {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px 32px 120px;
+}
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--link);
+    text-decoration: none;
+    font-size: 13px;
+    margin-bottom: 24px;
+}
+.back-link:hover { color: var(--link-hover); }
+.header {
+    margin-bottom: 32px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+}
+.header h1 {
+    font-size: 26px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.header-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+.header-meta span {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: rgba(255, 183, 3, 0.12);
+    color: var(--amber);
+}
+section { margin-bottom: 32px; }
+section h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+section h2 i { opacity: 0.6; font-size: 15px; }
+p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+}
+.divider {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: 28px 0;
+}
+.outcomes {
+    list-style: none;
+    counter-reset: outcome;
+}
+.outcomes li {
+    counter-increment: outcome;
+    font-size: 14px;
+    color: var(--text-secondary);
+    padding: 6px 0;
+    display: flex;
+    gap: 10px;
+}
+.outcomes li::before {
+    content: counter(outcome) ".";
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 24px;
+    text-align: right;
+}
+.module {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    margin-bottom: 12px;
+    overflow: hidden;
+}
+.module-head {
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.module-num {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 20px;
+}
+.module-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    flex: 1;
+}
+.module-hours {
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+.module-body {
+    padding: 0 16px 14px;
+    border-top: 1px solid var(--border-subtle);
+}
+.lesson-heading {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 12px 0 6px;
+}
+.topic-list {
+    list-style: none;
+    padding-left: 12px;
+}
+.topic-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.topic-list li::before {
+    content: "\2022";
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.activities {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: var(--surface-raised);
+    border-radius: 6px;
+}
+.activities-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+.activities ul {
+    list-style: none;
+    padding: 0;
+}
+.activities li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+.activities li::before {
+    content: "\f0eb";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 400;
+    font-size: 10px;
+    color: var(--amber);
+    flex-shrink: 0;
+}
+.assessment-box {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 16px;
+}
+.assessment-box p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+.assessment-box ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 8px;
+}
+.assessment-box li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.assessment-box li::before {
+    content: "\f00c";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: #3fb950;
+}
+.software-list {
+    list-style: none;
+    padding: 0;
+}
+.software-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.software-list li::before {
+    content: "\f019";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--text-muted);
+}
+.labs-list {
+    list-style: none;
+    padding: 0;
+}
+.labs-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.labs-list li::before {
+    content: "\f120";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--sky-blue);
+}
+code {
+    background: var(--surface-raised);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+    color: var(--sky-blue);
+}
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
+    </style>
+</head>
+<body>
+    <div class="page">
+        <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
+
+        <div class="header">
+            <h1>Syllabus: Spring MVC Secure Coding</h1>
+            <div class="header-meta">
+                <span><i class="fa-solid fa-layer-group"></i> Cyber Developer Associate — Phase 5 (Secure AI Integration, APIs &amp; Advanced Programming)</span>
+                <span><i class="fa-regular fa-clock"></i> 10 hours</span>
+                <span class="badge">CURRENT</span>
+            </div>
+        </div>
+        <section>
+            <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
+            <p>Course description pending.</p>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
+            <ol class="outcomes">
+                <li>Trace an HTTP request through the Spring MVC pipeline — from `DispatcherServlet` to `HandlerMapping` to the matched controller method — and explain why this lifecycle is the map of an endpoint's attack surface.</li>
+                <li>Explain how HTTP request bodies and JSON deserialize and bind into controller method parameters and DTOs through Jackson and Spring's argument resolvers.</li>
+                <li>Identify every binding annotation — `@RequestBody`, `@RequestParam`, `@PathVariable`, `@RequestHeader`, `@CookieValue` — as a distinct channel through which untrusted data enters the application.</li>
+                <li>Map the complete attack surface of a single Spring endpoint by enumerating every untrusted source that reaches the controller, and explain why that map is the unit of analysis for every defense in this course.</li>
+                <li>Construct a Spring `@RestController` with explicit request mappings and bind a JSON request body to a typed DTO with `@RequestBody`, naming the exact point where untrusted input crosses into the application.</li>
+                <li>Explain why the controller boundary is the application's first input-trust boundary and why a typed DTO is a stronger contract than reading raw maps or loose parameters.</li>
+                <li>Enforce the shape and bounds of a request DTO using Jakarta Bean Validation constraint annotations (`@NotNull`, `@NotBlank`, `@Size`, `@Min`/`@Max`, `@Pattern`, `@Email`) and trigger them at the boundary with `@Valid`.</li>
+                <li>Reject malformed or hostile requests before they reach business logic by relying on `MethodArgumentNotValidException` and a fail-closed validation posture, choosing allow-list constraints over blocklist filtering.</li>
+                <li>Explain why an HTTP API — not just a browser-rendered page — benefits from security response headers, and identify the headers that matter at an API boundary and the threat each one blunts.</li>
+                <li>Configure security response headers on Spring endpoints through `HttpSecurity.headers()`, setting `Content-Security-Policy`, `X-Content-Type-Options`, `Strict-Transport-Security`, and related headers deliberately rather than relying on defaults.</li>
+                <li>Explain what Cross-Site Request Forgery (CSRF) is, why it depends on ambient credentials, and reason through whether a given REST endpoint needs CSRF protection enabled or can safely disable it.</li>
+                <li>Apply Spring's `CsrfConfigurer` correctly for the endpoint's authentication model — keeping CSRF protection on for cookie/session-authenticated endpoints and disabling it deliberately (with justification) for stateless token-authenticated APIs.</li>
+                <li>Configure Cross-Origin Resource Sharing (CORS) as a least-privilege allow-list using `CorsConfigurationSource`, enumerating allowed origins, methods, and headers, and explain why a `` wildcard — especially combined with credentials — is dangerous.</li>
+                <li>Explain where the Spring Security filter chain sits in the request lifecycle — in front of the `DispatcherServlet` — and why placing security at the servlet-filter layer means a request is screened before any controller code runs.</li>
+                <li>Configure a `SecurityFilterChain` bean using component-based configuration, and explain why the deprecated `WebSecurityConfigurerAdapter` is no longer the pattern in Spring Security 6.x.</li>
+                <li>Distinguish authentication (establishing who is calling) from authorization (deciding what that caller may do), and trace how the `AuthenticationManager`, the `Authentication` token, and the `SecurityContext` carry identity through a request.</li>
+                <li>Protect endpoints by role and authority with `authorizeHttpRequests`, applying a deny-by-default, least-privilege posture so that every path is locked down unless explicitly opened.</li>
+                <li>Apply method-level authorization with `@PreAuthorize` to enforce fine-grained, least-privilege checks at the service boundary as a defense-in-depth layer behind the URL rules.</li>
+                <li>Explain how Spring's default error responses leak stack traces, exception class names, and other system internals, and why that information disclosure aids an attacker fingerprinting the application.</li>
+                <li>Implement centralized exception handling with `@ControllerAdvice` and `@ExceptionHandler` (or `ResponseEntityExceptionHandler`) so that every failure returns a controlled, safe response instead of a default leak.</li>
+                <li>Return useful, non-revealing error payloads — a structured `ProblemDetail` (RFC 7807) body mapped to the correct HTTP status code — while logging the full exception detail server-side only.</li>
+            </ol>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-sitemap"></i> Course Outline</h2>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">1</span>
+                    <span class="module-title">Spring MVC Foundations</span>
+                    <span class="module-hours">3 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 1: HTTP, JSON, and the Spring MVC Request Lifecycle (1.5h)</div>
+                    <ul class="topic-list">
+                        <li>The request lifecycle: from `DispatcherServlet` through handler mapping to the controller</li>
+                        <li>How HTTP bodies and JSON bind to method parameters and DTOs</li>
+                        <li>Where untrusted input enters — the attack surface of a Spring endpoint</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 2: Controllers, Request Mapping, and Input Validation (1.5h)</div>
+                    <ul class="topic-list">
+                        <li>`@RestController`, request mapping, and DTO-based request binding</li>
+                        <li>Bean Validation (`@Valid`, constraint annotations) to enforce shape and bounds</li>
+                        <li>Rejecting malformed or hostile requests before they reach business logic</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">2</span>
+                    <span class="module-title">Securing the Endpoints</span>
+                    <span class="module-hours">4 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 3: Secure REST Endpoint Design — Headers, CSRF, and CORS (1.5h)</div>
+                    <ul class="topic-list">
+                        <li>Security response headers and why they matter for an API</li>
+                        <li>CSRF protection: when it applies to REST endpoints and how Spring enforces it</li>
+                        <li>Configuring CORS as a least-privilege allow-list, not a wildcard</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 4: Spring Security Essentials — Authentication and Authorization (1.5h)</div>
+                    <ul class="topic-list">
+                        <li>The Spring Security filter chain and where it sits in the request lifecycle</li>
+                        <li>Authentication primitives: establishing who is calling</li>
+                        <li>Authorization primitives: protecting endpoints by role and least privilege</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 5: Secure Error Handling — No Stack-Trace Leakage (1h)</div>
+                    <ul class="topic-list">
+                        <li>How default error responses leak stack traces, types, and system internals</li>
+                        <li>Centralized exception handling (`@ControllerAdvice` / `@ExceptionHandler`) for safe responses</li>
+                        <li>Returning useful, non-revealing error payloads and correct status codes</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">3</span>
+                    <span class="module-title">Secure-Endpoint Capstone</span>
+                    <span class="module-hours">3 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 6: Secure-Endpoint Capstone Lab (3h)</div>
+                    <ul class="topic-list">
+                        <li>Build a REST endpoint that validates input, authenticates and authorizes callers, sets correct headers/CSRF/CORS, and handles errors safely</li>
+                        <li>Audit the endpoint against the course's secure-coding controls</li>
+                        <li>Demonstrate the endpoint resists a scripted set of attacks (bad input, unauthorized access, error-leak probes)</li>
+                    </ul>
+                </div>
+            </div>
+
+        </section>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Row 13 (Pre-Upload Reconciliation) for onboarding meta `apprenti-org/design-documentation#1051` / sub-issue #1068.

Adds the tracking registration deferred from Row 5 (per the XSS precedent — a net-new CDA course isn't dashboard-registered until its content is built), bringing Pre-Upload Reconciliation to **READY 7/7**:
- **courses.json** entry — `status.design: Complete`, `development: In Progress`, `statusConfirmed: false` (flips to Complete/true after Absorb upload at Row 14, per R2)
- **outlines/manifest.json** entry
- **syllabi/spring-mvc-secure-coding.html** (generated from the course syllabus markdown)
- rebuilt **courses.js + outlines.js** bundles

R1–R7 all PASS (course-outline.txt · courses.json · SCORM objects[] · syllabus HTML · bundles · module PDFs · html mirror). Report: `courses/spring-mvc-secure-coding/_REVIEW/pre-upload-reconciliation-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)