### PR TITLE
Register tracking record: Secure Java Programming Capstone Review (CDA, 102h)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -1112,6 +1112,21 @@ const courseData = [
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"
   },
   {
+    "id": "secure-java-programming-supplement",
+    "name": "Secure Java Programming Capstone Review",
+    "hours": 102,
+    "status": {
+      "design": "Complete",
+      "development": "In Progress"
+    },
+    "syllabus": null,
+    "outline": true,
+    "note": "Cyber Developer Associate curriculum-level capstone (capstone-design-process.md §3c), delivered between Phase 5 and Phase 6; attributed to RTI Area 3. Apprentices build VitalLedger, a secure clinical-records backend, from a provided design package (ERDs/flowcharts/API contract/security spec/issue backlog); assessed by a Competency-Based Rubric + apprentice evidence map + facilitation presentation milestones (no lectures/quizzes). One module, six type:capstone phase-lessons (Setup → Data+Encryption → Service → Spring MVC API → LLM/MCP → Audit+Evidence). Design→tracking: outline #1458, facilitation #1460, lesson outlines #1462, lesson sources #1464. Onboarding meta apprenti-org/design-documentation#1456. Record created new at Row 5 (CDA was structure-only); 800h CDA total preserved.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+  },
+  {
     "id": "secure-llm-api-integration",
     "name": "Secure LLM API Integration (Cyber Developer Associate)",
     "hours": 20,
@@ -1491,8 +1506,8 @@ const curriculaData = [
             "id": "ai-assisted-test-driven-development"
           },
           {
-            "name": "Secure Java Programming Supplement",
-            "hoursOverride": 102
+            "name": "Secure Java Programming Capstone Review",
+            "id": "secure-java-programming-supplement"
           }
         ]
       },

--- a/courses.json
+++ b/courses.json
@@ -1110,6 +1110,21 @@
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {
+      "id": "secure-java-programming-supplement",
+      "name": "Secure Java Programming Capstone Review",
+      "hours": 102,
+      "status": {
+        "design": "Complete",
+        "development": "In Progress"
+      },
+      "syllabus": null,
+      "outline": true,
+      "note": "Cyber Developer Associate curriculum-level capstone (capstone-design-process.md §3c), delivered between Phase 5 and Phase 6; attributed to RTI Area 3. Apprentices build VitalLedger, a secure clinical-records backend, from a provided design package (ERDs/flowcharts/API contract/security spec/issue backlog); assessed by a Competency-Based Rubric + apprentice evidence map + facilitation presentation milestones (no lectures/quizzes). One module, six type:capstone phase-lessons (Setup → Data+Encryption → Service → Spring MVC API → LLM/MCP → Audit+Evidence). Design→tracking: outline #1458, facilitation #1460, lesson outlines #1462, lesson sources #1464. Onboarding meta apprenti-org/design-documentation#1456. Record created new at Row 5 (CDA was structure-only); 800h CDA total preserved.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/design-documentation"
+    },
+    {
       "id": "secure-llm-api-integration",
       "name": "Secure LLM API Integration (Cyber Developer Associate)",
       "hours": 20,
@@ -1442,10 +1457,7 @@
               "hoursOverride": 56
             },
             "ai-assisted-test-driven-development",
-            {
-              "name": "Secure Java Programming Supplement",
-              "hoursOverride": 102
-            }
+            "secure-java-programming-supplement"
           ]
         },
         {

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -360,6 +360,11 @@
     "id": "safe-hybrid-development-legacy-integration"
   },
   {
+    "file": "secure-java-programming-supplement.json",
+    "course": "Secure Java Programming Capstone Review",
+    "id": "secure-java-programming-supplement"
+  },
+  {
     "file": "secure-llm-api-integration.json",
     "course": "Secure LLM API Integration",
     "id": "secure-llm-api-integration"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -12553,6 +12553,104 @@ const courseOutlines = {
       }
     ]
   },
