### PR TITLE
Add tracking record: security-and-cybersecurity-fundamentals-secure (60h, CDA Phase 2)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -409,6 +409,21 @@ const courseData = [
     "statusConfirmed": true
   },
   {
+    "id": "security-and-cybersecurity-fundamentals-secure",
+    "name": "Compressed Cybersecurity Fundamentals — Secure Edition (Cyber Developer Associate)",
+    "hours": 60,
+    "status": {
+      "design": "Complete",
+      "development": "Complete"
+    },
+    "syllabus": "Syllabus: Compressed Cybersecurity Fundamentals — Secure Edition",
+    "outline": true,
+    "note": "Cyber Developer Associate Phase 2 — the developer-relevant compression of Security and Cybersecurity Fundamentals. 7 modules / 18 lessons / 60h. Framing is developer-relevant security awareness and secure-by-design mindset, NOT CompTIA Security+ certification prep. Built by clone-and-subtract in Absorb (18 of 36 lessons retained) rather than through the content pipeline, so lesson content ships as SCORM interactives only — no learner lesson PDFs, no standalone quizzes, no activity files; assessment is the embedded knowledge checks. Live in Absorb 2026-07-18. Carries A-31 Phase-2 required topics CIA Triad, threat actors & attack vectors, and modern security compliance standards, plus OJL 2.a (conceptual) and 2.b. Hours settled at 60 by operator decision 2026-08-10; coverage depth is instructor-calibrated with some topics delivered as surveys. Course root artifacts (outline, syllabus + R8 PDF, manifest, 7 module overviews) and the Row 11 instructor package (18 consolidated guides + pacing guide) built 2026-08-09/10. Build issue apprenti-org/design-documentation#1313; remediation #1575.",
+    "driveFolder": null,
+    "statusConfirmed": false,
+    "sourceRepo": "https://github.com/apprenti-org/security-and-cybersecurity-fundamentals-secure-instructor"
+  },
+  {
     "id": "comptia-a-plus",
     "name": "CompTIA A+",
     "hours": 120,

--- a/courses.json
+++ b/courses.json
@@ -407,6 +407,21 @@
       "statusConfirmed": true
     },
     {
+      "id": "security-and-cybersecurity-fundamentals-secure",
+      "name": "Compressed Cybersecurity Fundamentals — Secure Edition (Cyber Developer Associate)",
+      "hours": 60,
+      "status": {
+        "design": "Complete",
+        "development": "Complete"
+      },
+      "syllabus": "Syllabus: Compressed Cybersecurity Fundamentals — Secure Edition",
+      "outline": true,
+      "note": "Cyber Developer Associate Phase 2 — the developer-relevant compression of Security and Cybersecurity Fundamentals. 7 modules / 18 lessons / 60h. Framing is developer-relevant security awareness and secure-by-design mindset, NOT CompTIA Security+ certification prep. Built by clone-and-subtract in Absorb (18 of 36 lessons retained) rather than through the content pipeline, so lesson content ships as SCORM interactives only — no learner lesson PDFs, no standalone quizzes, no activity files; assessment is the embedded knowledge checks. Live in Absorb 2026-07-18. Carries A-31 Phase-2 required topics CIA Triad, threat actors & attack vectors, and modern security compliance standards, plus OJL 2.a (conceptual) and 2.b. Hours settled at 60 by operator decision 2026-08-10; coverage depth is instructor-calibrated with some topics delivered as surveys. Course root artifacts (outline, syllabus + R8 PDF, manifest, 7 module overviews) and the Row 11 instructor package (18 consolidated guides + pacing guide) built 2026-08-09/10. Build issue apprenti-org/design-documentation#1313; remediation #1575.",
+      "driveFolder": null,
+      "statusConfirmed": false,
+      "sourceRepo": "https://github.com/apprenti-org/security-and-cybersecurity-fundamentals-secure-instructor"
+    },
+    {
       "id": "comptia-a-plus",
       "name": "CompTIA A+",
       "hours": 120,

--- a/outlines/manifest.json
+++ b/outlines/manifest.json
@@ -125,6 +125,11 @@
     "id": "compliance-and-security-awareness"
   },
   {
+    "file": "security-and-cybersecurity-fundamentals-secure.json",
+    "course": "Compressed Cybersecurity Fundamentals — Secure Edition",
+    "id": "security-and-cybersecurity-fundamentals-secure"
+  },
+  {
     "file": "comptia-a-plus.json",
     "course": "CompTIA A+",
     "id": "comptia-a-plus"

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -2862,6 +2862,235 @@ const courseOutlines = {
       }
     ]
   },
