### PR TITLE
Phase 0 reconciliation: compliance-and-security-awareness (CDA P2)

### DIFF
--- a/convert-syllabi.js
+++ b/convert-syllabi.js
@@ -701,7 +701,7 @@ const manualMap = {
     'C# OOP': 'csharp-oop.html',
     'C++ Coding Booster Intensive': 'cpp-coding-booster.html',
     'CI/CD Pipeline Concepts': 'cicd-pipeline-concepts.html',
-    'Compliance and Security Awareness': 'compliance-security-awareness.html',
+    'Compliance and Security Awareness': 'compliance-and-security-awareness.html',
     'CompTIA A+': 'comptia-a-plus.html',
     'CompTIA Network+': 'comptia-network-plus.html',
     'Data Fundamentals — Data Literacy': 'data-literacy.html',

--- a/courses.js
+++ b/courses.js
@@ -399,12 +399,12 @@ const courseData = [
     "name": "Compliance and Security Awareness",
     "hours": 4,
     "status": {
-      "design": "Not Started",
-      "development": "Not Started"
+      "design": "Complete",
+      "development": "In Progress"
     },
     "syllabus": null,
-    "outline": null,
-    "note": "Removed from OSS (Security & Professional Skills) per curriculum-tracking#162 / design-documentation#721. Now a Cyber Developer Associate (A-31) Phase 2 course, 4h — build pending (design/development Not Started). Standard-mapped to A-31 OJL 1.b, 2.b.",
+    "outline": true,
+    "note": "CDA Phase 2, 4h. Design Complete (course outline + 4 lesson outlines + 4 lesson sources); development In Progress (Row 5 content scaffolding). Removed from OSS per curriculum-tracking#162 / design-documentation#721; CDA-owned. Standard-mapped to A-31 OJL 1.b, 2.b.",
     "driveFolder": null,
     "statusConfirmed": true
   },

--- a/courses.json
+++ b/courses.json
@@ -397,12 +397,12 @@
       "name": "Compliance and Security Awareness",
       "hours": 4,
       "status": {
-        "design": "Not Started",
-        "development": "Not Started"
+        "design": "Complete",
+        "development": "In Progress"
       },
       "syllabus": null,
-      "outline": null,
-      "note": "Removed from OSS (Security & Professional Skills) per curriculum-tracking#162 / design-documentation#721. Now a Cyber Developer Associate (A-31) Phase 2 course, 4h — build pending (design/development Not Started). Standard-mapped to A-31 OJL 1.b, 2.b.",
+      "outline": true,
+      "note": "CDA Phase 2, 4h. Design Complete (course outline + 4 lesson outlines + 4 lesson sources); development In Progress (Row 5 content scaffolding). Removed from OSS per curriculum-tracking#162 / design-documentation#721; CDA-owned. Standard-mapped to A-31 OJL 1.b, 2.b.",
       "driveFolder": null,
       "statusConfirmed": true
     },

