### PR TITLE
web-development-with-javascript-secure outline: add SCORM objects[] (Row 9 packaging)

### DIFF
--- a/outlines/web-development-with-javascript-secure.json
+++ b/outlines/web-development-with-javascript-secure.json
@@ -21,7 +21,8 @@
           ],
           "objects": [
             "Object: Lesson: The Browser as a Policy Enforcer — CSP Fundamentals",
-            "Assessment: Quiz: The Browser as a Policy Enforcer — CSP Fundamentals"
+            "Assessment: Quiz: The Browser as a Policy Enforcer — CSP Fundamentals",
+            "SCORM: Interactive — The Browser as a Policy Enforcer — CSP Fundamentals (scorm-lesson-01-the-browser-as-a-policy-enforcer-csp-fundamentals.zip)"
           ]
         },
         {
@@ -37,7 +38,8 @@
           ],
           "objects": [
             "Object: Lesson: Writing and Deploying a Content Security Policy",
-            "Assessment: Quiz: Writing and Deploying a Content Security Policy"
+            "Assessment: Quiz: Writing and Deploying a Content Security Policy",
+            "SCORM: Interactive — Writing and Deploying a Content Security Policy (scorm-lesson-02-writing-and-deploying-a-content-security-policy.zip)"
           ]
         },
         {
@@ -53,7 +55,8 @@
           ],
           "objects": [
             "Object: Lesson: Eliminating Inline Script — Nonces, Hashes, and Refactoring",
-            "Assessment: Quiz: Eliminating Inline Script — Nonces, Hashes, and Refactoring"
+            "Assessment: Quiz: Eliminating Inline Script — Nonces, Hashes, and Refactoring",
+            "SCORM: Interactive — Eliminating Inline Script — Nonces, Hashes, and Refactoring (scorm-lesson-03-eliminating-inline-script-nonces-hashes-and-refactoring.zip)"
           ]
         },
         {
@@ -69,7 +72,8 @@
           ],
           "objects": [
             "Object: Lesson: CSP for Dynamic and Third-Party Content",
-            "Assessment: Quiz: CSP for Dynamic and Third-Party Content"
+            "Assessment: Quiz: CSP for Dynamic and Third-Party Content",
+            "SCORM: Interactive — CSP for Dynamic and Third-Party Content (scorm-lesson-04-csp-for-dynamic-and-third-party-content.zip)"
           ]
         },
         {
@@ -85,7 +89,8 @@
           ],
           "objects": [
             "Object: Lesson: Reporting, Testing, and Iterating a Policy",
-            "Assessment: Quiz: Reporting, Testing, and Iterating a Policy"
+            "Assessment: Quiz: Reporting, Testing, and Iterating a Policy",
+            "SCORM: Interactive — Reporting, Testing, and Iterating a Policy (scorm-lesson-05-reporting-testing-and-iterating-a-policy.zip)"
           ]
         }
       ]
@@ -107,7 +112,8 @@
           ],
           "objects": [
             "Object: Lesson: The Client-Side Trust Boundary — Sanitize Before You Process",
-            "Assessment: Quiz: The Client-Side Trust Boundary — Sanitize Before You Process"
+            "Assessment: Quiz: The Client-Side Trust Boundary — Sanitize Before You Process",
+            "SCORM: Interactive — The Client-Side Trust Boundary — Sanitize Before You Process (scorm-lesson-06-the-client-side-trust-boundary-sanitize-before-you-process.zip)"
           ]
         },
         {
@@ -123,7 +129,8 @@
           ],
           "objects": [
             "Object: Lesson: Manual Sanitization — Encoding, Escaping, and Allow-Lists",
-            "Assessment: Quiz: Manual Sanitization — Encoding, Escaping, and Allow-Lists"
+            "Assessment: Quiz: Manual Sanitization — Encoding, Escaping, and Allow-Lists",
+            "SCORM: Interactive — Manual Sanitization — Encoding, Escaping, and Allow-Lists (scorm-lesson-07-manual-sanitization-encoding-escaping-and-allow-lists.zip)"
           ]
         },
         {
@@ -139,7 +146,8 @@
           ],
           "objects": [
             "Object: Lesson: DOMPurify — Library-Based HTML Sanitization",
-            "Assessment: Quiz: DOMPurify — Library-Based HTML Sanitization"
+            "Assessment: Quiz: DOMPurify — Library-Based HTML Sanitization",
+            "SCORM: Interactive — DOMPurify — Library-Based HTML Sanitization (scorm-lesson-08-dompurify-library-based-html-sanitization.zip)"
           ]
         },
         {
@@ -155,7 +163,8 @@
           ],
           "objects": [
             "Object: Lesson: Safe Dynamic UI Construction",
-            "Assessment: Quiz: Safe Dynamic UI Construction"
+            "Assessment: Quiz: Safe Dynamic UI Construction",
+            "SCORM: Interactive — Safe Dynamic UI Construction (scorm-lesson-09-safe-dynamic-ui-construction.zip)"
           ]
         },
         {
@@ -171,7 +180,8 @@
           ],
           "objects": [
             "Object: Lesson: Sanitizing Structured and Rich Input",
-            "Assessment: Quiz: Sanitizing Structured and Rich Input"
+            "Assessment: Quiz: Sanitizing Structured and Rich Input",
+            "SCORM: Interactive — Sanitizing Structured and Rich Input (scorm-lesson-10-sanitizing-structured-and-rich-input.zip)"
           ]
         }
       ]
