### PR TITLE
Introduction to HTML & CSS — Secure: development → Complete (uploaded + CDA-live)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -684,13 +684,13 @@ const courseData = [
     "hours": 40,
     "status": {
       "design": "Complete",
-      "development": "In Progress"
+      "development": "Complete"
     },
     "syllabus": null,
     "outline": true,
     "note": "Cyber Developer Associate net-new foundational Phase-6 (Secure Web and Front-End Development) course. 5 modules, 20 lessons, 40h: HTML foundations → CSS foundations → secure forms & input-validation attributes → CSP & web security headers → integrative secure static-site build (summative). Owns no verbatim A-31 Phase-6 RTI topic by design (both Phase-6 RTI topics are JavaScript/JSON, owned by the downstream Phase-6 JS courses); this course is their prerequisite. Claims OJL 4.c at the foundations level only (secure forms / input-validation attributes + CSP/security-header baseline); does not claim 4.a/4.b or teach JavaScript. Design folder course-design/introduction-to-html-and-css-secure/. Rows 2–5 complete (course outline, lesson outlines, lesson sources, content scaffolding — 20/20 lessons); code-bearing (Row 6 secure static-site starter/solution repos next). Onboarding meta apprenti-org/design-documentation#1476; CDA build #981.",
     "driveFolder": null,
-    "statusConfirmed": false,
+    "statusConfirmed": true,
     "sourceRepo": "https://github.com/apprenti-org/design-documentation"
   },
   {

--- a/courses.json
+++ b/courses.json
@@ -682,13 +682,13 @@
       "hours": 40,
       "status": {
         "design": "Complete",
-        "development": "In Progress"
+        "development": "Complete"
       },
       "syllabus": null,
       "outline": true,
       "note": "Cyber Developer Associate net-new foundational Phase-6 (Secure Web and Front-End Development) course. 5 modules, 20 lessons, 40h: HTML foundations → CSS foundations → secure forms & input-validation attributes → CSP & web security headers → integrative secure static-site build (summative). Owns no verbatim A-31 Phase-6 RTI topic by design (both Phase-6 RTI topics are JavaScript/JSON, owned by the downstream Phase-6 JS courses); this course is their prerequisite. Claims OJL 4.c at the foundations level only (secure forms / input-validation attributes + CSP/security-header baseline); does not claim 4.a/4.b or teach JavaScript. Design folder course-design/introduction-to-html-and-css-secure/. Rows 2–5 complete (course outline, lesson outlines, lesson sources, content scaffolding — 20/20 lessons); code-bearing (Row 6 secure static-site starter/solution repos next). Onboarding meta apprenti-org/design-documentation#1476; CDA build #981.",
       "driveFolder": null,
-      "statusConfirmed": false,
+      "statusConfirmed": true,
       "sourceRepo": "https://github.com/apprenti-org/design-documentation"
     },
     {


### PR DESCRIPTION
Course uploaded to Absorb + added to the CDA curriculum (2026-07-23). Flips `status.development` → Complete and `statusConfirmed` → true; regenerated `courses.js`. Closes #254. META apprenti-org/design-documentation#1476. Handed back — not self-merged.