### PR TITLE
java-oop Row 13: development In Progress + note + SCORM objects[]

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -757,11 +757,11 @@ const courseData = [
     "hours": 40,
     "status": {
       "design": "Complete",
-      "development": "Not Started"
+      "development": "In Progress"
     },
     "syllabus": null,
     "outline": "Course Outline: Java OOP",
-    "note": null,
+    "note": "Capture-mode reverse-engineered SWD Java course (base slug java-oop). 22 lessons + 5 labs + summative; 18 interactives + 22 SCORMs built; student/instructor code repos + consolidated instructor guides + pacing guide delivered. Targeted-legacy deploy tree (prose PDFs + SCORMs) staged; pending LMS upload.",
     "driveFolder": "https://drive.google.com/drive/folders/1tv8SLDEgmhaODtDeM1HTQVqCcult6DhU",
     "statusConfirmed": false
   },

--- a/courses.json
+++ b/courses.json
@@ -755,11 +755,11 @@
       "hours": 40,
       "status": {
         "design": "Complete",
-        "development": "Not Started"
+        "development": "In Progress"
       },
       "syllabus": null,
       "outline": "Course Outline: Java OOP",
-      "note": null,
+      "note": "Capture-mode reverse-engineered SWD Java course (base slug java-oop). 22 lessons + 5 labs + summative; 18 interactives + 22 SCORMs built; student/instructor code repos + consolidated instructor guides + pacing guide delivered. Targeted-legacy deploy tree (prose PDFs + SCORMs) staged; pending LMS upload.",
       "driveFolder": "https://drive.google.com/drive/folders/1tv8SLDEgmhaODtDeM1HTQVqCcult6DhU",
       "statusConfirmed": false
     },

--- a/outlines/java-oop.json
+++ b/outlines/java-oop.json
@@ -12,17 +12,35 @@
         {
           "title": "Procedural vs. Object-Oriented Programming",
           "hours": 2,
-          "topics": ["Procedural programming characteristics", "Object-oriented programming principles", "Comparing procedural and OOP approaches", "When to use each paradigm"]
+          "topics": [
+            "Procedural programming characteristics",
+            "Object-oriented programming principles",
+            "Comparing procedural and OOP approaches",
+            "When to use each paradigm"
+          ]
         },
         {
           "title": "Classes and Objects",
           "hours": 4,
-          "topics": ["Creating classes in Java", "Importing classes", "Fields and methods", "Class constructors and overloading", "Access modifiers: public, private, protected", "Getters and setters", "Instantiating objects"]
+          "topics": [
+            "Creating classes in Java",
+            "Importing classes",
+            "Fields and methods",
+            "Class constructors and overloading",
+            "Access modifiers: public, private, protected",
+            "Getters and setters",
+            "Instantiating objects"
+          ]
         },
         {
           "title": "Maven",
           "hours": 2,
-          "topics": ["Software project complexity challenges", "Maven project structure and POM", "Dependency management", "Build lifecycle and plugins"]
+          "topics": [
+            "Software project complexity challenges",
+            "Maven project structure and POM",
+            "Dependency management",
+            "Build lifecycle and plugins"
+          ]
         }
       ]
     },
@@ -34,22 +52,44 @@
         {
           "title": "The Pillars of Object-Oriented Programming",
           "hours": 2,
-          "topics": ["Encapsulation: bundling data and methods", "Abstraction: hiding complexity", "Inheritance: reusing code through class hierarchies", "Polymorphism: interchangeable object behavior"]
+          "topics": [
+            "Encapsulation: bundling data and methods",
+            "Abstraction: hiding complexity",
+            "Inheritance: reusing code through class hierarchies",
+            "Polymorphism: interchangeable object behavior"
+          ]
         },
         {
           "title": "Interpreting Requirements",
           "hours": 2,
-          "topics": ["Software requirements documents", "Design decisions vs. requirements", "Interpreting specifications for implementation", "Translating requirements to class designs"]
+          "topics": [
+            "Software requirements documents",
+            "Design decisions vs. requirements",
+            "Interpreting specifications for implementation",
+            "Translating requirements to class designs"
+          ]
         },
         {
           "title": "Interfaces",
           "hours": 4,
-          "topics": ["Abstract vs. concrete elements", "Declaring and implementing interfaces", "Implementing multiple interfaces", "Using interfaces for polymorphism", "Composition with interfaces"]
+          "topics": [
+            "Abstract vs. concrete elements",
+            "Declaring and implementing interfaces",
+            "Implementing multiple interfaces",
+            "Using interfaces for polymorphism",
+            "Composition with interfaces"
+          ]
         },
         {
           "title": "Code Smells and Refactoring",
           "hours": 4,
-          "topics": ["Large class smell identification and refactoring", "Large method smell and method extraction", "Duplicated code smell and DRY principle", "Long parameter list smell", "Class design best practices"]
+          "topics": [
+            "Large class smell identification and refactoring",
+            "Large method smell and method extraction",
+            "Duplicated code smell and DRY principle",
+            "Long parameter list smell",
+            "Class design best practices"
+          ]
         }
       ]
     },