@@ -193,7 +203,8 @@
           ],
           "objects": [
             "Object: Lesson: The fetch() API and the Same-Origin Model",
-            "Assessment: Quiz: The fetch() API and the Same-Origin Model"
+            "Assessment: Quiz: The fetch() API and the Same-Origin Model",
+            "SCORM: Interactive — The fetch() API and the Same-Origin Model (scorm-lesson-11-the-fetch-api-and-the-same-origin-model.zip)"
           ]
         },
         {
@@ -210,7 +221,8 @@
           ],
           "objects": [
             "Object: Lesson: CORS — How Cross-Origin Requests Are Governed",
-            "Assessment: Quiz: CORS — How Cross-Origin Requests Are Governed"
+            "Assessment: Quiz: CORS — How Cross-Origin Requests Are Governed",
+            "SCORM: Interactive — CORS — How Cross-Origin Requests Are Governed (scorm-lesson-12-cors-how-cross-origin-requests-are-governed.zip)"
           ]
         },
         {
@@ -226,7 +238,8 @@
           ],
           "objects": [
             "Object: Lesson: Authentication for Client-Side API Calls",
-            "Assessment: Quiz: Authentication for Client-Side API Calls"
+            "Assessment: Quiz: Authentication for Client-Side API Calls",
+            "SCORM: Interactive — Authentication for Client-Side API Calls (scorm-lesson-13-authentication-for-client-side-api-calls.zip)"
           ]
         },
         {
@@ -242,7 +255,8 @@
           ],
           "objects": [
             "Object: Lesson: Validating and Handling API Responses",
-            "Assessment: Quiz: Validating and Handling API Responses"
+            "Assessment: Quiz: Validating and Handling API Responses",
+            "SCORM: Interactive — Validating and Handling API Responses (scorm-lesson-14-validating-and-handling-api-responses.zip)"
           ]
         },
         {
@@ -258,7 +272,8 @@
           ],
           "objects": [
             "Object: Lesson: Building a Secure API-Client Layer",
-            "Assessment: Quiz: Building a Secure API-Client Layer"
+            "Assessment: Quiz: Building a Secure API-Client Layer",
+            "SCORM: Interactive — Building a Secure API-Client Layer (scorm-lesson-15-building-a-secure-api-client-layer.zip)"
           ]
         }
       ]
@@ -280,7 +295,8 @@
           ],
           "objects": [
             "Object: Lesson: JSON.parse and JSON.stringify — Risks and Safe Use",
-            "Assessment: Quiz: JSON.parse and JSON.stringify — Risks and Safe Use"
+            "Assessment: Quiz: JSON.parse and JSON.stringify — Risks and Safe Use",
+            "SCORM: Interactive — JSON.parse and JSON.stringify — Risks and Safe Use (scorm-lesson-16-json-parse-and-json-stringify-risks-and-safe-use.zip)"
           ]
         },
         {
@@ -296,7 +312,8 @@
           ],
           "objects": [
             "Object: Lesson: Reviver Functions — Controlling Deserialization",
-            "Assessment: Quiz: Reviver Functions — Controlling Deserialization"
+            "Assessment: Quiz: Reviver Functions — Controlling Deserialization",
+            "SCORM: Interactive — Reviver Functions — Controlling Deserialization (scorm-lesson-17-reviver-functions-controlling-deserialization.zip)"
           ]
         },
         {
@@ -312,7 +329,8 @@
           ],
           "objects": [
             "Object: Lesson: Prototype Pollution and Insecure Object Handling",
-            "Assessment: Quiz: Prototype Pollution and Insecure Object Handling"
+            "Assessment: Quiz: Prototype Pollution and Insecure Object Handling",
+            "SCORM: Interactive — Prototype Pollution and Insecure Object Handling (scorm-lesson-18-prototype-pollution-and-insecure-object-handling.zip)"
           ]
         },
         {
@@ -328,7 +346,8 @@
           ],
           "objects": [
             "Object: Lesson: Schema Validation of Parsed Data",
-            "Assessment: Quiz: Schema Validation of Parsed Data"
+            "Assessment: Quiz: Schema Validation of Parsed Data",
+            "SCORM: Interactive — Schema Validation of Parsed Data (scorm-lesson-19-schema-validation-of-parsed-data.zip)"
           ]
         },
         {
@@ -343,7 +362,8 @@
           ],
           "objects": [
             "Object: Lesson: Secure Client-Side App — Integrative Graded Lab",
-            "Assessment: Quiz: Secure Client-Side App — Integrative Graded Lab"
+            "Assessment: Quiz: Secure Client-Side App — Integrative Graded Lab",
+            "SCORM: Interactive — Secure Client-Side App — Integrative Graded Lab (scorm-lesson-20-secure-client-side-app-integrative-graded-lab.zip)"
           ]
         }
       ]


### PR DESCRIPTION
## What

Adds the filename-embedded SCORM entry to each of the 20 lessons' `objects[]` in `outlines/web-development-with-javascript-secure.json`, e.g.:

`SCORM: Interactive — The Browser as a Policy Enforcer — CSP Fundamentals (scorm-lesson-01-the-browser-as-a-policy-enforcer-csp-fundamentals.zip)`

## Why

Row 9 SCORM Packaging (design-documentation **#1553**, onboarding META **#1478**) produced 20 SCORM 1.2 zips. The zip-filename-embedded outline entry is what **Pre-Upload Reconciliation R3** (zip-filename-stem matcher) checks for; a title-only entry does not satisfy R3.

## Scope

- **Outline JSON only** — no `courses.json` status flip (development stays `In Progress`; the flip to `Complete` belongs at the end of the onboarding chain). Matches sibling PR #202 (`xss-defense-secure-data-parsing-lab`).
- Written by `scorm/package.js --tracking-repo` (matches each lesson by folder slug; idempotent).
- Valid JSON; 20/20 entries.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJKY8VuypR6mapL5ujRmJ