### PR TITLE
Fill syllabus course description: ai-code-auditing-for-security

### DIFF
--- a/syllabi/ai-code-auditing-for-security.html
+++ b/syllabi/ai-code-auditing-for-security.html
@@ -318,7 +318,8 @@ code {
         </div>
         <section>
             <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
-            <p>Course description pending.</p>
+            <p>AI-generated code is fast, fluent, and unverified. This hands-on course teaches you to audit it before it ships. You will read, critique, and remediate intentionally-flawed AI-generated code, configurations, and Dependency Injection setups — spotting hallucinations and slopsquatted dependencies, reviewing configurations for insecure defaults and exposed secrets, auditing dependency-injection wiring for vulnerabilities, confirming exploitability by tracing untrusted input to its sink, and remediating findings through a fix–verify–re-audit loop.</p>
+            <p>By the end of the course you can run a complete security audit of an AI-generated codebase and render a documented pre-deployment sign-off — practicing the discipline that nothing AI-authored ships until a human has audited it.</p>
         </section>
 
         <hr class="divider">


### PR DESCRIPTION
Fills the syllabus **Course Description** for `ai-code-auditing-for-security`, resolving the go-live note surfaced by the Row 13 `verify-pr` verdict (curriculum-tracking#213 / design-doc apprenti-org/design-documentation#1107, note 2: "Course Description renders 'pending'").

- Source markdown (`courses/<slug>/syllabus-<slug>.md`, workspace) updated: placeholder → a learner-facing description adapted from the approved course outline (no internal design-speak).
- `syllabi/ai-code-auditing-for-security.html` regenerated via `convert-syllabi.js`; global side-effects on other courses reverted — **only this course's HTML changed**.
- No `courses.json`/bundle change (description is HTML-only) — `outlines.js`/`courses.js` untouched.
