### PR TITLE
python-basics: SCORM objects[] for Row 13 reconciliation (R3)

### DIFF
--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -11040,6 +11040,9 @@ const courseOutlines = {
             "topics": [
               "Python overview, key features, history",
               "PEPs and PEP8"
+            ],
+            "objects": [
+              "SCORM: Interactive — Introduction to Python (scorm-lesson-01-introduction-to-python.zip)"
             ]
           }
         ]
@@ -11051,7 +11054,10 @@ const courseOutlines = {
           {
             "title": "Variables and Strings in Python",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Variables and Strings in Python (scorm-lesson-02-variables-and-strings-in-python.zip)"
+            ]
           }
         ]
       },
@@ -11062,22 +11068,34 @@ const courseOutlines = {
           {
             "title": "Arrays in Python",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Arrays in Python (scorm-lesson-03-arrays-in-python.zip)"
+            ]
           },
           {
             "title": "Lists in Python",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Lists in Python (scorm-lesson-04-lists-in-python.zip)"
+            ]
           },
           {
             "title": "Pseudocode",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Pseudocode (scorm-lesson-05-pseudocode.zip)"
+            ]
           },
           {
             "title": "Flowcharting",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Flowcharting (scorm-lesson-06-flowcharting.zip)"
+            ]
           }
         ]
       },
@@ -11088,7 +11106,10 @@ const courseOutlines = {
           {
             "title": "Functions",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Functions (scorm-lesson-07-functions.zip)"
+            ]
           }
         ]
       },
@@ -11099,7 +11120,10 @@ const courseOutlines = {
           {
             "title": "Lists, Tuples, Sets and Dictionaries",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Lists, Tuples, Sets and Dictionaries (scorm-lesson-08-lists-tuples-sets-and-dictionaries.zip)"
+            ]
           }
         ]
       },
@@ -11110,7 +11134,10 @@ const courseOutlines = {
           {
             "title": "File IO",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — File IO (scorm-lesson-09-file-io.zip)"
+            ]
           }
         ]
       },
@@ -11131,7 +11158,10 @@ const courseOutlines = {
           {
             "title": "Testing in Python",
             "hours": null,
-            "topics": []
+            "topics": [],
+            "objects": [
+              "SCORM: Interactive — Testing in Python (scorm-lesson-10-testing-in-python.zip)"
+            ]
           }
         ]
       }

--- a/outlines/python-basics.json
+++ b/outlines/python-basics.json
@@ -15,6 +15,9 @@
           "topics": [
             "Python overview, key features, history",
             "PEPs and PEP8"
+          ],
+          "objects": [
+            "SCORM: Interactive — Introduction to Python (scorm-lesson-01-introduction-to-python.zip)"
           ]
         }
       ]
@@ -26,7 +29,10 @@
         {
           "title": "Variables and Strings in Python",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Variables and Strings in Python (scorm-lesson-02-variables-and-strings-in-python.zip)"
+          ]
         }
       ]
     },
@@ -37,22 +43,34 @@
         {
           "title": "Arrays in Python",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Arrays in Python (scorm-lesson-03-arrays-in-python.zip)"
+          ]
         },
         {
           "title": "Lists in Python",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Lists in Python (scorm-lesson-04-lists-in-python.zip)"
+          ]
         },
         {
           "title": "Pseudocode",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Pseudocode (scorm-lesson-05-pseudocode.zip)"
+          ]
         },
         {
           "title": "Flowcharting",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Flowcharting (scorm-lesson-06-flowcharting.zip)"
+          ]
         }
       ]
     },
@@ -63,7 +81,10 @@
         {
           "title": "Functions",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Functions (scorm-lesson-07-functions.zip)"
+          ]
         }
       ]
     },
@@ -74,7 +95,10 @@
         {
           "title": "Lists, Tuples, Sets and Dictionaries",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Lists, Tuples, Sets and Dictionaries (scorm-lesson-08-lists-tuples-sets-and-dictionaries.zip)"
+          ]
         }
       ]
     },
@@ -85,7 +109,10 @@
         {
           "title": "File IO",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — File IO (scorm-lesson-09-file-io.zip)"
+          ]
         }
       ]
     },
@@ -106,7 +133,10 @@
         {
           "title": "Testing in Python",
           "hours": null,
-          "topics": []
+          "topics": [],
+          "objects": [
+            "SCORM: Interactive — Testing in Python (scorm-lesson-10-testing-in-python.zip)"
+          ]
         }
       ]
     }


### PR DESCRIPTION
Unblocks **Row 13 Pre-Upload Reconciliation** for `python-basics` (onboarding meta `apprenti-org/design-documentation#639`).

## Problem
`outlines/python-basics.json` was a stub with no `objects[]`, so `check-deploy-tree.js` reported **6/7 BLOCKED** — R3 flagged all **10** `scorm-lesson-NN-*.zip` files in `deploy/content/` as having no matching outline entry.

## Fix
Added the 10 filename-embedded SCORM entries (one per lesson) via the canonical `upsertScormObject` helper — the same Row 9 → R3 mechanism used by `package.js --tracking-repo` (precedent: #212/#216/#222/#224). Each lesson title slugifies exactly to its zip's lesson-slug, so all 10 matched. Regenerated `outlines.js`.

```
zips=10 matched=10 unmatched=0
```

## Result
`check-deploy-tree.js --course-slug=python-basics` → **7/7 READY** (R1–R7 all PASS).

## Deliberately not changed
Per-lesson and per-module **hours** remain `null` (documented TBD pending `design-documentation#83` 40h-vs-48h and `#90` content extraction). No R-check requires them; R2 passes on the course-level `hours: 48`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)