### PR TITLE
comptia-network-plus reconciliation: SCORM objects[] + syllabus + outlines bundle (R3/R4/R5)

### DIFF
--- a/outlines/comptia-network-plus.json
+++ b/outlines/comptia-network-plus.json
@@ -66,5 +66,29 @@
     "title": "Assessment & Exam Preparation",
     "hours": 4,
     "items": ["Full-length practice exams (simulation-based)", "Labs with real-world scenarios", "Final review session with Q&A", "Exam-taking strategies and test-day preparation"]
-  }
+  },
+  "objects": [
+    { "type": "scorm", "file": "scorm-lesson-01-osi-model-network-communication.zip", "module": "module-01-networking-concepts", "lesson": "lesson-01-osi-model-network-communication" },
+    { "type": "scorm", "file": "scorm-lesson-02-networking-appliances-applications.zip", "module": "module-01-networking-concepts", "lesson": "lesson-02-networking-appliances-applications" },
+    { "type": "scorm", "file": "scorm-lesson-03-cloud-concepts-connectivity.zip", "module": "module-01-networking-concepts", "lesson": "lesson-03-cloud-concepts-connectivity" },
+    { "type": "scorm", "file": "scorm-lesson-04-network-ports-protocols-services.zip", "module": "module-01-networking-concepts", "lesson": "lesson-04-network-ports-protocols-services" },
+    { "type": "scorm", "file": "scorm-lesson-05-transmission-media-network-topologies.zip", "module": "module-01-networking-concepts", "lesson": "lesson-05-transmission-media-network-topologies" },
+    { "type": "scorm", "file": "scorm-lesson-06-ipv4-addressing-modern-use-cases.zip", "module": "module-01-networking-concepts", "lesson": "lesson-06-ipv4-addressing-modern-use-cases" },
+    { "type": "scorm", "file": "scorm-lesson-07-routing-technologies-protocols.zip", "module": "module-02-network-implementation", "lesson": "lesson-07-routing-technologies-protocols" },
+    { "type": "scorm", "file": "scorm-lesson-08-switching-technologies-features.zip", "module": "module-02-network-implementation", "lesson": "lesson-08-switching-technologies-features" },
+    { "type": "scorm", "file": "scorm-lesson-09-wireless-networking.zip", "module": "module-02-network-implementation", "lesson": "lesson-09-wireless-networking" },
+    { "type": "scorm", "file": "scorm-lesson-10-ipv4-ipv6-network-services.zip", "module": "module-02-network-implementation", "lesson": "lesson-10-ipv4-ipv6-network-services" },
+    { "type": "scorm", "file": "scorm-lesson-11-organizational-processes-procedures.zip", "module": "module-03-network-operations", "lesson": "lesson-11-organizational-processes-procedures" },
+    { "type": "scorm", "file": "scorm-lesson-12-network-monitoring-tools-technologies.zip", "module": "module-03-network-operations", "lesson": "lesson-12-network-monitoring-tools-technologies" },
+    { "type": "scorm", "file": "scorm-lesson-13-disaster-recovery-concepts.zip", "module": "module-03-network-operations", "lesson": "lesson-13-disaster-recovery-concepts" },
+    { "type": "scorm", "file": "scorm-lesson-14-network-access-management.zip", "module": "module-03-network-operations", "lesson": "lesson-14-network-access-management" },
+    { "type": "scorm", "file": "scorm-lesson-15-network-security-principles.zip", "module": "module-04-network-security", "lesson": "lesson-15-network-security-principles" },
+    { "type": "scorm", "file": "scorm-lesson-16-types-of-network-attacks.zip", "module": "module-04-network-security", "lesson": "lesson-16-types-of-network-attacks" },
+    { "type": "scorm", "file": "scorm-lesson-17-network-defense-techniques.zip", "module": "module-04-network-security", "lesson": "lesson-17-network-defense-techniques" },
+    { "type": "scorm", "file": "scorm-lesson-18-securing-network-traffic-devices.zip", "module": "module-04-network-security", "lesson": "lesson-18-securing-network-traffic-devices" },
+    { "type": "scorm", "file": "scorm-lesson-19-troubleshooting-methodology.zip", "module": "module-05-network-troubleshooting", "lesson": "lesson-19-troubleshooting-methodology" },
+    { "type": "scorm", "file": "scorm-lesson-20-common-cabling-physical-issues.zip", "module": "module-05-network-troubleshooting", "lesson": "lesson-20-common-cabling-physical-issues" },
+    { "type": "scorm", "file": "scorm-lesson-21-troubleshooting-network-services.zip", "module": "module-05-network-troubleshooting", "lesson": "lesson-21-troubleshooting-network-services" },
+    { "type": "scorm", "file": "scorm-lesson-22-performance-issues-tools.zip", "module": "module-05-network-troubleshooting", "lesson": "lesson-22-performance-issues-tools" }
+  ]
 }

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -3928,7 +3928,141 @@ const courseOutlines = {
         "Final review session with Q&A",
         "Exam-taking strategies and test-day preparation"
       ]