--- a/outlines/compliance-and-security-awareness.json
+++ b/outlines/compliance-and-security-awareness.json
@@ -1,0 +1,76 @@
+{
+  "course": "Compliance and Security Awareness",
+  "totalHours": 4,
+  "totalModules": 2,
+  "totalLessons": 4,
+  "modules": [
+    {
+      "name": "Compliance Frameworks That Shape Software",
+      "hours": 2,
+      "lessons": [
+        {
+          "title": "Regulatory and Compliance Frameworks for Software",
+          "hours": 1,
+          "topics": [
+            "What GDPR, HIPAA, PCI-DSS, SOC 2, and SOX each govern, and the kinds of data and systems that trigger each",
+            "Determining which frameworks apply to a given system from the data it handles and the domain it operates in",
+            "The data-protection and privacy obligations behind the frameworks (personal data, health data, cardholder data)",
+            "Where compliance responsibility sits across cloud provider, organization, and developer (shared-responsibility view)"
+          ],
+          "objects": [
+            "Object: Lesson: Regulatory and Compliance Frameworks for Software",
+            "Assessment: Quiz: Regulatory and Compliance Frameworks for Software"
+          ]
+        },
+        {
+          "title": "From Compliance Obligation to Code",
+          "hours": 1,
+          "topics": [
+            "Translating a requirement into developer controls: data classification and handling",
+            "Encryption expectations in transit and at rest, and basic key-handling responsibilities",
+            "Access control, least privilege, and audit logging as compliance evidence",
+            "Data retention, minimization, and deletion — and treating compliance requirements as acceptance criteria"
+          ],
+          "objects": [
+            "Object: Lesson: From Compliance Obligation to Code",
+            "Assessment: Quiz: From Compliance Obligation to Code"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Responsible Practices and Security Awareness for Developers",
+      "hours": 2,
+      "lessons": [
+        {
+          "title": "Responsible AI and Regulatory Compliance in AI Integration",
+          "hours": 1,
+          "topics": [
+            "Identifying and mitigating bias in AI-assisted features",
+            "Protecting privacy when integrating AI: PII and sensitive data in prompts, model outputs, and logs",
+            "Maintaining regulatory compliance for AI use — data residency, consent, and auditability",
+            "Awareness of emerging AI governance: NIST AI Risk Management Framework and the EU AI Act at a high level"
+          ],
+          "objects": [
+            "Object: Lesson: Responsible AI and Regulatory Compliance in AI Integration",
+            "Assessment: Quiz: Responsible AI and Regulatory Compliance in AI Integration"
+          ]
+        },
+        {
+          "title": "Developer Security Awareness in Practice",
+          "hours": 1,
+          "topics": [
+            "Safe handling of secrets and credentials — no secrets in code or commit history; using secret managers",
+            "Phishing and social engineering aimed at developers — dependency lures, impersonated maintainers, credential capture",
+            "Safe data handling in day-to-day development — test data, screenshots, and shared channels",
+            "Recognizing a security incident and a developer's reporting responsibilities"
+          ],
+          "objects": [
+            "Object: Lesson: Developer Security Awareness in Practice",
+            "Assessment: Quiz: Developer Security Awareness in Practice"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -120,6 +120,11 @@
     "id": "ctse-capstone"
   },
   {
+    "file": "compliance-and-security-awareness.json",
+    "course": "Compliance and Security Awareness",
+    "id": "compliance-and-security-awareness"
+  },
+  {
     "file": "comptia-a-plus.json",
     "course": "CompTIA A+",
     "id": "comptia-a-plus"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -2778,6 +2778,82 @@ const courseOutlines = {
       }
     ]
   },
+  "Compliance and Security Awareness": {
+    "course": "Compliance and Security Awareness",
+    "totalHours": 4,
+    "totalModules": 2,
+    "totalLessons": 4,
+    "modules": [
+      {
+        "name": "Compliance Frameworks That Shape Software",
+        "hours": 2,
+        "lessons": [
+          {
+            "title": "Regulatory and Compliance Frameworks for Software",
+            "hours": 1,
+            "topics": [
+              "What GDPR, HIPAA, PCI-DSS, SOC 2, and SOX each govern, and the kinds of data and systems that trigger each",
+              "Determining which frameworks apply to a given system from the data it handles and the domain it operates in",
+              "The data-protection and privacy obligations behind the frameworks (personal data, health data, cardholder data)",
+              "Where compliance responsibility sits across cloud provider, organization, and developer (shared-responsibility view)"
+            ],
+            "objects": [
+              "Object: Lesson: Regulatory and Compliance Frameworks for Software",
+              "Assessment: Quiz: Regulatory and Compliance Frameworks for Software"
+            ]
+          },
+          {
+            "title": "From Compliance Obligation to Code",
+            "hours": 1,
+            "topics": [
+              "Translating a requirement into developer controls: data classification and handling",
+              "Encryption expectations in transit and at rest, and basic key-handling responsibilities",
+              "Access control, least privilege, and audit logging as compliance evidence",
+              "Data retention, minimization, and deletion — and treating compliance requirements as acceptance criteria"
+            ],
+            "objects": [
+              "Object: Lesson: From Compliance Obligation to Code",
+              "Assessment: Quiz: From Compliance Obligation to Code"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Responsible Practices and Security Awareness for Developers",
+        "hours": 2,
+        "lessons": [
+          {
+            "title": "Responsible AI and Regulatory Compliance in AI Integration",
+            "hours": 1,
+            "topics": [
+              "Identifying and mitigating bias in AI-assisted features",
+              "Protecting privacy when integrating AI: PII and sensitive data in prompts, model outputs, and logs",
+              "Maintaining regulatory compliance for AI use — data residency, consent, and auditability",
+              "Awareness of emerging AI governance: NIST AI Risk Management Framework and the EU AI Act at a high level"
+            ],
+            "objects": [
+              "Object: Lesson: Responsible AI and Regulatory Compliance in AI Integration",
+              "Assessment: Quiz: Responsible AI and Regulatory Compliance in AI Integration"
+            ]
+          },
+          {
+            "title": "Developer Security Awareness in Practice",
+            "hours": 1,
+            "topics": [
+              "Safe handling of secrets and credentials — no secrets in code or commit history; using secret managers",
+              "Phishing and social engineering aimed at developers — dependency lures, impersonated maintainers, credential capture",
+              "Safe data handling in day-to-day development — test data, screenshots, and shared channels",
+              "Recognizing a security incident and a developer's reporting responsibilities"
+            ],
+            "objects": [
+              "Object: Lesson: Developer Security Awareness in Practice",
+              "Assessment: Quiz: Developer Security Awareness in Practice"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "CompTIA A+": {
     "course": "CompTIA A+",
     "totalHours": 120,

--- a/syllabi/compliance-and-security-awareness.html
+++ b/syllabi/compliance-and-security-awareness.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Syllabus: Compliance and Security Awareness</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+:root[data-theme="dark"] {
+    --bg: #111117;
+    --surface: #1A1B23;
+    --surface-raised: #22232D;
+    --border: #2E2F3A;
+    --border-subtle: #23242E;
+    --text-primary: #F0F0EC;
+    --text-secondary: #C8C9CE;
+    --text-muted: #8B8D98;
+    --sky-blue: #8ECAE6;
+    --blue-green: #219EBC;
+    --deep-space: #023047;
+    --amber: #FFB703;
+    --tiger: #FB8500;
+    --link: #219EBC;
+    --link-hover: #8ECAE6;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+.page {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px 32px 120px;
+}
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--link);
+    text-decoration: none;
+    font-size: 13px;
+    margin-bottom: 24px;
+}
+.back-link:hover { color: var(--link-hover); }
+.header {
+    margin-bottom: 32px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+}
+.header h1 {
+    font-size: 26px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.header-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+.header-meta span {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: rgba(255, 183, 3, 0.12);
+    color: var(--amber);
+}
+section { margin-bottom: 32px; }
+section h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+section h2 i { opacity: 0.6; font-size: 15px; }
+p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+}
+.divider {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: 28px 0;
+}
+.outcomes {
+    list-style: none;
+    counter-reset: outcome;
+}
+.outcomes li {
+    counter-increment: outcome;
+    font-size: 14px;
+    color: var(--text-secondary);
+    padding: 6px 0;
+    display: flex;
+    gap: 10px;
+}
+.outcomes li::before {
+    content: counter(outcome) ".";
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 24px;
+    text-align: right;
+}
+.module {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    margin-bottom: 12px;
+    overflow: hidden;
+}
+.module-head {
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.module-num {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 20px;
+}
+.module-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    flex: 1;
+}
+.module-hours {
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+.module-body {
+    padding: 0 16px 14px;
+    border-top: 1px solid var(--border-subtle);
+}
+.lesson-heading {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 12px 0 6px;
+}
+.topic-list {
+    list-style: none;
+    padding-left: 12px;
+}
+.topic-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.topic-list li::before {
+    content: "\2022";
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.activities {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: var(--surface-raised);
+    border-radius: 6px;
+}
+.activities-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+.activities ul {
+    list-style: none;
+    padding: 0;
+}
+.activities li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+.activities li::before {
+    content: "\f0eb";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 400;
+    font-size: 10px;
+    color: var(--amber);
+    flex-shrink: 0;
+}
+.assessment-box {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 16px;
+}
+.assessment-box p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+.assessment-box ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 8px;
+}
+.assessment-box li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.assessment-box li::before {
+    content: "\f00c";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: #3fb950;
+}
+.software-list {
+    list-style: none;
+    padding: 0;
+}
+.software-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.software-list li::before {
+    content: "\f019";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--text-muted);
+}
+.labs-list {
+    list-style: none;
+    padding: 0;
+}
+.labs-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.labs-list li::before {
+    content: "\f120";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--sky-blue);
+}
+code {
+    background: var(--surface-raised);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+    color: var(--sky-blue);
+}
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
+    </style>
+</head>
+<body>
+    <div class="page">
+        <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
+
+        <div class="header">
+            <h1>Syllabus: Compliance and Security Awareness</h1>
+            <div class="header-meta">
+                <span><i class="fa-solid fa-layer-group"></i> Operations Support Specialist — Network</span>
+                <span><i class="fa-regular fa-clock"></i> 4 hours</span>
+                <span class="badge">CURRENT</span>
+            </div>
+        </div>
+        <section>
+            <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
+            <p>Course description pending.</p>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
+            <ol class="outcomes">
+                <li>Identify what GDPR, HIPAA, PCI-DSS, SOC 2, and SOX each govern, and the kinds of data and systems that trigger each.</li>
+                <li>Determine which frameworks apply to a given system from the data it handles and the domain it operates in, and describe the data-protection obligations behind them.</li>
+                <li>Explain where compliance responsibility sits across the cloud provider, the organization, and the developer under a shared-responsibility view.</li>
+                <li>Translate a compliance obligation into a data-classification and handling rule that governs how a given field is stored, moved, and displayed in code.</li>
+                <li>Describe the encryption-in-transit and at-rest expectations behind a compliance requirement, along with the basic key-handling, access-control, least-privilege, and audit-logging controls that satisfy and evidence it.</li>
+                <li>Apply data retention, minimization, and deletion obligations, and express a compliance requirement as acceptance criteria a developer can build and verify against.</li>
+                <li>Identify sources of bias in an AI-assisted feature and describe developer-side steps to mitigate it.</li>
+                <li>Explain how to protect privacy when integrating AI — keeping PII and sensitive data out of prompts, model outputs, and logs.</li>
+                <li>Maintain regulatory compliance for AI use by applying data-residency, consent, and auditability requirements, and describe emerging AI governance (NIST AI RMF, EU AI Act) at an awareness level.</li>
+                <li>Apply safe practices for handling secrets and credentials — keeping them out of code and commit history and reaching for a secret manager instead.</li>
+                <li>Recognize phishing and social engineering aimed at developers — dependency lures, impersonated maintainers, and credential capture — and respond safely.</li>
+                <li>Describe safe data-handling habits in day-to-day development, and identify a security incident along with a developer's responsibility to report it.</li>
+            </ol>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-sitemap"></i> Course Outline</h2>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">1</span>
+                    <span class="module-title">Compliance Frameworks That Shape Software</span>
+                    <span class="module-hours">2 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 1: Regulatory and Compliance Frameworks for Software (1h)</div>
+                    <ul class="topic-list">
+                        <li>What GDPR, HIPAA, PCI-DSS, SOC 2, and SOX each govern, and the kinds of data and systems that trigger each</li>
+                        <li>Determining which frameworks apply to a given system from the data it handles and the domain it operates in</li>
+                        <li>The data-protection and privacy obligations behind the frameworks (personal data, health data, cardholder data)</li>
+                        <li>Where compliance responsibility sits across cloud provider, organization, and developer (shared-responsibility view)</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 2: From Compliance Obligation to Code (1h)</div>
+                    <ul class="topic-list">
+                        <li>Translating a requirement into developer controls: data classification and handling</li>
+                        <li>Encryption expectations in transit and at rest, and basic key-handling responsibilities</li>
+                        <li>Access control, least privilege, and audit logging as compliance evidence</li>
+                        <li>Data retention, minimization, and deletion — and treating compliance requirements as acceptance criteria</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">2</span>
+                    <span class="module-title">Responsible Practices and Security Awareness for Developers</span>
+                    <span class="module-hours">2 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: 3: Responsible AI and Regulatory Compliance in AI Integration (1h)</div>
+                    <ul class="topic-list">
+                        <li>Identifying and mitigating bias in AI-assisted features</li>
+                        <li>Protecting privacy when integrating AI: PII and sensitive data in prompts, model outputs, and logs</li>
+                        <li>Maintaining regulatory compliance for AI use — data residency, consent, and auditability</li>
+                        <li>Awareness of emerging AI governance: NIST AI Risk Management Framework and the EU AI Act at a high level</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: 4: Developer Security Awareness in Practice (1h)</div>
+                    <ul class="topic-list">
+                        <li>Safe handling of secrets and credentials — no secrets in code or commit history; using secret managers</li>
+                        <li>Phishing and social engineering aimed at developers — dependency lures, impersonated maintainers, credential capture</li>
+                        <li>Safe data handling in day-to-day development — test data, screenshots, and shared channels</li>
+                        <li>Recognizing a security incident and a developer's reporting responsibilities</li>
+                    </ul>
+                </div>
+            </div>
+
+        </section>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Tracking-side of **Row 5 Phase 0** (course-root reconciliation) for the CDA Compliance & Security Awareness build. Design side: `apprenti-org/design-documentation` onboarding **#1317**, scaffolding **#1325**.

## Changes (compliance course only)
- **courses.json** — `status.design`: Not Started → **Complete**; `status.development`: Not Started → **In Progress**; `outline: true`; note refreshed (design artifacts done, scaffolding in progress).
- **outlines/compliance-and-security-awareness.json** — created from the design course outline (2 modules / 4 lessons / 4h, with topics + objects).
- **outlines/manifest.json** — add entry (localeCompare-sorted, matches build.js validator).
- **syllabi/compliance-and-security-awareness.html** — regenerated from the reconciled markdown syllabus.
- **convert-syllabi.js** — fix the hardcoded name map to the canonical `-and-` filename (was `compliance-security-awareness.html`, the pre-slug-fix name).
- Regenerated `courses.js` + `outlines/outlines.js`.

## Notes
- **Standard alignment PASSED** (A-31 OJL **1.b** + **2.b**) — enabled by the extractor fix `design-documentation#1326` (PR #1327, merged).
- **Slug reconciled**: the stale no-`and` workspace stub was archived; the canonical `compliance-and-security-awareness` folder + record are now the single source. The old `syllabi/compliance-security-awareness.html` was already removed in #162/PR #238.
- Build validates clean; only compliance-course paths touched (unrelated syllabi regen from the broad converter run were reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)