### PR TITLE
Row 9 SCORM: transaction-validation-service-capstone outline objects[]

### DIFF
--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -12671,7 +12671,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Requirements & Threat Model",
-              "Assessment: Quiz: Requirements & Threat Model"
+              "SCORM: Interactive — Requirements & Threat Model (scorm-lesson-01-requirements-threat-model.zip)"
             ]
           },
           {
@@ -12684,7 +12684,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Secure Architecture & AI-Collaboration Plan",
-              "Assessment: Quiz: Secure Architecture & AI-Collaboration Plan"
+              "SCORM: Interactive — Secure Architecture & AI-Collaboration Plan (scorm-lesson-02-secure-architecture-ai-collaboration-plan.zip)"
             ]
           }
         ]
@@ -12703,7 +12703,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Backend Validation Core",
-              "Assessment: Quiz: Backend Validation Core"
+              "SCORM: Interactive — Backend Validation Core (scorm-lesson-03-backend-validation-core.zip)"
             ]
           },
           {
@@ -12716,7 +12716,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Secure Data Layer",
-              "Assessment: Quiz: Secure Data Layer"
+              "SCORM: Interactive — Secure Data Layer (scorm-lesson-04-secure-data-layer.zip)"
             ]
           },
           {
@@ -12729,7 +12729,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Front-End Integration",
-              "Assessment: Quiz: Front-End Integration"
+              "SCORM: Interactive — Front-End Integration (scorm-lesson-05-front-end-integration.zip)"
             ]
           }
         ]
@@ -12748,7 +12748,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Unit & Regression Tests",
-              "Assessment: Quiz: Unit & Regression Tests"
+              "SCORM: Interactive — Unit & Regression Tests (scorm-lesson-06-unit-regression-tests.zip)"
             ]
           },
           {
@@ -12761,7 +12761,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Security Testing + Coverage to >80%",
-              "Assessment: Quiz: Security Testing + Coverage to >80%"
+              "SCORM: Interactive — Security Testing + Coverage to >80% (scorm-lesson-07-security-testing-coverage.zip)"
             ]
           }
         ]
@@ -12780,7 +12780,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Build the CI/CD Pipeline",
-              "Assessment: Quiz: Build the CI/CD Pipeline"
+              "SCORM: Interactive — Build the CI/CD Pipeline (scorm-lesson-08-build-cicd-pipeline.zip)"
             ]
           },
           {
@@ -12793,7 +12793,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Secure Package & Deploy",
-              "Assessment: Quiz: Secure Package & Deploy"
+              "SCORM: Interactive — Secure Package & Deploy (scorm-lesson-09-secure-package-deploy.zip)"
             ]
           }
         ]
@@ -12811,7 +12811,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: AI-Collaboration Documentation",
-              "Assessment: Quiz: AI-Collaboration Documentation"
+              "SCORM: Interactive — AI-Collaboration Documentation (scorm-lesson-10-ai-collaboration-documentation.zip)"
             ]
           },
           {
@@ -12825,7 +12825,7 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Evidence Map + CBR Signoff",
-              "Assessment: Quiz: Evidence Map + CBR Signoff"
+              "SCORM: Interactive — Evidence Map + CBR Signoff (scorm-lesson-11-evidence-map-cbr-signoff.zip)"
             ]
           }
         ]

--- a/outlines/transaction-validation-service-capstone.json
+++ b/outlines/transaction-validation-service-capstone.json
@@ -18,7 +18,7 @@
           ],
           "objects": [
             "Object: Lesson: Requirements & Threat Model",
-            "Assessment: Quiz: Requirements & Threat Model"
+            "SCORM: Interactive — Requirements & Threat Model (scorm-lesson-01-requirements-threat-model.zip)"
           ]
         },
         {
@@ -31,7 +31,7 @@
           ],
           "objects": [
             "Object: Lesson: Secure Architecture & AI-Collaboration Plan",
-            "Assessment: Quiz: Secure Architecture & AI-Collaboration Plan"
+            "SCORM: Interactive — Secure Architecture & AI-Collaboration Plan (scorm-lesson-02-secure-architecture-ai-collaboration-plan.zip)"
           ]
         }
       ]