-    }
+    },
+    "objects": [
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-01-osi-model-network-communication.zip",
+        "module": "module-01-networking-concepts",
+        "lesson": "lesson-01-osi-model-network-communication"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-02-networking-appliances-applications.zip",
+        "module": "module-01-networking-concepts",
+        "lesson": "lesson-02-networking-appliances-applications"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-03-cloud-concepts-connectivity.zip",
+        "module": "module-01-networking-concepts",
+        "lesson": "lesson-03-cloud-concepts-connectivity"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-04-network-ports-protocols-services.zip",
+        "module": "module-01-networking-concepts",
+        "lesson": "lesson-04-network-ports-protocols-services"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-05-transmission-media-network-topologies.zip",
+        "module": "module-01-networking-concepts",
+        "lesson": "lesson-05-transmission-media-network-topologies"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-06-ipv4-addressing-modern-use-cases.zip",
+        "module": "module-01-networking-concepts",
+        "lesson": "lesson-06-ipv4-addressing-modern-use-cases"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-07-routing-technologies-protocols.zip",
+        "module": "module-02-network-implementation",
+        "lesson": "lesson-07-routing-technologies-protocols"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-08-switching-technologies-features.zip",
+        "module": "module-02-network-implementation",
+        "lesson": "lesson-08-switching-technologies-features"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-09-wireless-networking.zip",
+        "module": "module-02-network-implementation",
+        "lesson": "lesson-09-wireless-networking"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-10-ipv4-ipv6-network-services.zip",
+        "module": "module-02-network-implementation",
+        "lesson": "lesson-10-ipv4-ipv6-network-services"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-11-organizational-processes-procedures.zip",
+        "module": "module-03-network-operations",
+        "lesson": "lesson-11-organizational-processes-procedures"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-12-network-monitoring-tools-technologies.zip",
+        "module": "module-03-network-operations",
+        "lesson": "lesson-12-network-monitoring-tools-technologies"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-13-disaster-recovery-concepts.zip",
+        "module": "module-03-network-operations",
+        "lesson": "lesson-13-disaster-recovery-concepts"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-14-network-access-management.zip",
+        "module": "module-03-network-operations",
+        "lesson": "lesson-14-network-access-management"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-15-network-security-principles.zip",
+        "module": "module-04-network-security",
+        "lesson": "lesson-15-network-security-principles"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-16-types-of-network-attacks.zip",
+        "module": "module-04-network-security",
+        "lesson": "lesson-16-types-of-network-attacks"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-17-network-defense-techniques.zip",
+        "module": "module-04-network-security",
+        "lesson": "lesson-17-network-defense-techniques"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-18-securing-network-traffic-devices.zip",
+        "module": "module-04-network-security",
+        "lesson": "lesson-18-securing-network-traffic-devices"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-19-troubleshooting-methodology.zip",
+        "module": "module-05-network-troubleshooting",
+        "lesson": "lesson-19-troubleshooting-methodology"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-20-common-cabling-physical-issues.zip",
+        "module": "module-05-network-troubleshooting",
+        "lesson": "lesson-20-common-cabling-physical-issues"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-21-troubleshooting-network-services.zip",
+        "module": "module-05-network-troubleshooting",
+        "lesson": "lesson-21-troubleshooting-network-services"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-22-performance-issues-tools.zip",
+        "module": "module-05-network-troubleshooting",
+        "lesson": "lesson-22-performance-issues-tools"
+      }
+    ]
   },
   "Data Fundamentals — Data Literacy": {
     "course": "Data Fundamentals — Data Literacy",

--- a/syllabi/comptia-network-plus.html
+++ b/syllabi/comptia-network-plus.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Syllabus: CompTIA Network+</title>
+    <title>Syllabus: CompTIA Network+ (96 Hours)</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
 :root[data-theme="dark"] {
@@ -309,9 +309,9 @@ code {
         <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
 
         <div class="header">
-            <h1>Syllabus: CompTIA Network+</h1>
+            <h1>Syllabus: CompTIA Network+ (96 Hours)</h1>
             <div class="header-meta">
-                <span><i class="fa-solid fa-layer-group"></i> IT Support Professional</span>
+                <span><i class="fa-solid fa-layer-group"></i> IT Support Professional · Operations Support Specialist — Network</span>
                 <span><i class="fa-regular fa-clock"></i> 96 hours</span>
                 <span class="badge">DRAFT</span>
             </div>
@@ -363,7 +363,6 @@ code {
                 <div class="module-head">
                     <span class="module-num">1</span>
                     <span class="module-title">Networking Concepts</span>
-                    <span class="module-hours">20 hours</span>
                 </div>
                 <div class="module-body">
                     <div class="lesson-heading">Lesson: OSI Model &amp; Network Communication</div>
@@ -404,7 +403,6 @@ code {
                 <div class="module-head">
                     <span class="module-num">2</span>
                     <span class="module-title">Network Implementation</span>
-                    <span class="module-hours">20 hours</span>
                 </div>
                 <div class="module-body">
                     <div class="lesson-heading">Lesson: Routing Technologies &amp; Protocols</div>
@@ -434,7 +432,6 @@ code {
                 <div class="module-head">
                     <span class="module-num">3</span>
                     <span class="module-title">Network Operations</span>
-                    <span class="module-hours">20 hours</span>
                 </div>
                 <div class="module-body">
                     <div class="lesson-heading">Lesson: Organizational Processes &amp; Procedures</div>
@@ -464,7 +461,6 @@ code {
                 <div class="module-head">
                     <span class="module-num">4</span>
                     <span class="module-title">Network Security</span>
-                    <span class="module-hours">20 hours</span>
                 </div>
                 <div class="module-body">
                     <div class="lesson-heading">Lesson: Network Security Principles</div>
@@ -494,7 +490,6 @@ code {
                 <div class="module-head">
                     <span class="module-num">5</span>
                     <span class="module-title">Network Troubleshooting</span>
-                    <span class="module-hours">12 hours</span>
                 </div>
                 <div class="module-body">
                     <div class="lesson-heading">Lesson: Troubleshooting Methodology</div>


### PR DESCRIPTION
Closes #224. Pre-Upload Reconciliation fixes for comptia-network-plus (design-documentation #1166): R3 (22 SCORM `objects[]`), R4 (syllabus HTML regen), R5 (outlines.js rebuild). Reconciliation now **6/7** — only R1 (canonical outline regen) remains, a legacy/targeted-deploy structural deviation. 🤖