+  "Secure Java Programming Capstone Review": {
+    "course": "Secure Java Programming Capstone Review",
+    "totalHours": 102,
+    "totalModules": 1,
+    "totalLessons": 6,
+    "modules": [
+      {
+        "name": "Secure Clinical Records Capstone — VitalLedger",
+        "hours": 102,
+        "lessons": [
+          {
+            "title": "Phase A — Setup & Secure Foundations",
+            "hours": 10,
+            "topics": [
+              "Analyze the provided design package (ERDs, flowcharts, API contract, security requirements spec) to reconstruct the intended architecture and sequence the issue backlog.",
+              "Stand up the starter repo and a project board, and containerize the service with Docker as an isolation boundary.",
+              "Establish an AI-assisted, spec-first, version-controlled workflow (branch/PR/board discipline) for the build.",
+              "Present a build plan articulating how you read the design and how you will sequence the work."
+            ],
+            "objects": [
+              "Object: Lesson: Phase A — Setup & Secure Foundations",
+              "Assessment: Quiz: Phase A — Setup & Secure Foundations"
+            ]
+          },
+          {
+            "title": "Phase B — Secure Domain Model & Data Layer",
+            "hours": 25,
+            "topics": [
+              "Create an object-oriented domain model from the ERD that enforces reference security (no unguarded exposure of internal references to PHI).",
+              "Implement AES-GCM encryption at rest for the PHI fields the design package marks as sensitive.",
+              "Build a secure repository/DAO layer using parameterized access (PreparedStatement) so untrusted input can never alter query structure.",
+              "Evaluate the data layer against the security requirements spec for encryption coverage and injection resistance."
+            ],
+            "objects": [
+              "Object: Lesson: Phase B — Secure Domain Model & Data Layer",
+              "Assessment: Quiz: Phase B — Secure Domain Model & Data Layer"
+            ]
+          },
+          {
+            "title": "Phase C — Secure Service Layer",
+            "hours": 20,
+            "topics": [
+              "Enforce strict input validation at the service boundary for all untrusted input.",
+              "Apply injection-defense patterns and safe error handling that surfaces no sensitive system information.",
+              "Design correct, secure multi-step transaction handling (consistent state under partial failure).",
+              "Evaluate the service layer against the security spec for validation coverage and information-leak resistance."
+            ],
+            "objects": [
+              "Object: Lesson: Phase C — Secure Service Layer",
+              "Assessment: Quiz: Phase C — Secure Service Layer"
+            ]
+          },
+          {
+            "title": "Phase D — Spring MVC REST API & Access Control",
+            "hours": 20,
+            "topics": [
+              "Implement the REST API to the provided contract (endpoints, request/response schemas, status/error model).",
+              "Enforce authentication and role-based authorization (RBAC) so callers reach only what their role permits.",
+              "Apply secure response practices (secure headers, no-leak error responses) so the API surfaces nothing exploitable.",
+              "Evaluate the API against the contract and security spec for conformance and hardening."
+            ],
+            "objects": [
+              "Object: Lesson: Phase D — Spring MVC REST API & Access Control",
+              "Assessment: Quiz: Phase D — Spring MVC REST API & Access Control"
+            ]
+          },
+          {
+            "title": "Phase E — Secure LLM Summarizer via MCP",
+            "hours": 15,
+            "topics": [
+              "Integrate a secure LLM API call to summarize a clinical record, exposed/consumed through an MCP tool.",
+              "Apply PHI data-minimization (redaction/minimization before any model call) so the model never receives more than necessary.",
+              "Defend the summarizer against prompt injection from record content.",
+              "Evaluate the integration against the security spec for data minimization and injection resistance."
+            ],
+            "objects": [
+              "Object: Lesson: Phase E — Secure LLM Summarizer via MCP",
+              "Assessment: Quiz: Phase E — Secure LLM Summarizer via MCP"
+            ]
+          },
+          {
+            "title": "Phase F — Security Self-Audit, Tests & Evidence",
+            "hours": 12,
+            "topics": [
+              "Build a security-focused test suite using TDD, actively generating edge-case and boundary inputs (e.g., null/oversized/malformed) to test defenses against exploits.",
+              "Conduct an AI-assisted security self-audit of the full system and remediate the findings.",
+              "Author an evidence map linking each competency to concrete evidence (commits/PRs/files/tests/presentation).",
+              "Present the complete system end-to-end and defend the security decisions and evidence."
+            ],
+            "objects": [
+              "Object: Lesson: Phase F — Security Self-Audit, Tests & Evidence",
+              "Assessment: Quiz: Phase F — Security Self-Audit, Tests & Evidence"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "Secure LLM API Integration": {
     "course": "Secure LLM API Integration",
     "totalHours": 20,

--- a/outlines/secure-java-programming-supplement.json
+++ b/outlines/secure-java-programming-supplement.json
@@ -1,0 +1,98 @@
+{
+  "course": "Secure Java Programming Capstone Review",
+  "totalHours": 102,
+  "totalModules": 1,
+  "totalLessons": 6,
+  "modules": [
+    {
+      "name": "Secure Clinical Records Capstone — VitalLedger",
+      "hours": 102,
+      "lessons": [
+        {
+          "title": "Phase A — Setup & Secure Foundations",
+          "hours": 10,
+          "topics": [
+            "Analyze the provided design package (ERDs, flowcharts, API contract, security requirements spec) to reconstruct the intended architecture and sequence the issue backlog.",
+            "Stand up the starter repo and a project board, and containerize the service with Docker as an isolation boundary.",
+            "Establish an AI-assisted, spec-first, version-controlled workflow (branch/PR/board discipline) for the build.",
+            "Present a build plan articulating how you read the design and how you will sequence the work."
+          ],
+          "objects": [
+            "Object: Lesson: Phase A — Setup & Secure Foundations",
+            "Assessment: Quiz: Phase A — Setup & Secure Foundations"
+          ]
+        },
+        {
+          "title": "Phase B — Secure Domain Model & Data Layer",
+          "hours": 25,
+          "topics": [
+            "Create an object-oriented domain model from the ERD that enforces reference security (no unguarded exposure of internal references to PHI).",
+            "Implement AES-GCM encryption at rest for the PHI fields the design package marks as sensitive.",
+            "Build a secure repository/DAO layer using parameterized access (PreparedStatement) so untrusted input can never alter query structure.",
+            "Evaluate the data layer against the security requirements spec for encryption coverage and injection resistance."
+          ],
+          "objects": [
+            "Object: Lesson: Phase B — Secure Domain Model & Data Layer",
+            "Assessment: Quiz: Phase B — Secure Domain Model & Data Layer"
+          ]
+        },
+        {
+          "title": "Phase C — Secure Service Layer",
+          "hours": 20,
+          "topics": [
+            "Enforce strict input validation at the service boundary for all untrusted input.",
+            "Apply injection-defense patterns and safe error handling that surfaces no sensitive system information.",
+            "Design correct, secure multi-step transaction handling (consistent state under partial failure).",
+            "Evaluate the service layer against the security spec for validation coverage and information-leak resistance."
+          ],
+          "objects": [
+            "Object: Lesson: Phase C — Secure Service Layer",
+            "Assessment: Quiz: Phase C — Secure Service Layer"
+          ]
+        },
+        {
+          "title": "Phase D — Spring MVC REST API & Access Control",
+          "hours": 20,
+          "topics": [
+            "Implement the REST API to the provided contract (endpoints, request/response schemas, status/error model).",
+            "Enforce authentication and role-based authorization (RBAC) so callers reach only what their role permits.",
+            "Apply secure response practices (secure headers, no-leak error responses) so the API surfaces nothing exploitable.",
+            "Evaluate the API against the contract and security spec for conformance and hardening."
+          ],
+          "objects": [
+            "Object: Lesson: Phase D — Spring MVC REST API & Access Control",
+            "Assessment: Quiz: Phase D — Spring MVC REST API & Access Control"
+          ]
+        },
+        {
+          "title": "Phase E — Secure LLM Summarizer via MCP",
+          "hours": 15,
+          "topics": [
+            "Integrate a secure LLM API call to summarize a clinical record, exposed/consumed through an MCP tool.",
+            "Apply PHI data-minimization (redaction/minimization before any model call) so the model never receives more than necessary.",
+            "Defend the summarizer against prompt injection from record content.",
+            "Evaluate the integration against the security spec for data minimization and injection resistance."
+          ],
+          "objects": [
+            "Object: Lesson: Phase E — Secure LLM Summarizer via MCP",
+            "Assessment: Quiz: Phase E — Secure LLM Summarizer via MCP"
+          ]
+        },
+        {
+          "title": "Phase F — Security Self-Audit, Tests & Evidence",
+          "hours": 12,
+          "topics": [
+            "Build a security-focused test suite using TDD, actively generating edge-case and boundary inputs (e.g., null/oversized/malformed) to test defenses against exploits.",
+            "Conduct an AI-assisted security self-audit of the full system and remediate the findings.",
+            "Author an evidence map linking each competency to concrete evidence (commits/PRs/files/tests/presentation).",
+            "Present the complete system end-to-end and defend the security decisions and evidence."
+          ],
+          "objects": [
+            "Object: Lesson: Phase F — Security Self-Audit, Tests & Evidence",
+            "Assessment: Quiz: Phase F — Security Self-Audit, Tests & Evidence"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Register tracking record — Secure Java Programming Capstone Review (CDA, 102h)

New per-course tracking record for the CDA curriculum-level capstone, created during **Row 5 Phase 0** reconciliation of onboarding `apprenti-org/design-documentation#1465` (META #1456). Operator-approved to create a record (the CDA was registered structure-only). Closes #246.

### Changes
- **`courses.json`** — new full record `secure-java-programming-supplement` (name "Secure Java Programming Capstone Review", 102h, `status.design: Complete` / `status.development: In Progress`, `statusConfirmed: false`, `outline: true`, `sourceRepo` design-documentation). Sorted in by name (localeCompare).
- **CDA curriculum** — the Phase-3 "Secure Java Language Fundamentals" group's inline ref `{name: "Secure Java Programming Supplement", hoursOverride: 102}` → slug string `"secure-java-programming-supplement"` (also corrects the stale pre-recast name to the record's).
- **`outlines/secure-java-programming-supplement.json`** — new outline bundle (generated by the Phase 0 extractor from the merged course outline: 1 module / 6 phase-lessons / 102h).
- **`outlines/manifest.json`** — outline registered.
- **Bundles regenerated** — `courses.js`, `outlines/outlines.js`, `course-overview.js` (via `build.js`; validations passed).

### Notes
- **800h CDA total preserved** — the 102h was already in the CDA rollup as the inline ref; this converts it to a full record, no hour change.
- **`statusConfirmed: false`** — course is mid-build; a Curriculum Tracking Audit flips it later.
- **Syllabus HTML deferred** — `build.js` skipped the Python syllabi generator (workspace not detected in this run); the markdown syllabus was generated in the workspace at `courses/secure-java-programming-supplement/`. Consistent with the sibling secure course's `syllabus: null`. Can be wired at a later row.
- Count: 91 → 92 courses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJKY8VuypR6mapL5ujRmJ
