### PR TITLE
Go-live: transaction-validation-service-capstone (Complete + statusConfirmed)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -1229,13 +1229,13 @@ const courseData = [
     "hours": 40,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": null,
     "outline": true,
     "note": "Cyber Developer Associate net-new 40h Phase 8 — the curriculum-level integrative capstone. Standard multi-module course structure (5 modules = build phases, 11 lessons); assessment is the Competency-Based Rubric + apprentice evidence map (no quizzes; syllabus null by capstone convention). Apprentice builds + deploys a secure Transaction Validation Service (HarborFT scenario) via gated CI/CD with >80% coverage and documented AI collaboration. Tags OJL 6.a/6.b/6.c at full depth. Code-bearing: paired student/instructor repos (Java/Spring backend + React frontend, instructor solution at ~92% JaCoCo). Design+outline (#1109) + lesson outlines (#1111) + lesson sources (#1113) + scaffolding (#1115) + code migration (#1117) + content/interactives 22/22 check.js + CBR/evidence-map (Row 7, #1119) + slides deferred (#1121, per #606) + SCORM 11 zips (Row 9, #1122) + deployment 3 private repos (Row 10, #1123) + instructor/pacing guide (Row 11, #1124) + starter asset audit (Row 12, #1125) complete. Pre-upload (Row 13); LMS upload (Row 14) pending. Onboarding meta #1108.",
     "driveFolder": null,
-    "statusConfirmed": false,
+    "statusConfirmed": true,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -1227,13 +1227,13 @@
       "hours": 40,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": null,
       "outline": true,
       "note": "Cyber Developer Associate net-new 40h Phase 8 — the curriculum-level integrative capstone. Standard multi-module course structure (5 modules = build phases, 11 lessons); assessment is the Competency-Based Rubric + apprentice evidence map (no quizzes; syllabus null by capstone convention). Apprentice builds + deploys a secure Transaction Validation Service (HarborFT scenario) via gated CI/CD with >80% coverage and documented AI collaboration. Tags OJL 6.a/6.b/6.c at full depth. Code-bearing: paired student/instructor repos (Java/Spring backend + React frontend, instructor solution at ~92% JaCoCo). Design+outline (#1109) + lesson outlines (#1111) + lesson sources (#1113) + scaffolding (#1115) + code migration (#1117) + content/interactives 22/22 check.js + CBR/evidence-map (Row 7, #1119) + slides deferred (#1121, per #606) + SCORM 11 zips (Row 9, #1122) + deployment 3 private repos (Row 10, #1123) + instructor/pacing guide (Row 11, #1124) + starter asset audit (Row 12, #1125) complete. Pre-upload (Row 13); LMS upload (Row 14) pending. Onboarding meta #1108.",
       "driveFolder": null,
-      "statusConfirmed": false,
+      "statusConfirmed": true,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {


### PR DESCRIPTION
Course published in Absorb (Row 14). Flips `status.development: Complete` + `statusConfirmed: true` (#892 post-upload step). Rebuilt `courses.js`. Closes the dashboard's 'status not yet audited' state for this course. Refs design-documentation#1108.

## Conformance verification
- [x] Ran /verify-pr; verdict below
- [x] Not FAIL