### PR TITLE
Add introduction-to-advanced-concepts-in-java-secure course record (CDA Phase 5)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -593,6 +593,21 @@ const courseData = [
     "statusConfirmed": false
   },
   {
+    "id": "introduction-to-advanced-concepts-in-java-secure",
+    "name": "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)",
+    "hours": 30,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate secure edition of Introduction to Advanced Concepts in Java. Delivered as the 40h base course plus a net-new 10h 'Advanced Java Security' secure module (5 lessons: Secure Transaction Processing; Data at Rest — Encryption Basics; The Secure Repository Pattern; Advanced Java for Performance, Securely; Secure Advanced Java Lab) that the operator adds to a duplicated base course in Absorb. A-31 Phase 5 Advanced Java secure strands (performance / secure transaction processing / securing data at rest); OJL 3.a/3.b + CIA 2.b. 30h reflects the CDA curriculum allocation. Design folder course-design/introduction-to-advanced-concepts-in-java-secure/. Onboarding meta apprenti-org/design-documentation#1412.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "introduction-to-aws-cloud-platform",
     "name": "Introduction to AWS Cloud Platform",
     "hours": null,
@@ -1510,8 +1525,8 @@ const curriculaData = [
             "hoursOverride": 40
           },
           {
-            "name": "Introduction to Advanced Concepts in Java — Secure Edition",
-            "hoursOverride": 30
+            "name": "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)",
+            "id": "introduction-to-advanced-concepts-in-java-secure"
           },
           {
             "name": "Spring MVC Secure Coding",

--- a/courses.json
+++ b/courses.json
@@ -591,6 +591,21 @@
       "statusConfirmed": false
     },
     {
+      "id": "introduction-to-advanced-concepts-in-java-secure",
+      "name": "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)",
+      "hours": 30,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate secure edition of Introduction to Advanced Concepts in Java. Delivered as the 40h base course plus a net-new 10h 'Advanced Java Security' secure module (5 lessons: Secure Transaction Processing; Data at Rest — Encryption Basics; The Secure Repository Pattern; Advanced Java for Performance, Securely; Secure Advanced Java Lab) that the operator adds to a duplicated base course in Absorb. A-31 Phase 5 Advanced Java secure strands (performance / secure transaction processing / securing data at rest); OJL 3.a/3.b + CIA 2.b. 30h reflects the CDA curriculum allocation. Design folder course-design/introduction-to-advanced-concepts-in-java-secure/. Onboarding meta apprenti-org/design-documentation#1412.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "introduction-to-aws-cloud-platform",
       "name": "Introduction to AWS Cloud Platform",
       "hours": null,
@@ -1461,10 +1476,7 @@
               "name": "Java OOP — Secure-OOP",
               "hoursOverride": 40
             },
-            {
-              "name": "Introduction to Advanced Concepts in Java — Secure Edition",
-              "hoursOverride": 30
-            },
+            "introduction-to-advanced-concepts-in-java-secure",
             {
               "name": "Spring MVC Secure Coding",
               "hoursOverride": 10

--- a/outlines/introduction-to-advanced-concepts-in-java-secure.json
+++ b/outlines/introduction-to-advanced-concepts-in-java-secure.json
@@ -1,0 +1,90 @@
+{
+  "course": "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)",
+  "totalHours": 10,
+  "totalLessons": 5,
+  "totalModules": 1,
+  "modules": [
+    {
+      "name": "Advanced Java Security",
+      "hours": 10,
+      "description": "The CDA secure delta over Introduction to Advanced Concepts in Java: securing multi-step transactions, encrypting data at rest, the repository as a security boundary, performant-and-safe resource handling, and an integrative secure lab. Grounded in A-31 Phase 5 (OJL 3.a/3.b, CIA 2.b).",
+      "lessons": [
+        {
+          "title": "Secure Transaction Processing in Java",
+          "hours": 2,
+          "topics": [
+            "ACID properties with an integrity focus; partial writes as an integrity vulnerability",
+            "Atomic multi-step operations (LedgerCore transfer = debit + credit)",
+            "JDBC transactions: setAutoCommit(false), commit(), rollback()",
+            "try/catch-rollback with try-with-resources; isolation levels at a high level"
+          ],
+          "objects": [
+            "Object: Lesson: Secure Transaction Processing in Java",
+            "Assessment: Quiz: Secure Transaction Processing in Java",
+            "SCORM: scorm-lesson-01-secure-transaction-processing"
+          ]
+        },
+        {
+          "title": "Data at Rest — Encryption Basics in Java",
+          "hours": 2,
+          "topics": [
+            "Data at rest vs. data in transit; what sensitive data needs at-rest protection",
+            "Hashing (one-way, passwords) vs. symmetric encryption (reversible, data)",
+            "AES-GCM encryption via javax.crypto with a fresh random IV",
+            "Key management: externalized keys (never hardcoded), rotation, common pitfalls"
+          ],
+          "objects": [
+            "Object: Lesson: Data at Rest — Encryption Basics in Java",
+            "Assessment: Quiz: Data at Rest — Encryption Basics in Java",
+            "SCORM: scorm-lesson-02-data-at-rest-encryption-basics"
+          ]
+        },
+        {
+          "title": "The Secure Repository Pattern",
+          "hours": 2,
+          "topics": [
+            "The repository/DAO as a single auditable security boundary",
+            "Centralizing parameterized access with PreparedStatement",
+            "Boundary input validation (allow-lists, type/range checks)",
+            "Secure exception handling: log internally, return a safe message; safe result mapping"
+          ],
+          "objects": [
+            "Object: Lesson: The Secure Repository Pattern",
+            "Assessment: Quiz: The Secure Repository Pattern",
+            "SCORM: scorm-lesson-03-the-secure-repository-pattern"
+          ]
+        },
+        {
+          "title": "Advanced Java for Performance, Securely",
+          "hours": 2,
+          "topics": [
+            "Buffered/streamed I/O for large data without exhausting memory",
+            "Resource leaks as an availability/DoS risk; try-with-resources everywhere",
+            "Bounding input size as a denial-of-service defense (reject, not truncate)",
+            "Safe-concurrency basics: immutability and thread-safe shared state"
+          ],
+          "objects": [
+            "Object: Lesson: Advanced Java for Performance, Securely",
+            "Assessment: Quiz: Advanced Java for Performance, Securely",
+            "SCORM: scorm-lesson-04-advanced-java-for-performance-securely"
+          ]
+        },
+        {
+          "title": "Secure Advanced Java Lab",
+          "hours": 2,
+          "topics": [
+            "Integrative secure refactor applying transactions, at-rest encryption, secure repository, and resource safety",
+            "Reading an insecure LedgerCore component adversarially (defect inventory)",
+            "Verifying atomicity, at-rest confidentiality, boundary validation, and no resource leaks",
+            "Graded lab: insecure starter → secured solution"
+          ],
+          "objects": [
+            "Object: Lesson: Secure Advanced Java Lab",
+            "Assessment: Quiz: Secure Advanced Java Lab",
+            "SCORM: scorm-lesson-05-secure-advanced-java-lab"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -185,6 +185,11 @@
     "id": "introduction-to-advanced-concepts-in-java"
   },
   {
+    "file": "introduction-to-advanced-concepts-in-java-secure.json",
+    "course": "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)",
+    "id": "introduction-to-advanced-concepts-in-java-secure"
+  },
+  {
     "file": "intro-to-aws.json",
     "course": "Introduction to AWS Cloud Platform",
     "id": "introduction-to-aws-cloud-platform"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -6478,6 +6478,96 @@ const courseOutlines = {
       ]
     }
   },
+  "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)": {
+    "course": "Introduction to Advanced Concepts in Java — Secure Edition (Cyber Developer Associate)",
+    "totalHours": 10,
+    "totalLessons": 5,
+    "totalModules": 1,
+    "modules": [
+      {
+        "name": "Advanced Java Security",
+        "hours": 10,
+        "description": "The CDA secure delta over Introduction to Advanced Concepts in Java: securing multi-step transactions, encrypting data at rest, the repository as a security boundary, performant-and-safe resource handling, and an integrative secure lab. Grounded in A-31 Phase 5 (OJL 3.a/3.b, CIA 2.b).",
+        "lessons": [
+          {
+            "title": "Secure Transaction Processing in Java",
+            "hours": 2,
+            "topics": [
+              "ACID properties with an integrity focus; partial writes as an integrity vulnerability",
+              "Atomic multi-step operations (LedgerCore transfer = debit + credit)",
+              "JDBC transactions: setAutoCommit(false), commit(), rollback()",
+              "try/catch-rollback with try-with-resources; isolation levels at a high level"
+            ],
+            "objects": [
+              "Object: Lesson: Secure Transaction Processing in Java",
+              "Assessment: Quiz: Secure Transaction Processing in Java",
+              "SCORM: scorm-lesson-01-secure-transaction-processing"
+            ]
+          },
+          {
+            "title": "Data at Rest — Encryption Basics in Java",
+            "hours": 2,
+            "topics": [
+              "Data at rest vs. data in transit; what sensitive data needs at-rest protection",
+              "Hashing (one-way, passwords) vs. symmetric encryption (reversible, data)",
+              "AES-GCM encryption via javax.crypto with a fresh random IV",
+              "Key management: externalized keys (never hardcoded), rotation, common pitfalls"
+            ],
+            "objects": [
+              "Object: Lesson: Data at Rest — Encryption Basics in Java",
+              "Assessment: Quiz: Data at Rest — Encryption Basics in Java",
+              "SCORM: scorm-lesson-02-data-at-rest-encryption-basics"
+            ]
+          },
+          {
+            "title": "The Secure Repository Pattern",
+            "hours": 2,
+            "topics": [
+              "The repository/DAO as a single auditable security boundary",
+              "Centralizing parameterized access with PreparedStatement",
+              "Boundary input validation (allow-lists, type/range checks)",
+              "Secure exception handling: log internally, return a safe message; safe result mapping"
+            ],
+            "objects": [
+              "Object: Lesson: The Secure Repository Pattern",
+              "Assessment: Quiz: The Secure Repository Pattern",
+              "SCORM: scorm-lesson-03-the-secure-repository-pattern"
+            ]
+          },
+          {
+            "title": "Advanced Java for Performance, Securely",
+            "hours": 2,
+            "topics": [
+              "Buffered/streamed I/O for large data without exhausting memory",
+              "Resource leaks as an availability/DoS risk; try-with-resources everywhere",
+              "Bounding input size as a denial-of-service defense (reject, not truncate)",
+              "Safe-concurrency basics: immutability and thread-safe shared state"
+            ],
+            "objects": [
+              "Object: Lesson: Advanced Java for Performance, Securely",
+              "Assessment: Quiz: Advanced Java for Performance, Securely",
+              "SCORM: scorm-lesson-04-advanced-java-for-performance-securely"
+            ]
+          },
+          {
+            "title": "Secure Advanced Java Lab",
+            "hours": 2,
+            "topics": [
+              "Integrative secure refactor applying transactions, at-rest encryption, secure repository, and resource safety",
+              "Reading an insecure LedgerCore component adversarially (defect inventory)",
+              "Verifying atomicity, at-rest confidentiality, boundary validation, and no resource leaks",
+              "Graded lab: insecure starter → secured solution"
+            ],
+            "objects": [
+              "Object: Lesson: Secure Advanced Java Lab",
+              "Assessment: Quiz: Secure Advanced Java Lab",
+              "SCORM: scorm-lesson-05-secure-advanced-java-lab"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "Introduction to AWS Cloud Platform": {
     "course": "Introduction to AWS Cloud Platform",
     "totalHours": null,


### PR DESCRIPTION
Row 5 (Phase 0 tracking) of onboarding META apprenti-org/design-documentation#1412.

Creates the tracking record for the **CDA secure edition** of Introduction to Advanced Concepts in Java, per operator decision to give this secure module its own tracking record (diverges from the databases/sql secure modules which had none).

- New `introduction-to-advanced-concepts-in-java-secure` course record (30h CDA allocation; delivered as the untouched 40h base course + a net-new 10h **Advanced Java Security** secure module, 5 lessons).
- New outline JSON (1 module / 5 lessons) + manifest entry.
- Migrates the CDA curriculum ref from inline `{name, hoursOverride:30}` to a slug ID ref — 800h total preserved.
- Bundles regenerated via `build.js` (courses.js, outlines/outlines.js). Build passes.

A-31 Phase 5 Advanced Java secure strands (performance / secure transaction processing / securing data at rest); OJL 3.a/3.b + CIA 2.b.