### PR TITLE
Add SCORM objects[] entries for ai-assisted-coding-fundamentals (unblocks Pre-Upload Reconciliation R3)

### DIFF
--- a/outlines/ai-assisted-coding-fundamentals.json
+++ b/outlines/ai-assisted-coding-fundamentals.json
@@ -19,7 +19,8 @@
           ],
           "objects": [
             "Object: Lesson: Your First AI-Assisted Program",
-            "Assessment: Quiz: Your First AI-Assisted Program"
+            "Assessment: Quiz: Your First AI-Assisted Program",
+            "SCORM: scorm-lesson-01-your-first-ai-assisted-program.zip"
           ]
         },
         {
@@ -33,7 +34,8 @@
           ],
           "objects": [
             "Object: Lesson: Prompting AI Effectively for Code",
-            "Assessment: Quiz: Prompting AI Effectively for Code"
+            "Assessment: Quiz: Prompting AI Effectively for Code",
+            "SCORM: scorm-lesson-02-prompting-ai-effectively-for-code.zip"
           ]
         }
       ]
@@ -53,7 +55,8 @@
           ],
           "objects": [
             "Object: Lesson: Debugging and Refactoring with AI",
-            "Assessment: Quiz: Debugging and Refactoring with AI"
+            "Assessment: Quiz: Debugging and Refactoring with AI",
+            "SCORM: scorm-lesson-03-debugging-and-refactoring-with-ai.zip"
           ]
         },
         {
@@ -67,7 +70,8 @@
           ],
           "objects": [
             "Object: Lesson: Reviewing AI-Generated Code for Security and Accuracy",
-            "Assessment: Quiz: Reviewing AI-Generated Code for Security and Accuracy"
+            "Assessment: Quiz: Reviewing AI-Generated Code for Security and Accuracy",
+            "SCORM: scorm-lesson-04-reviewing-ai-generated-code-for-security-and-accuracy.zip"
           ]
         }
       ]

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -1268,7 +1268,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Your First AI-Assisted Program",
-              "Assessment: Quiz: Your First AI-Assisted Program"
+              "Assessment: Quiz: Your First AI-Assisted Program",
+              "SCORM: scorm-lesson-01-your-first-ai-assisted-program.zip"
             ]
           },
           {
@@ -1282,7 +1283,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Prompting AI Effectively for Code",
-              "Assessment: Quiz: Prompting AI Effectively for Code"
+              "Assessment: Quiz: Prompting AI Effectively for Code",
+              "SCORM: scorm-lesson-02-prompting-ai-effectively-for-code.zip"
             ]
           }
         ]
@@ -1302,7 +1304,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Debugging and Refactoring with AI",
-              "Assessment: Quiz: Debugging and Refactoring with AI"
+              "Assessment: Quiz: Debugging and Refactoring with AI",
+              "SCORM: scorm-lesson-03-debugging-and-refactoring-with-ai.zip"
             ]
           },
           {
@@ -1316,7 +1319,8 @@ const courseOutlines = {
             ],
             "objects": [
               "Object: Lesson: Reviewing AI-Generated Code for Security and Accuracy",
-              "Assessment: Quiz: Reviewing AI-Generated Code for Security and Accuracy"
+              "Assessment: Quiz: Reviewing AI-Generated Code for Security and Accuracy",
+              "SCORM: scorm-lesson-04-reviewing-ai-generated-code-for-security-and-accuracy.zip"
             ]
           }
         ]


### PR DESCRIPTION
Closes #266.

## Why

Pre-Upload Reconciliation (`check-deploy-tree.js`) fails **R3** for `ai-assisted-coding-fundamentals` — all 4 SCORM zips exist in `deploy/content/` but none had a matching entry in the outline JSON `objects` array.

Each lesson carried only two entries; the convention used elsewhere in this repo (e.g. `ai-assisted-it-governance.json`) has three:

```
Object: Lesson: <title>
Assessment: Quiz: <title>
SCORM: scorm-lesson-NN-<lesson-slug>.zip     <- was missing
```

## Change

4 entries added, bundles regenerated with `build.js`:

```
+ SCORM: scorm-lesson-01-your-first-ai-assisted-program.zip
+ SCORM: scorm-lesson-02-prompting-ai-effectively-for-code.zip
+ SCORM: scorm-lesson-03-debugging-and-refactoring-with-ai.zip
+ SCORM: scorm-lesson-04-reviewing-ai-generated-code-for-security-and-accuracy.zip
```

No `courses.json` change.

## Context

The course is under QA remediation in apprenti-org/design-documentation#1567 (3 blockers, all now fixed). All 4 SCORM packages were rebuilt today and must be re-versioned in Absorb — **R3 is a hard gate before that upload**, so this PR unblocks it.

## Note on scope

This repo was explicitly scoped **out** of the #1567 remediation by operator decision. This PR is the exception: R3 is a blocking gate rather than the tracking *drift* that was deferred. That separate drift — `course-overview.json` reporting 3 modules / 5 lessons / 60% for a 2-module, 4-lesson course — remains unaddressed and is still recorded as **[F2]** on #1567.