@@ -61,22 +101,43 @@
         {
           "title": "Introduction to Testing",
           "hours": 1,
-          "topics": ["Automated testing overview", "Unit testing vs. integration testing", "When to implement tests", "Testing tradeoffs and best practices"]
+          "topics": [
+            "Automated testing overview",
+            "Unit testing vs. integration testing",
+            "When to implement tests",
+            "Testing tradeoffs and best practices"
+          ]
         },
         {
           "title": "JUnit and Stateless Testing",
           "hours": 3,
-          "topics": ["JUnit framework setup", "Arrange/Act/Assert pattern", "Stateless testing concepts", "Writing and running unit tests", "Test assertions and expected values"]
+          "topics": [
+            "JUnit framework setup",
+            "Arrange/Act/Assert pattern",
+            "Stateless testing concepts",
+            "Writing and running unit tests",
+            "Test assertions and expected values"
+          ]
         },
         {
           "title": "Stateful Testing",
           "hours": 2,
-          "topics": ["Stateful vs. stateless testing", "Testing state-dependent classes", "Arrange step for stateful tests", "Managing test state and setup"]
+          "topics": [
+            "Stateful vs. stateless testing",
+            "Testing state-dependent classes",
+            "Arrange step for stateful tests",
+            "Managing test state and setup"
+          ]
         },
         {
           "title": "How to Test Collections",
           "hours": 2,
-          "topics": ["Testing code that uses collections", "What not to test in collections", "Testing exception handling", "Bug identification through unit tests"]
+          "topics": [
+            "Testing code that uses collections",
+            "What not to test in collections",
+            "Testing exception handling",
+            "Bug identification through unit tests"
+          ]
         }
       ]
     },
@@ -88,17 +149,34 @@
         {
           "title": "Generics",
           "hours": 2,
-          "topics": ["Generic types and classes in Java", "Type parameters and type safety", "Generic containers and collections", "Generics in standard libraries"]
+          "topics": [
+            "Generic types and classes in Java",
+            "Type parameters and type safety",
+            "Generic containers and collections",
+            "Generics in standard libraries"
+          ]
         },
         {
           "title": "Lists",
           "hours": 4,
-          "topics": ["List interface and ArrayList implementation", "ArrayList vs. arrays", "Adding, removing, and accessing elements", "Iterating over lists", "Sorting and searching collections"]
+          "topics": [
+            "List interface and ArrayList implementation",
+            "ArrayList vs. arrays",
+            "Adding, removing, and accessing elements",
+            "Iterating over lists",
+            "Sorting and searching collections"
+          ]
         },
         {
           "title": "Hash-Based Collections",
           "hours": 4,
-          "topics": ["Hash functions and hash codes", "HashMap declaration and usage", "Put, get, containsKey, and remove operations", "Iterating over maps with entrySet", "Choosing between List and Map"]
+          "topics": [
+            "Hash functions and hash codes",
+            "HashMap declaration and usage",
+            "Put, get, containsKey, and remove operations",
+            "Iterating over maps with entrySet",
+            "Choosing between List and Map"
+          ]
         }
       ]
     }
@@ -109,5 +187,139 @@
     "items": [
       "Summative Assessment: Shopping Cart"
     ]
-  }
+  },
+  "objects": [
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-01-procedural-vs-object-oriented-programming.zip",
+      "module": "01-fundamentals-of-object-oriented-programming",
+      "lesson": "01-procedural-vs-object-oriented-programming"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-02-classes-and-objects.zip",
+      "module": "01-fundamentals-of-object-oriented-programming",
+      "lesson": "02-classes-and-objects"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-03-pillars-of-oop.zip",
+      "module": "02-object-oriented-design",
+      "lesson": "03-pillars-of-oop"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-04-inheritance.zip",
+      "module": "02-object-oriented-design",
+      "lesson": "04-inheritance"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-05-composition.zip",
+      "module": "02-object-oriented-design",
+      "lesson": "05-composition"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-06-interfaces.zip",
+      "module": "02-object-oriented-design",
+      "lesson": "06-interfaces"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-07-maven.zip",
+      "module": "03-maven-and-interpreting-project-requirements",
+      "lesson": "07-maven"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-08-interpreting-requirements.zip",
+      "module": "03-maven-and-interpreting-project-requirements",
+      "lesson": "08-interpreting-requirements"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-09-class-design.zip",
+      "module": "04-class-design",
+      "lesson": "09-class-design"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-10-code-smells.zip",
+      "module": "05-code-smells",
+      "lesson": "10-code-smells"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-11-large-class-smell.zip",
+      "module": "05-code-smells",
+      "lesson": "11-large-class-smell"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-12-large-method-smell.zip",
+      "module": "05-code-smells",
+      "lesson": "12-large-method-smell"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-13-duplicated-code-smell.zip",
+      "module": "05-code-smells",
+      "lesson": "13-duplicated-code-smell"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-14-long-parameter-list-smell.zip",
+      "module": "05-code-smells",
+      "lesson": "14-long-parameter-list-smell"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-15-comment-smell.zip",
+      "module": "05-code-smells",
+      "lesson": "15-comment-smell"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-16-generics.zip",
+      "module": "06-collections",
+      "lesson": "16-generics"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-17-lists.zip",
+      "module": "06-collections",
+      "lesson": "17-lists"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-18-hash-based-collections.zip",
+      "module": "06-collections",
+      "lesson": "18-hash-based-collections"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-19-introduction-to-testing.zip",
+      "module": "07-testing",
+      "lesson": "19-introduction-to-testing"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-20-junit-and-stateless-testing.zip",
+      "module": "07-testing",
+      "lesson": "20-junit-and-stateless-testing"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-21-stateful-testing.zip",
+      "module": "07-testing",
+      "lesson": "21-stateful-testing"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-22-how-to-test-collections.zip",
+      "module": "07-testing",
+      "lesson": "22-how-to-test-collections"
+    }
+  ]
 }

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -8735,7 +8735,141 @@ const courseOutlines = {
       "items": [
         "Summative Assessment: Shopping Cart"
       ]
-    }
+    },
+    "objects": [
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-01-procedural-vs-object-oriented-programming.zip",
+        "module": "01-fundamentals-of-object-oriented-programming",
+        "lesson": "01-procedural-vs-object-oriented-programming"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-02-classes-and-objects.zip",
+        "module": "01-fundamentals-of-object-oriented-programming",
+        "lesson": "02-classes-and-objects"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-03-pillars-of-oop.zip",
+        "module": "02-object-oriented-design",
+        "lesson": "03-pillars-of-oop"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-04-inheritance.zip",
+        "module": "02-object-oriented-design",
+        "lesson": "04-inheritance"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-05-composition.zip",
+        "module": "02-object-oriented-design",
+        "lesson": "05-composition"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-06-interfaces.zip",
+        "module": "02-object-oriented-design",
+        "lesson": "06-interfaces"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-07-maven.zip",
+        "module": "03-maven-and-interpreting-project-requirements",
+        "lesson": "07-maven"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-08-interpreting-requirements.zip",
+        "module": "03-maven-and-interpreting-project-requirements",
+        "lesson": "08-interpreting-requirements"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-09-class-design.zip",
+        "module": "04-class-design",
+        "lesson": "09-class-design"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-10-code-smells.zip",
+        "module": "05-code-smells",
+        "lesson": "10-code-smells"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-11-large-class-smell.zip",
+        "module": "05-code-smells",
+        "lesson": "11-large-class-smell"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-12-large-method-smell.zip",
+        "module": "05-code-smells",
+        "lesson": "12-large-method-smell"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-13-duplicated-code-smell.zip",
+        "module": "05-code-smells",
+        "lesson": "13-duplicated-code-smell"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-14-long-parameter-list-smell.zip",
+        "module": "05-code-smells",
+        "lesson": "14-long-parameter-list-smell"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-15-comment-smell.zip",
+        "module": "05-code-smells",
+        "lesson": "15-comment-smell"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-16-generics.zip",
+        "module": "06-collections",
+        "lesson": "16-generics"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-17-lists.zip",
+        "module": "06-collections",
+        "lesson": "17-lists"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-18-hash-based-collections.zip",
+        "module": "06-collections",
+        "lesson": "18-hash-based-collections"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-19-introduction-to-testing.zip",
+        "module": "07-testing",
+        "lesson": "19-introduction-to-testing"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-20-junit-and-stateless-testing.zip",
+        "module": "07-testing",
+        "lesson": "20-junit-and-stateless-testing"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-21-stateful-testing.zip",
+        "module": "07-testing",
+        "lesson": "21-stateful-testing"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-22-how-to-test-collections.zip",
+        "module": "07-testing",
+        "lesson": "22-how-to-test-collections"
+      }
+    ]
   },
   "JavaScript": {
     "course": "JavaScript",


### PR DESCRIPTION
Pre-Upload Reconciliation (Row 13) tracking fixes for java-oop (apprenti-org/design-documentation#1221): sets `status.development` → In Progress, adds a descriptive `note` (R2), and adds `objects[]` with the 22 SCORM zips to `outlines/java-oop.json` (R3). Bundles rebuilt (`node build.js`). Mirrors CompTIA Network+ #225. After merge, reconciliation is 6/7 (R1 canonical-outline waived — capture-mode targeted-legacy deploy, no `modules/` content.md tree). Closes #229.