### PR TITLE
spring-mvc-secure-coding → development Complete (Row 14 uploaded)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -1113,13 +1113,13 @@ const courseData = [
     "hours": 10,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": "Syllabus: Spring MVC Secure Coding",
     "outline": true,
-    "note": "Cyber Developer Associate net-new 10h Phase 5 course. 3 modules, 6 lessons (L6 capstone). Covers the 'Spring MVC with secure coding' clause of the shared Advanced Java RTI topic; teaches Spring MVC through a security lens — input validation, secure transport (headers/CSRF/CORS), Spring Security authn/authz, and safe error handling. Design + content (Row 7, apprenti-org/design-documentation#1063) + SCORM (Row 9, #1064) + deployment (Row 10, #1065) + instructor/pacing guide (Row 11, #1066) + starter asset audit (Row 12, #1067) complete; LMS upload (Row 14) pending. No OJL claimed (topic-coverage course; consistent with the 15/15-verified curriculum mapping). Onboarding meta #1051.",
+    "note": "Cyber Developer Associate net-new 10h Phase 5 course. 3 modules, 6 lessons (L6 capstone). Covers the 'Spring MVC with secure coding' clause of the shared Advanced Java RTI topic; teaches Spring MVC through a security lens — input validation, secure transport (headers/CSRF/CORS), Spring Security authn/authz, and safe error handling. Design + content (Row 7, apprenti-org/design-documentation#1063) + SCORM (Row 9, #1064) + deployment (Row 10, #1065) + instructor/pacing guide (Row 11, #1066) + starter asset audit (Row 12, #1067) complete; uploaded and published to Absorb (Row 14 complete). No OJL claimed (topic-coverage course; consistent with the 15/15-verified curriculum mapping). Onboarding meta #1051.",
     "driveFolder": null,
-    "statusConfirmed": false,
+    "statusConfirmed": true,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -1111,13 +1111,13 @@
       "hours": 10,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": "Syllabus: Spring MVC Secure Coding",
       "outline": true,
-      "note": "Cyber Developer Associate net-new 10h Phase 5 course. 3 modules, 6 lessons (L6 capstone). Covers the 'Spring MVC with secure coding' clause of the shared Advanced Java RTI topic; teaches Spring MVC through a security lens — input validation, secure transport (headers/CSRF/CORS), Spring Security authn/authz, and safe error handling. Design + content (Row 7, apprenti-org/design-documentation#1063) + SCORM (Row 9, #1064) + deployment (Row 10, #1065) + instructor/pacing guide (Row 11, #1066) + starter asset audit (Row 12, #1067) complete; LMS upload (Row 14) pending. No OJL claimed (topic-coverage course; consistent with the 15/15-verified curriculum mapping). Onboarding meta #1051.",
+      "note": "Cyber Developer Associate net-new 10h Phase 5 course. 3 modules, 6 lessons (L6 capstone). Covers the 'Spring MVC with secure coding' clause of the shared Advanced Java RTI topic; teaches Spring MVC through a security lens — input validation, secure transport (headers/CSRF/CORS), Spring Security authn/authz, and safe error handling. Design + content (Row 7, apprenti-org/design-documentation#1063) + SCORM (Row 9, #1064) + deployment (Row 10, #1065) + instructor/pacing guide (Row 11, #1066) + starter asset audit (Row 12, #1067) complete; uploaded and published to Absorb (Row 14 complete). No OJL claimed (topic-coverage course; consistent with the 15/15-verified curriculum mapping). Onboarding meta #1051.",
       "driveFolder": null,
-      "statusConfirmed": false,
+      "statusConfirmed": true,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {


### PR DESCRIPTION
Final close-out for onboarding meta `apprenti-org/design-documentation#1051`. Course uploaded and published to Absorb (Row 14). Flips `status.development` In Progress → Complete and `statusConfirmed` → true; note updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)