### PR TITLE
Register Java OOP Secure (Cyber Developer Associate) — Phase 0 tracking

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -766,6 +766,21 @@ const courseData = [
     "statusConfirmed": false
   },
   {
+    "id": "java-oop-security-module",
+    "name": "Java OOP Secure (Cyber Developer Associate)",
+    "hours": 8,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate net-new Phase 5 module — Java OOP Secure, the secure counterpart to base Java OOP (kept separate). One module: Secure Object-Oriented Programming (6 lessons: encapsulation as defense, secure dependency injection, lambdas/functional defensive code, data classes & secure object design, security code smells, edge-case & adversarial input testing) + a capstone extension. Row 4 lesson sources complete and passing the new check.js --type lesson-source gate (#1262/#1263). Hours (8) are the built-lesson figure; curriculum pacing handles compression vs the CDA outline's 40h Phase-5 line. Onboarding meta apprenti-org/design-documentation#1255; scaffolding #1266.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "javascript",
     "name": "JavaScript",
     "hours": 16,

--- a/courses.json
+++ b/courses.json
@@ -764,6 +764,21 @@
       "statusConfirmed": false
     },
     {
+      "id": "java-oop-security-module",
+      "name": "Java OOP Secure (Cyber Developer Associate)",
+      "hours": 8,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate net-new Phase 5 module — Java OOP Secure, the secure counterpart to base Java OOP (kept separate). One module: Secure Object-Oriented Programming (6 lessons: encapsulation as defense, secure dependency injection, lambdas/functional defensive code, data classes & secure object design, security code smells, edge-case & adversarial input testing) + a capstone extension. Row 4 lesson sources complete and passing the new check.js --type lesson-source gate (#1262/#1263). Hours (8) are the built-lesson figure; curriculum pacing handles compression vs the CDA outline's 40h Phase-5 line. Onboarding meta apprenti-org/design-documentation#1255; scaffolding #1266.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "javascript",
       "name": "JavaScript",
       "hours": 16,

--- a/outlines/java-oop-security-module.json
+++ b/outlines/java-oop-security-module.json
@@ -1,0 +1,18 @@
+{
+  "course": "Java OOP Secure",
+  "totalHours": 8,
+  "totalModules": 2,
+  "totalLessons": 0,
+  "modules": [
+    {
+      "name": "Secure Object-Oriented Programming",
+      "hours": null,
+      "lessons": []
+    },
+    {
+      "name": "Capstone Extension",
+      "hours": null,
+      "lessons": []
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -240,6 +240,11 @@
     "id": "java-oop"
   },
   {
+    "file": "java-oop-security-module.json",
+    "course": "Java OOP Secure",
+    "id": "java-oop-security-module"
+  },
+  {
     "file": "javascript.json",
     "course": "JavaScript",
     "id": "javascript"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -8737,6 +8737,24 @@ const courseOutlines = {
       ]
     }
   },
+  "Java OOP Secure": {
+    "course": "Java OOP Secure",
+    "totalHours": 8,
+    "totalModules": 2,
+    "totalLessons": 0,
+    "modules": [
+      {
+        "name": "Secure Object-Oriented Programming",
+        "hours": null,
+        "lessons": []
+      },
+      {
+        "name": "Capstone Extension",
+        "hours": null,
+        "lessons": []
+      }
+    ]
+  },
   "JavaScript": {
     "course": "JavaScript",
     "totalHours": 16,


### PR DESCRIPTION
Phase 0 tracking registration for the new course **Java OOP Secure** (slug `java-oop-security-module`), part of New Course Onboarding Row 5 (Content Scaffolding), design-documentation meta #1255 / sub #1266.

## What's here
- New flat `courses.json` record: id `java-oop-security-module`, name **"Java OOP Secure (Cyber Developer Associate)"**, **8h**, status `design: Complete` / `development: In Progress`, `statusConfirmed: false`, `outline: true`, `syllabus: null`, `sourceRepo: design-documentation`.
- `outlines/java-oop-security-module.json` (extractor-generated; name → "Java OOP Secure", totalHours → 8).
- `outlines/manifest.json` entry; `courses.js` + `outlines.js` regenerated via `node build.js`.
- **`curricula` block untouched** — the CDA Phase-5 group already lists this course inline; loose linkage as with other CDA records.

## Notes
- **Hours = 8** (the built-lesson figure). The CDA outline's Phase-5 line still reads "Java OOP — Secure-OOP (40h)"; per direction, the 8h-vs-40h difference is handled later in the **pacing guide** (compression), not reconciled here — so the verified CDA curriculum totals are deliberately **not** touched.
- **Syllabus HTML deferred:** the reconciled syllabus is still a Phase-0 stub (placeholder description/assessment), so no `syllabi/*.html` was generated (consistent with other in-progress CDA courses that carry `syllabus: null`). It'll be wired once real syllabus content lands.
- This is the **Phase 0 review-gate** deliverable. Handed back for your review — not self-merged. After merge I'll run **Phase 1** (lesson scaffolding).