+  "Compressed Cybersecurity Fundamentals — Secure Edition": {
+    "course": "Compressed Cybersecurity Fundamentals — Secure Edition",
+    "totalHours": 60,
+    "totalModules": 7,
+    "totalLessons": 18,
+    "modules": [
+      {
+        "name": "Introduction to Cybersecurity Concepts",
+        "hours": 13.5,
+        "lessons": [
+          {
+            "title": "Introduction to Cybersecurity & Industry Relevance",
+            "topics": [
+              "What cybersecurity covers, and the evolution of cyber threats",
+              "Key domains of cybersecurity and their real-world applications",
+              "Cybersecurity roles and industry-recognized certifications",
+              "Workforce demand and current job trends"
+            ]
+          },
+          {
+            "title": "Understanding Security Controls",
+            "topics": [
+              "The three types of security controls",
+              "The five control functions, and how type and function combine",
+              "Layering controls together: defense in depth",
+              "Evaluating control effectiveness against real breaches",
+              "Common pitfalls and best practices"
+            ]
+          },
+          {
+            "title": "Core Security Principles & Risk Management",
+            "topics": [
+              "The Confidentiality, Integrity, and Availability triad",
+              "Least privilege and separation of duties",
+              "The four building blocks of risk: threat, vulnerability, impact, likelihood",
+              "Assessing risk in four steps, and building a risk matrix",
+              "Four ways to respond to a risk",
+              "Change management as a security control"
+            ]
+          },
+          {
+            "title": "Cryptographic Concepts & Applications",
+            "topics": [
+              "Why cryptography matters, and the vocabulary of encryption",
+              "Symmetric and asymmetric encryption compared",
+              "Common algorithms and their use cases",
+              "Encryption versus hashing",
+              "Matching a cryptographic technique to a business need",
+              "Where cryptography falls short, and key management"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Threats, Vulnerabilities, and Mitigations",
+        "hours": 10,
+        "lessons": [
+          {
+            "title": "Threat Actors, Vectors & Attack Surfaces",
+            "topics": [
+              "Who launches attacks, and what motivates them",
+              "Common attack vectors",
+              "Attack surfaces and how they are categorized",
+              "Advanced persistent threats compared with cybercriminals",
+              "Tracing a vector to the surface it reaches"
+            ]
+          },
+          {
+            "title": "Vulnerabilities & Indicators of Malicious Activity",
+            "topics": [
+              "Types of vulnerabilities and their impact",
+              "Indicators of compromise in systems and logs",
+              "Behavioral signs of malicious activity",
+              "The exploit lifecycle from discovery to compromise",
+              "Case study: tracing an exploit chain",
+              "Detection challenges and practical detection strategies"
+            ]
+          },
+          {
+            "title": "Mitigation Techniques & Vulnerability Response",
+            "topics": [
+              "Mitigation compared with remediation",
+              "Enterprise mitigation strategies: patching, least privilege, segmentation",
+              "Risk-based prioritization of vulnerabilities",
+              "The vulnerability handling lifecycle",
+              "Documentation, escalation, and communication during response"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Security Architecture",
+        "hours": 7,
+        "lessons": [
+          {
+            "title": "Architecture Models and Their Security Implications",
+            "topics": [
+              "On-premise, cloud, hybrid, and edge architecture models",
+              "Zero trust compared with perimeter-based design",
+              "Virtualization and container security",
+              "Evaluating security trade-offs in design decisions",
+              "Cloud service models and shared responsibility"
+            ]
+          },
+          {
+            "title": "Data Protection Strategies",
+            "topics": [
+              "Data classification, categories, and labeling",
+              "Encryption in transit and at rest, and key management",
+              "Hashing, tokenization, and data masking",
+              "Data loss prevention strategies and tools",
+              "How HIPAA, GDPR, and PCI-DSS shape data protection"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Security Operations",
+        "hours": 7,
+        "lessons": [
+          {
+            "title": "Securing Computing Resources & Asset Management",
+            "topics": [
+              "Security hardening techniques",
+              "Secure configuration, baselines, and patch management",
+              "Asset lifecycle management from acquisition to disposal",
+              "Asset classification and prioritization",
+              "Endpoint detection and response",
+              "The shadow IT challenge"
+            ]
+          },
+          {
+            "title": "Identity and Access Management (IAM)",
+            "topics": [
+              "IAM core principles: least privilege, role-based and attribute-based access control",
+              "Multi-factor authentication",
+              "The identity lifecycle from onboarding to offboarding",
+              "Authentication compared with authorization",
+              "Identity providers, single sign-on, and federation",
+              "Directory services"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Security Program Management and Oversight",
+        "hours": 13.5,
+        "lessons": [
+          {
+            "title": "Foundations of Security Governance",
+            "topics": [
+              "What security governance is, and what it is for",
+              "Key governance frameworks",
+              "Security leadership roles and responsibilities",
+              "The policy hierarchy: policies, standards, guidelines, procedures"
+            ]
+          },
+          {
+            "title": "Risk Management Fundamentals",
+            "topics": [
+              "The language of risk",
+              "The risk assessment process",
+              "Four risk response strategies and when each applies",
+              "The risk register as a tracking and prioritization tool",
+              "Governing risk"
+            ]
+          },
+          {
+            "title": "Third-Party Risk and Vendor Management",
+            "topics": [
+              "Why supply chain security matters, and the expanding threat landscape",
+              "Vendor security assessments, third-party audits, and certifications",
+              "Contractual protections in vendor agreements",
+              "Ongoing monitoring and breach alert services"
+            ]
+          },
+          {
+            "title": "Compliance, Audits, and Security Awareness",
+            "topics": [
+              "Regulatory compliance and its reach",
+              "Types of audits and their purpose",
+              "The audit lifecycle from planning to follow-up",
+              "Security awareness training",
+              "Creating and sustaining a security culture"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Incident Response and Management",
+        "hours": 3,
+        "lessons": [
+          {
+            "title": "Understanding Attack Methodologies & Frameworks",
+            "topics": [
+              "The Cyber Kill Chain and the phases of an attack",
+              "MITRE ATT&CK compared with the Cyber Kill Chain",
+              "Tactics, techniques, and procedures",
+              "Common attack types and how they map to frameworks"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Reporting and Communication",
+        "hours": 6,
+        "lessons": [
+          {
+            "title": "Fundamentals of Security Communication",
+            "topics": [
+              "Why communication determines security outcomes",
+              "Stakeholder audiences and their differing needs",
+              "Types of security communication",
+              "Timing, tone, and channel selection"
+            ]
+          },
+          {
+            "title": "Vulnerability Management Reporting",
+            "topics": [
+              "The purpose and structure of a vulnerability report",
+              "The components that make a report actionable",
+              "Risk-based prioritization frameworks",
+              "Using visuals for technical and non-technical audiences"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "CompTIA A+": {
     "course": "CompTIA A+",
     "totalHours": 120,

--- a/outlines/security-and-cybersecurity-fundamentals-secure.json
+++ b/outlines/security-and-cybersecurity-fundamentals-secure.json
@@ -1,0 +1,229 @@
+{
+  "course": "Compressed Cybersecurity Fundamentals — Secure Edition",
+  "totalHours": 60,
+  "totalModules": 7,
+  "totalLessons": 18,
+  "modules": [
+    {
+      "name": "Introduction to Cybersecurity Concepts",
+      "hours": 13.5,
+      "lessons": [
+        {
+          "title": "Introduction to Cybersecurity & Industry Relevance",
+          "topics": [
+            "What cybersecurity covers, and the evolution of cyber threats",
+            "Key domains of cybersecurity and their real-world applications",
+            "Cybersecurity roles and industry-recognized certifications",
+            "Workforce demand and current job trends"
+          ]
+        },
+        {
+          "title": "Understanding Security Controls",
+          "topics": [
+            "The three types of security controls",
+            "The five control functions, and how type and function combine",
+            "Layering controls together: defense in depth",
+            "Evaluating control effectiveness against real breaches",
+            "Common pitfalls and best practices"
+          ]
+        },
+        {
+          "title": "Core Security Principles & Risk Management",
+          "topics": [
+            "The Confidentiality, Integrity, and Availability triad",
+            "Least privilege and separation of duties",
+            "The four building blocks of risk: threat, vulnerability, impact, likelihood",
+            "Assessing risk in four steps, and building a risk matrix",
+            "Four ways to respond to a risk",
+            "Change management as a security control"
+          ]
+        },
+        {
+          "title": "Cryptographic Concepts & Applications",
+          "topics": [
+            "Why cryptography matters, and the vocabulary of encryption",
+            "Symmetric and asymmetric encryption compared",
+            "Common algorithms and their use cases",
+            "Encryption versus hashing",
+            "Matching a cryptographic technique to a business need",
+            "Where cryptography falls short, and key management"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Threats, Vulnerabilities, and Mitigations",
+      "hours": 10,
+      "lessons": [
+        {
+          "title": "Threat Actors, Vectors & Attack Surfaces",
+          "topics": [
+            "Who launches attacks, and what motivates them",
+            "Common attack vectors",
+            "Attack surfaces and how they are categorized",
+            "Advanced persistent threats compared with cybercriminals",
+            "Tracing a vector to the surface it reaches"
+          ]
+        },
+        {
+          "title": "Vulnerabilities & Indicators of Malicious Activity",
+          "topics": [
+            "Types of vulnerabilities and their impact",
+            "Indicators of compromise in systems and logs",
+            "Behavioral signs of malicious activity",
+            "The exploit lifecycle from discovery to compromise",
+            "Case study: tracing an exploit chain",
+            "Detection challenges and practical detection strategies"
+          ]
+        },
+        {
+          "title": "Mitigation Techniques & Vulnerability Response",
+          "topics": [
+            "Mitigation compared with remediation",
+            "Enterprise mitigation strategies: patching, least privilege, segmentation",
+            "Risk-based prioritization of vulnerabilities",
+            "The vulnerability handling lifecycle",
+            "Documentation, escalation, and communication during response"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Security Architecture",
+      "hours": 7,
+      "lessons": [
+        {
+          "title": "Architecture Models and Their Security Implications",
+          "topics": [
+            "On-premise, cloud, hybrid, and edge architecture models",
+            "Zero trust compared with perimeter-based design",
+            "Virtualization and container security",
+            "Evaluating security trade-offs in design decisions",
+            "Cloud service models and shared responsibility"
+          ]
+        },
+        {
+          "title": "Data Protection Strategies",
+          "topics": [
+            "Data classification, categories, and labeling",
+            "Encryption in transit and at rest, and key management",
+            "Hashing, tokenization, and data masking",
+            "Data loss prevention strategies and tools",
+            "How HIPAA, GDPR, and PCI-DSS shape data protection"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Security Operations",
+      "hours": 7,
+      "lessons": [
+        {
+          "title": "Securing Computing Resources & Asset Management",
+          "topics": [
+            "Security hardening techniques",
+            "Secure configuration, baselines, and patch management",
+            "Asset lifecycle management from acquisition to disposal",
+            "Asset classification and prioritization",
+            "Endpoint detection and response",
+            "The shadow IT challenge"
+          ]
+        },
+        {
+          "title": "Identity and Access Management (IAM)",
+          "topics": [
+            "IAM core principles: least privilege, role-based and attribute-based access control",
+            "Multi-factor authentication",
+            "The identity lifecycle from onboarding to offboarding",
+            "Authentication compared with authorization",
+            "Identity providers, single sign-on, and federation",
+            "Directory services"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Security Program Management and Oversight",
+      "hours": 13.5,
+      "lessons": [
+        {
+          "title": "Foundations of Security Governance",
+          "topics": [
+            "What security governance is, and what it is for",
+            "Key governance frameworks",
+            "Security leadership roles and responsibilities",
+            "The policy hierarchy: policies, standards, guidelines, procedures"
+          ]
+        },
+        {
+          "title": "Risk Management Fundamentals",
+          "topics": [
+            "The language of risk",
+            "The risk assessment process",
+            "Four risk response strategies and when each applies",
+            "The risk register as a tracking and prioritization tool",
+            "Governing risk"
+          ]
+        },
+        {
+          "title": "Third-Party Risk and Vendor Management",
+          "topics": [
+            "Why supply chain security matters, and the expanding threat landscape",
+            "Vendor security assessments, third-party audits, and certifications",
+            "Contractual protections in vendor agreements",
+            "Ongoing monitoring and breach alert services"
+          ]
+        },
+        {
+          "title": "Compliance, Audits, and Security Awareness",
+          "topics": [
+            "Regulatory compliance and its reach",
+            "Types of audits and their purpose",
+            "The audit lifecycle from planning to follow-up",
+            "Security awareness training",
+            "Creating and sustaining a security culture"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Incident Response and Management",
+      "hours": 3,
+      "lessons": [
+        {
+          "title": "Understanding Attack Methodologies & Frameworks",
+          "topics": [
+            "The Cyber Kill Chain and the phases of an attack",
+            "MITRE ATT&CK compared with the Cyber Kill Chain",
+            "Tactics, techniques, and procedures",
+            "Common attack types and how they map to frameworks"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Reporting and Communication",
+      "hours": 6,
+      "lessons": [
+        {
+          "title": "Fundamentals of Security Communication",
+          "topics": [
+            "Why communication determines security outcomes",
+            "Stakeholder audiences and their differing needs",
+            "Types of security communication",
+            "Timing, tone, and channel selection"
+          ]
+        },
+        {
+          "title": "Vulnerability Management Reporting",
+          "topics": [
+            "The purpose and structure of a vulnerability report",
+            "The components that make a report actionable",
+            "Risk-based prioritization frameworks",
+            "Using visuals for technical and non-technical audiences"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/syllabi/security-and-cybersecurity-fundamentals-secure.html
+++ b/syllabi/security-and-cybersecurity-fundamentals-secure.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Syllabus: Compressed Cybersecurity Fundamentals — Secure Edition</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+:root[data-theme="dark"] {
+    --bg: #111117;
+    --surface: #1A1B23;
+    --surface-raised: #22232D;
+    --border: #2E2F3A;
+    --border-subtle: #23242E;
+    --text-primary: #F0F0EC;
+    --text-secondary: #C8C9CE;
+    --text-muted: #8B8D98;
+    --sky-blue: #8ECAE6;
+    --blue-green: #219EBC;
+    --deep-space: #023047;
+    --amber: #FFB703;
+    --tiger: #FB8500;
+    --link: #219EBC;
+    --link-hover: #8ECAE6;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+.page {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px 32px 120px;
+}
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--link);
+    text-decoration: none;
+    font-size: 13px;
+    margin-bottom: 24px;
+}
+.back-link:hover { color: var(--link-hover); }
+.header {
+    margin-bottom: 32px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+}
+.header h1 {
+    font-size: 26px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.header-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+.header-meta span {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: rgba(255, 183, 3, 0.12);
+    color: var(--amber);
+}
+section { margin-bottom: 32px; }
+section h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+section h2 i { opacity: 0.6; font-size: 15px; }
+p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+}
+.divider {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: 28px 0;
+}
+.outcomes {
+    list-style: none;
+    counter-reset: outcome;
+}
+.outcomes li {
+    counter-increment: outcome;
+    font-size: 14px;
+    color: var(--text-secondary);
+    padding: 6px 0;
+    display: flex;
+    gap: 10px;
+}
+.outcomes li::before {
+    content: counter(outcome) ".";
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 24px;
+    text-align: right;
+}
+.module {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    margin-bottom: 12px;
+    overflow: hidden;
+}
+.module-head {
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.module-num {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 600;
+    min-width: 20px;
+}
+.module-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    flex: 1;
+}
+.module-hours {
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+.module-body {
+    padding: 0 16px 14px;
+    border-top: 1px solid var(--border-subtle);
+}
+.lesson-heading {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 12px 0 6px;
+}
+.topic-list {
+    list-style: none;
+    padding-left: 12px;
+}
+.topic-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.topic-list li::before {
+    content: "\2022";
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.activities {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: var(--surface-raised);
+    border-radius: 6px;
+}
+.activities-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+.activities ul {
+    list-style: none;
+    padding: 0;
+}
+.activities li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 2px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+.activities li::before {
+    content: "\f0eb";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 400;
+    font-size: 10px;
+    color: var(--amber);
+    flex-shrink: 0;
+}
+.assessment-box {
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 16px;
+}
+.assessment-box p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+.assessment-box ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 8px;
+}
+.assessment-box li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.assessment-box li::before {
+    content: "\f00c";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: #3fb950;
+}
+.software-list {
+    list-style: none;
+    padding: 0;
+}
+.software-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.software-list li::before {
+    content: "\f019";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--text-muted);
+}
+.labs-list {
+    list-style: none;
+    padding: 0;
+}
+.labs-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    padding: 3px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+.labs-list li::before {
+    content: "\f120";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 10px;
+    color: var(--sky-blue);
+}
+code {
+    background: var(--surface-raised);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+    color: var(--sky-blue);
+}
+.review-banner {
+    background: rgba(255, 183, 3, 0.10);
+    border: 1px solid rgba(255, 183, 3, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--amber);
+    font-weight: 600;
+}
+.review-banner i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
+    </style>
+</head>
+<body>
+    <div class="page">
+        <a href="../index.html" class="back-link"><i class="fa-solid fa-arrow-left"></i> Back to Dashboard</a>
+
+        <div class="header">
+            <h1>Syllabus: Compressed Cybersecurity Fundamentals — Secure Edition</h1>
+            <div class="header-meta">
+                <span><i class="fa-solid fa-layer-group"></i> Cyber Developer Associate (Phase 2)</span>
+                <span><i class="fa-regular fa-clock"></i> 60 hours</span>
+                <span class="badge">DRAFT</span>
+            </div>
+        </div>
+        <section>
+            <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
+            <p>This course builds the security judgement a developer needs to design, write, and review software that holds up under attack. It covers the field's core vocabulary — security controls, the Confidentiality, Integrity, and Availability triad, risk, and cryptography — then moves through the threats that software faces, the architectural and operational decisions that constrain them, the governance and compliance obligations that shape requirements, and the communication skills that turn a security finding into a fix.</p>
+            <p>The framing throughout is developer-relevant security awareness and a secure-by-design mindset, not certification preparation. Where a topic has both a practitioner depth and a developer-relevant depth, this course takes the latter: you will learn to recognize an access-control model and choose between them, not to administer a directory service; to read and write a vulnerability report, not to run a security operations centre. Coverage is calibrated by the instructor — some topics are surveyed rather than taught in full, which is a deliberate design of the course rather than a gap in it.</p>
+            <p>Learners leave able to reason about security as a property of the systems they build: where the attack surface is, which control interrupts which stage of an attack, what obligations attach to the data they handle, and how to communicate a risk so that someone acts on it.</p>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-trophy"></i> Summative Assessment: Embedded Knowledge Checks</h2>
+            <div class="assessment-box">
+                <p>Assessment in this course is continuous rather than terminal. Each lesson carries a set of knowledge checks embedded in its interactive module — single-answer, multi-select, and true/false items woven through the material rather than gathered into an end-of-course examination. These score in the learning management system and constitute the course's assessment of record.</p>
+                <p>There is no separate quiz, answer key, or proctored final for this edition. Learners demonstrate understanding continuously as they work through each lesson; instructors monitor completion and scoring in the LMS.</p>
+                <p>&gt; Pending: a developer-scoped summative assessment is an open follow-up for this course (`apprenti-org/design-documentation#1313`, carried on `#1575`). The certification-oriented summative belonging to the source material was removed as out of scope for this edition, and a replacement aligned to developer outcomes has not yet been authored. Until it exists, the embedded knowledge checks are the assessment.</p>
+            </div>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-bullseye"></i> Learning Outcomes</h2>
+            <ol class="outcomes">
+                <li>Apply the Confidentiality, Integrity, and Availability triad to evaluate a design decision, and explain where its three goals conflict.</li>
+                <li>Classify a security control by type and function, and explain how layered controls produce defense in depth.</li>
+                <li>Assess a risk in terms of threat, vulnerability, impact, and likelihood, and select an appropriate response strategy.</li>
+                <li>Select a cryptographic technique appropriate to a stated requirement, and explain the limits of what it protects.</li>
+                <li>Identify the threat actors, attack vectors, and attack surfaces relevant to a given system, and trace a vector to the surface it reaches.</li>
+                <li>Recognize common vulnerability classes and the indicators and behavioral signals that suggest active compromise.</li>
+                <li>Prioritize vulnerabilities using risk-based reasoning and follow a structured handling and escalation process.</li>
+                <li>Compare architecture models and articulate the security trade-offs each imposes, including cloud service models and container isolation.</li>
+                <li>Choose appropriate data protection techniques — encryption, hashing, tokenization, masking — and explain how major regulations shape those choices.</li>
+                <li>Distinguish authentication from authorization and apply access-control models and least privilege to an application design.</li>
+                <li>Explain the purpose of security governance and distinguish a policy from a standard, guideline, or procedure.</li>
+                <li>Evaluate third-party and supply chain risk, including the dependencies introduced into a software project.</li>
+                <li>Map attacker behavior onto the Cyber Kill Chain and MITRE ATT&amp;CK, and identify where a control would interrupt the sequence.</li>
+                <li>Communicate a security finding to a given audience and write a vulnerability report that drives action.</li>
+            </ol>
+        </section>
+
+        <hr class="divider">
+
+        <section>
+            <h2><i class="fa-solid fa-sitemap"></i> Course Outline</h2>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">1</span>
+                    <span class="module-title">Introduction to Cybersecurity Concepts (13.5 Hours)</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Introduction to Cybersecurity &amp; Industry Relevance</div>
+                    <ul class="topic-list">
+                        <li>What cybersecurity covers, and the evolution of cyber threats</li>
+                        <li>Key domains of cybersecurity and their real-world applications</li>
+                        <li>Cybersecurity roles and industry-recognized certifications</li>
+                        <li>Workforce demand and current job trends</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Understanding Security Controls</div>
+                    <ul class="topic-list">
+                        <li>The three types of security controls</li>
+                        <li>The five control functions, and how type and function combine</li>
+                        <li>Layering controls together: defense in depth</li>
+                        <li>Evaluating control effectiveness against real breaches</li>
+                        <li>Common pitfalls and best practices</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Core Security Principles &amp; Risk Management</div>
+                    <ul class="topic-list">
+                        <li>The Confidentiality, Integrity, and Availability triad</li>
+                        <li>Least privilege and separation of duties</li>
+                        <li>The four building blocks of risk: threat, vulnerability, impact, likelihood</li>
+                        <li>Assessing risk in four steps, and building a risk matrix</li>
+                        <li>Four ways to respond to a risk</li>
+                        <li>Change management as a security control</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Cryptographic Concepts &amp; Applications</div>
+                    <ul class="topic-list">
+                        <li>Why cryptography matters, and the vocabulary of encryption</li>
+                        <li>Symmetric and asymmetric encryption compared</li>
+                        <li>Common algorithms and their use cases</li>
+                        <li>Encryption versus hashing</li>
+                        <li>Matching a cryptographic technique to a business need</li>
+                        <li>Where cryptography falls short, and key management</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">2</span>
+                    <span class="module-title">Threats, Vulnerabilities, and Mitigations</span>
+                    <span class="module-hours">10 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Threat Actors, Vectors &amp; Attack Surfaces</div>
+                    <ul class="topic-list">
+                        <li>Who launches attacks, and what motivates them</li>
+                        <li>Common attack vectors</li>
+                        <li>Attack surfaces and how they are categorized</li>
+                        <li>Advanced persistent threats compared with cybercriminals</li>
+                        <li>Tracing a vector to the surface it reaches</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Vulnerabilities &amp; Indicators of Malicious Activity</div>
+                    <ul class="topic-list">
+                        <li>Types of vulnerabilities and their impact</li>
+                        <li>Indicators of compromise in systems and logs</li>
+                        <li>Behavioral signs of malicious activity</li>
+                        <li>The exploit lifecycle from discovery to compromise</li>
+                        <li>Case study: tracing an exploit chain</li>
+                        <li>Detection challenges and practical detection strategies</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Mitigation Techniques &amp; Vulnerability Response</div>
+                    <ul class="topic-list">
+                        <li>Mitigation compared with remediation</li>
+                        <li>Enterprise mitigation strategies: patching, least privilege, segmentation</li>
+                        <li>Risk-based prioritization of vulnerabilities</li>
+                        <li>The vulnerability handling lifecycle</li>
+                        <li>Documentation, escalation, and communication during response</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">3</span>
+                    <span class="module-title">Security Architecture</span>
+                    <span class="module-hours">7 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Architecture Models and Their Security Implications</div>
+                    <ul class="topic-list">
+                        <li>On-premise, cloud, hybrid, and edge architecture models</li>
+                        <li>Zero trust compared with perimeter-based design</li>
+                        <li>Virtualization and container security</li>
+                        <li>Evaluating security trade-offs in design decisions</li>
+                        <li>Cloud service models and shared responsibility</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Data Protection Strategies</div>
+                    <ul class="topic-list">
+                        <li>Data classification, categories, and labeling</li>
+                        <li>Encryption in transit and at rest, and key management</li>
+                        <li>Hashing, tokenization, and data masking</li>
+                        <li>Data loss prevention strategies and tools</li>
+                        <li>How HIPAA, GDPR, and PCI-DSS shape data protection</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">4</span>
+                    <span class="module-title">Security Operations</span>
+                    <span class="module-hours">7 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Securing Computing Resources &amp; Asset Management</div>
+                    <ul class="topic-list">
+                        <li>Security hardening techniques</li>
+                        <li>Secure configuration, baselines, and patch management</li>
+                        <li>Asset lifecycle management from acquisition to disposal</li>
+                        <li>Asset classification and prioritization</li>
+                        <li>Endpoint detection and response</li>
+                        <li>The shadow IT challenge</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Identity and Access Management (IAM)</div>
+                    <ul class="topic-list">
+                        <li>IAM core principles: least privilege, role-based and attribute-based access control</li>
+                        <li>Multi-factor authentication</li>
+                        <li>The identity lifecycle from onboarding to offboarding</li>
+                        <li>Authentication compared with authorization</li>
+                        <li>Identity providers, single sign-on, and federation</li>
+                        <li>Directory services</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">5</span>
+                    <span class="module-title">Security Program Management and Oversight (13.5 Hours)</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Foundations of Security Governance</div>
+                    <ul class="topic-list">
+                        <li>What security governance is, and what it is for</li>
+                        <li>Key governance frameworks</li>
+                        <li>Security leadership roles and responsibilities</li>
+                        <li>The policy hierarchy: policies, standards, guidelines, procedures</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Risk Management Fundamentals</div>
+                    <ul class="topic-list">
+                        <li>The language of risk</li>
+                        <li>The risk assessment process</li>
+                        <li>Four risk response strategies and when each applies</li>
+                        <li>The risk register as a tracking and prioritization tool</li>
+                        <li>Governing risk</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Third-Party Risk and Vendor Management</div>
+                    <ul class="topic-list">
+                        <li>Why supply chain security matters, and the expanding threat landscape</li>
+                        <li>Vendor security assessments, third-party audits, and certifications</li>
+                        <li>Contractual protections in vendor agreements</li>
+                        <li>Ongoing monitoring and breach alert services</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Compliance, Audits, and Security Awareness</div>
+                    <ul class="topic-list">
+                        <li>Regulatory compliance and its reach</li>
+                        <li>Types of audits and their purpose</li>
+                        <li>The audit lifecycle from planning to follow-up</li>
+                        <li>Security awareness training</li>
+                        <li>Creating and sustaining a security culture</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">6</span>
+                    <span class="module-title">Incident Response and Management</span>
+                    <span class="module-hours">3 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Understanding Attack Methodologies &amp; Frameworks</div>
+                    <ul class="topic-list">
+                        <li>The Cyber Kill Chain and the phases of an attack</li>
+                        <li>MITRE ATT&amp;CK compared with the Cyber Kill Chain</li>
+                        <li>Tactics, techniques, and procedures</li>
+                        <li>Common attack types and how they map to frameworks</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="module">
+                <div class="module-head">
+                    <span class="module-num">7</span>
+                    <span class="module-title">Reporting and Communication</span>
+                    <span class="module-hours">6 hours</span>
+                </div>
+                <div class="module-body">
+                    <div class="lesson-heading">Lesson: Fundamentals of Security Communication</div>
+                    <ul class="topic-list">
+                        <li>Why communication determines security outcomes</li>
+                        <li>Stakeholder audiences and their differing needs</li>
+                        <li>Types of security communication</li>
+                        <li>Timing, tone, and channel selection</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: Vulnerability Management Reporting</div>
+                    <ul class="topic-list">
+                        <li>The purpose and structure of a vulnerability report</li>
+                        <li>The components that make a report actionable</li>
+                        <li>Risk-based prioritization frameworks</li>
+                        <li>Using visuals for technical and non-technical audiences</li>
+                    </ul>
+                    <div class="lesson-heading">Lesson: s are delivered as self-paced interactive modules in the learning management system, each combining instruction, worked scenarios, and embedded knowledge checks. Instructors facilitate discussion, work the scenarios as a group, and calibrate the depth of coverage to the cohort.</div>
+                </div>
+            </div>
+
+        </section>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #268.

Creates the missing tracking record for **Compressed Cybersecurity Fundamentals — Secure Edition** (`security-and-cybersecurity-fundamentals-secure`), CDA Phase 2. The course has been **live in Absorb since 2026-07-18** with no record at all — one of the four missing CDA records from `apprenti-org/design-documentation#1563` (L2-02), and an unticked follow-up from `#1313`.

## Changes

| File | Change |
|---|---|
| `courses.json` | New entry — 60h, design/development `Complete`, `statusConfirmed: false` |
| `outlines/security-and-cybersecurity-fundamentals-secure.json` | New — 7 modules / 18 lessons |
| `outlines/manifest.json` | Registered |
| `syllabi/security-and-cybersecurity-fundamentals-secure.html` | Generated |
| `courses.js`, `outlines/outlines.js` | Regenerated by `build.js` |

`build.js` passes clean.

## How the outline JSON was produced

**Generated from the course syllabus**, not hand-authored, so the two cannot drift. Verified: module hours `13.5 · 10 · 7 · 7 · 13.5 · 3 · 6` = **60.0**, matching both the syllabus and the 18 instructor guides in the course's Row 11 package.

## Hours

**60h is settled** (operator decision 2026-08-10, `apprenti-org/design-documentation#1575`). An earlier ≈90h content estimate on `#1313` is withdrawn as a planning input — coverage depth is instructor-calibrated, with some topics delivered as surveys.

`statusConfirmed` is left **`false`**: this record is newly created, not audited.

## Two pre-existing `convert-syllabi.js` bugs surfaced — NOT introduced here

Both affect the generated HTML only. The R8 syllabus PDF (rendered by `deploy.js`) is correct and carries every section.

**1 — Sections after `## Course Outline` are silently dropped.** This syllabus loses `Delivery Format` and `Software Requirements`; 4 of 6 sections render. **`Software Requirements` is a canonical template section**, so this is not specific to this course:

```
technical-documentation    source=4 rendered=3  dropped=['Summative Assessment']
cicd-pipeline-concepts     source=4 rendered=3  dropped=['Summative Assessment']
itil-foundations           source=4 rendered=4  dropped=[]
```

**2 — Decimal module hours are not parsed.** Modules with integer hours get a `module-hours` badge (`10 hours`, `7 hours`, …); the two 13.5h modules get none and instead keep the literal `(13.5 Hours)` inside `module-title`. Rendering is inconsistent across the same page.

I did **not** fix these here — out of scope for a tracking-record PR and they touch a shared tool used by every course. Happy to file them as their own issue.

## Scope discipline

`convert-syllabi.js` regenerates every syllabus and produced 13 additional untracked files plus 4 unrelated modifications on this run. **All of that was reverted** — this PR touches only the six files listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShDzTLZQitYNJjt7LJxQc4