### PR TITLE
Reconcile javascript-secure: SCORM objects[] + rebuild bundles (Row 13)

### DIFF
--- a/outlines/javascript-secure.json
+++ b/outlines/javascript-secure.json
@@ -148,5 +148,55 @@
         }
       ]
     }
+  ],
+  "objects": [
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-01-javascript-essentials-for-the-browser.zip",
+      "module": "module-01-javascript-foundations-for-secure-dom-work",
+      "lesson": "lesson-01-javascript-essentials-for-the-browser"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-02-the-dom-and-untrusted-data.zip",
+      "module": "module-01-javascript-foundations-for-secure-dom-work",
+      "lesson": "lesson-02-the-dom-and-untrusted-data"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-03-how-xss-happens-injection-sinks.zip",
+      "module": "module-02-safe-dom-manipulation-the-core-xss-defense",
+      "lesson": "lesson-03-how-xss-happens-injection-sinks"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-04-writing-text-safely-textcontent.zip",
+      "module": "module-02-safe-dom-manipulation-the-core-xss-defense",
+      "lesson": "lesson-04-writing-text-safely-textcontent"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-05-building-dom-safely-createelement.zip",
+      "module": "module-02-safe-dom-manipulation-the-core-xss-defense",
+      "lesson": "lesson-05-building-dom-safely-createelement"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-06-avoiding-eval-dynamic-execution.zip",
+      "module": "module-03-dangerous-dynamic-execution-and-insecure-object-handling",
+      "lesson": "lesson-06-avoiding-eval-dynamic-execution"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-07-json-parse-prototype-pollution.zip",
+      "module": "module-03-dangerous-dynamic-execution-and-insecure-object-handling",
+      "lesson": "lesson-07-json-parse-prototype-pollution"
+    },
+    {
+      "type": "scorm",
+      "file": "scorm-lesson-08-input-sanitization-defense-in-depth.zip",
+      "module": "module-04-actively-preventing-xss",
+      "lesson": "lesson-08-input-sanitization-defense-in-depth"
+    }
   ]
 }

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -9721,6 +9721,56 @@ const courseOutlines = {
           }
         ]
       }
+    ],
+    "objects": [
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-01-javascript-essentials-for-the-browser.zip",
+        "module": "module-01-javascript-foundations-for-secure-dom-work",
+        "lesson": "lesson-01-javascript-essentials-for-the-browser"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-02-the-dom-and-untrusted-data.zip",
+        "module": "module-01-javascript-foundations-for-secure-dom-work",
+        "lesson": "lesson-02-the-dom-and-untrusted-data"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-03-how-xss-happens-injection-sinks.zip",
+        "module": "module-02-safe-dom-manipulation-the-core-xss-defense",
+        "lesson": "lesson-03-how-xss-happens-injection-sinks"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-04-writing-text-safely-textcontent.zip",
+        "module": "module-02-safe-dom-manipulation-the-core-xss-defense",
+        "lesson": "lesson-04-writing-text-safely-textcontent"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-05-building-dom-safely-createelement.zip",
+        "module": "module-02-safe-dom-manipulation-the-core-xss-defense",
+        "lesson": "lesson-05-building-dom-safely-createelement"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-06-avoiding-eval-dynamic-execution.zip",
+        "module": "module-03-dangerous-dynamic-execution-and-insecure-object-handling",
+        "lesson": "lesson-06-avoiding-eval-dynamic-execution"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-07-json-parse-prototype-pollution.zip",
+        "module": "module-03-dangerous-dynamic-execution-and-insecure-object-handling",
+        "lesson": "lesson-07-json-parse-prototype-pollution"
+      },
+      {
+        "type": "scorm",
+        "file": "scorm-lesson-08-input-sanitization-defense-in-depth.zip",
+        "module": "module-04-actively-preventing-xss",
+        "lesson": "lesson-08-input-sanitization-defense-in-depth"
+      }
     ]
   },
   "JavaScript Coding Booster Intensive": {


### PR DESCRIPTION
Pre-Upload Reconciliation (Row 13, onboarding meta apprenti-org/design-documentation#1477).

- **R3:** added 8 SCORM `objects[]` entries to `outlines/javascript-secure.json` (one per deploy/content SCORM zip) — the packager's title-normalizer couldn't auto-match (#1523/dd#1523), added manually per the `java-oop-security-module` format.
- **R5:** rebuilt `courses.js`/`outlines.js`/`course-overview.js` via `build.js` (validations passed).

`check-deploy-tree.js` → **READY** (R1/R2/R3/R5/R6/R7 PASS, R4 N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJKY8VuypR6mapL5ujRmJ