@@ -50,7 +50,7 @@
           ],
           "objects": [
             "Object: Lesson: Backend Validation Core",
-            "Assessment: Quiz: Backend Validation Core"
+            "SCORM: Interactive — Backend Validation Core (scorm-lesson-03-backend-validation-core.zip)"
           ]
         },
         {
@@ -63,7 +63,7 @@
           ],
           "objects": [
             "Object: Lesson: Secure Data Layer",
-            "Assessment: Quiz: Secure Data Layer"
+            "SCORM: Interactive — Secure Data Layer (scorm-lesson-04-secure-data-layer.zip)"
           ]
         },
         {
@@ -76,7 +76,7 @@
           ],
           "objects": [
             "Object: Lesson: Front-End Integration",
-            "Assessment: Quiz: Front-End Integration"
+            "SCORM: Interactive — Front-End Integration (scorm-lesson-05-front-end-integration.zip)"
           ]
         }
       ]
@@ -95,7 +95,7 @@
           ],
           "objects": [
             "Object: Lesson: Unit & Regression Tests",
-            "Assessment: Quiz: Unit & Regression Tests"
+            "SCORM: Interactive — Unit & Regression Tests (scorm-lesson-06-unit-regression-tests.zip)"
           ]
         },
         {
@@ -108,7 +108,7 @@
           ],
           "objects": [
             "Object: Lesson: Security Testing + Coverage to >80%",
-            "Assessment: Quiz: Security Testing + Coverage to >80%"
+            "SCORM: Interactive — Security Testing + Coverage to >80% (scorm-lesson-07-security-testing-coverage.zip)"
           ]
         }
       ]
@@ -127,7 +127,7 @@
           ],
           "objects": [
             "Object: Lesson: Build the CI/CD Pipeline",
-            "Assessment: Quiz: Build the CI/CD Pipeline"
+            "SCORM: Interactive — Build the CI/CD Pipeline (scorm-lesson-08-build-cicd-pipeline.zip)"
           ]
         },
         {
@@ -140,7 +140,7 @@
           ],
           "objects": [
             "Object: Lesson: Secure Package & Deploy",
-            "Assessment: Quiz: Secure Package & Deploy"
+            "SCORM: Interactive — Secure Package & Deploy (scorm-lesson-09-secure-package-deploy.zip)"
           ]
         }
       ]
@@ -158,7 +158,7 @@
           ],
           "objects": [
             "Object: Lesson: AI-Collaboration Documentation",
-            "Assessment: Quiz: AI-Collaboration Documentation"
+            "SCORM: Interactive — AI-Collaboration Documentation (scorm-lesson-10-ai-collaboration-documentation.zip)"
           ]
         },
         {
@@ -172,7 +172,7 @@
           ],
           "objects": [
             "Object: Lesson: Evidence Map + CBR Signoff",
-            "Assessment: Quiz: Evidence Map + CBR Signoff"
+            "SCORM: Interactive — Evidence Map + CBR Signoff (scorm-lesson-11-evidence-map-cbr-signoff.zip)"
           ]
         }
       ]


### PR DESCRIPTION
## Summary
Row 9 (SCORM Packaging) tracking update for the **Transaction Validation Service Capstone** (CDA Phase 8).

11 SCORM 1.2 zips built from the capstone `interactive.html` decks via `package.js --lesson=all` and **all 11 verified** by the post-pass verification. This PR updates the outline `objects[]`:
- **SCORM entries:** 9 auto-matched by package.js + **2 hand-added** for the title-auto-match misses (`Security Testing + Coverage to >80%`, `Build the CI/CD Pipeline`) — the documented #896 gotcha. Now 11/11 lessons carry a SCORM object.
- **Removed 11 bogus `Assessment: Quiz:` entries** — leftovers from the Row-5 extractor (which assumed standard lessons); the capstone has **no quizzes** (assessment is the CBR + evidence map). Makes objects[] accurate ahead of Row-13 reconciliation (R3).
- Rebuilt `outlines.js`.

Zips live in the workspace lesson `scorm/` folders (deploy-tree copy happens at Row 10). Refs design-documentation#1122 · Meta #1108.

## Conformance verification
- [x] Ran `/verify-pr`; verdict pasted as a comment
- [x] Not FAIL
