### PR TITLE
databases-in-java: remove Module 1 (Virtualization, Containers, and Docker)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -495,7 +495,7 @@ const courseData = [
   {
     "id": "databases-in-java",
     "name": "Databases in Java",
-    "hours": 40,
+    "hours": 36,
     "status": {
       "design": "Complete",
       "development": "Not Started"

--- a/courses.json
+++ b/courses.json
@@ -493,7 +493,7 @@
     {
       "id": "databases-in-java",
       "name": "Databases in Java",
-      "hours": 40,
+      "hours": 36,
       "status": {
         "design": "Complete",
         "development": "Not Started"

--- a/outlines/databases-in-java.json
+++ b/outlines/databases-in-java.json
@@ -1,31 +1,9 @@
 {
   "course": "Databases in Java",
-  "totalHours": 40,
-  "totalLessons": 23,
-  "totalModules": 10,
+  "totalHours": 36,
+  "totalLessons": 22,
+  "totalModules": 9,
   "modules": [
-    {
-      "name": "Virtualization, Containers, and Docker",
-      "hours": 4,
-      "description": "Introduction to virtualization concepts, container technology, Docker fundamentals, and core Docker CLI commands for containerized development environments.",
-      "lessons": [
-        {
-          "title": "Introduction to Containers",
-          "hours": 1,
-          "topics": ["Virtualization concepts and history", "What containers are and how they work", "Container vs. virtual machine comparison", "Container use cases in development"]
-        },
-        {
-          "title": "Introduction to Docker",
-          "hours": 1,
-          "topics": ["What Docker is and its purpose", "Running containers locally and in the cloud", "Docker architecture and components", "Docker Desktop installation"]
-        },
-        {
-          "title": "Docker Commands Core",
-          "hours": 2,
-          "topics": ["Docker artifacts: images, containers, registries, tags", "Core image commands: pull, build, rmi", "Core container commands: ps, start, stop, rm", "Running and executing commands in containers"]
-        }
-      ]
-    },
     {
       "name": "Databases",
       "hours": 2,

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -5001,47 +5001,10 @@ const courseOutlines = {
   },
   "Databases in Java": {
     "course": "Databases in Java",
-    "totalHours": 40,
-    "totalLessons": 23,
-    "totalModules": 10,
+    "totalHours": 36,
+    "totalLessons": 22,
+    "totalModules": 9,
     "modules": [
-      {
-        "name": "Virtualization, Containers, and Docker",
-        "hours": 4,
-        "description": "Introduction to virtualization concepts, container technology, Docker fundamentals, and core Docker CLI commands for containerized development environments.",
-        "lessons": [
-          {
-            "title": "Introduction to Containers",
-            "hours": 1,
-            "topics": [
-              "Virtualization concepts and history",
-              "What containers are and how they work",
-              "Container vs. virtual machine comparison",
-              "Container use cases in development"
-            ]
-          },
-          {
-            "title": "Introduction to Docker",
-            "hours": 1,
-            "topics": [
-              "What Docker is and its purpose",
-              "Running containers locally and in the cloud",
-              "Docker architecture and components",
-              "Docker Desktop installation"
-            ]
-          },
-          {
-            "title": "Docker Commands Core",
-            "hours": 2,
-            "topics": [
-              "Docker artifacts: images, containers, registries, tags",
-              "Core image commands: pull, build, rmi",
-              "Core container commands: ps, start, stop, rm",
-              "Running and executing commands in containers"
-            ]
-          }
-        ]
-      },
       {
         "name": "Databases",
         "hours": 2,

--- a/syllabi/databases-in-java.html
+++ b/syllabi/databases-in-java.html
@@ -312,14 +312,14 @@ code {
             <h1>Syllabus: Databases in Java</h1>
             <div class="header-meta">
                 <span><i class="fa-solid fa-layer-group"></i> Software Developer Java (JVFD)</span>
-                <span><i class="fa-regular fa-clock"></i> 40 hours</span>
+                <span><i class="fa-regular fa-clock"></i> 36 hours</span>
                 <span class="badge">DRAFT</span>
             </div>
         </div>
         <section>
             <h2><i class="fa-solid fa-book-open"></i> Course Description</h2>
             <p>This course guides students through essential concepts and practical applications of working with databases in a Java environment. Spanning ten content modules, students explore topics ranging from database fundamentals and relational modeling to advanced SQL techniques and Java Database Connectivity (JDBC).</p>
-            <p>Starting with virtualization, containers, and Docker, the course progresses through database types and terminology, relational modeling with normalization and entity relationship diagrams, and hands-on installation and configuration of MySQL and SQL Server Express. Students gain deep proficiency in SQL — from basic SELECT statements through JOINs, aggregation, subqueries, and data manipulation (INSERT, UPDATE, DELETE). The course culminates with stored procedures, transactions, and connecting Java applications to databases using JDBC and Spring's JdbcTemplate.</p>
+            <p>The course begins with database types and terminology, relational modeling with normalization and entity relationship diagrams, and hands-on installation and configuration of MySQL and SQL Server Express. Students gain deep proficiency in SQL — from basic SELECT statements through JOINs, aggregation, subqueries, and data manipulation (INSERT, UPDATE, DELETE). The course culminates with stored procedures, transactions, and connecting Java applications to databases using JDBC and Spring's JdbcTemplate.</p>
         </section>
 
         <hr class="divider">
@@ -357,41 +357,6 @@ code {
             <div class="module">
                 <div class="module-head">
                     <span class="module-num">1</span>
-                    <span class="module-title">Virtualization, Containers, and Docker</span>
-                    <span class="module-hours">4 hours</span>
-                </div>
-                <div class="module-body">
-                    <div class="lesson-heading">Lesson: Introduction to Containers</div>
-                    <ul class="topic-list">
-                        <li>Virtualization concepts and history</li>
-                        <li>What containers are and how they work</li>
-                        <li>Container vs. virtual machine comparison</li>
-                    </ul>
-                    <div class="activities">
-                        <div class="activities-label">Activities</div>
-                        <ul>
-                            <li>Install: Docker Desktop</li>
-                        </ul>
-                    </div>
-                    <div class="lesson-heading">Lesson: Introduction to Docker</div>
-                    <ul class="topic-list">
-                        <li>What Docker is and its purpose</li>
-                        <li>Running containers locally and in the cloud</li>
-                        <li>Docker architecture and components</li>
-                    </ul>
-                    <div class="lesson-heading">Lesson: Docker Commands Core</div>
-                    <ul class="topic-list">
-                        <li>Docker artifacts: images, containers, registries, tags</li>
-                        <li>Core image commands: pull, build, rmi</li>
-                        <li>Core container commands: ps, start, stop, rm</li>
-                        <li>Running and executing commands in containers</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="module">
-                <div class="module-head">
-                    <span class="module-num">2</span>
                     <span class="module-title">Databases</span>
                     <span class="module-hours">2 hours</span>
                 </div>
@@ -413,7 +378,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">3</span>
+                    <span class="module-num">2</span>
                     <span class="module-title">Relational Modeling</span>
                     <span class="module-hours">4 hours</span>
                 </div>
@@ -452,7 +417,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">4</span>
+                    <span class="module-num">3</span>
                     <span class="module-title">Database Instance Installs</span>
                     <span class="module-hours">4 hours</span>
                 </div>
@@ -486,7 +451,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">5</span>
+                    <span class="module-num">4</span>
                     <span class="module-title">Database Creation and Maintenance</span>
                     <span class="module-hours">4 hours</span>
                 </div>
@@ -513,7 +478,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">6</span>
+                    <span class="module-num">5</span>
                     <span class="module-title">SQL Fundamentals</span>
                     <span class="module-hours">4 hours</span>
                 </div>
@@ -552,7 +517,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">7</span>
+                    <span class="module-num">6</span>
                     <span class="module-title">Intermediate SQL</span>
                     <span class="module-hours">6 hours</span>
                 </div>
@@ -603,7 +568,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">8</span>
+                    <span class="module-num">7</span>
                     <span class="module-title">Advanced SQL</span>
                     <span class="module-hours">6 hours</span>
                 </div>
@@ -653,7 +618,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">9</span>
+                    <span class="module-num">8</span>
                     <span class="module-title">Stored Procedures and Transactions</span>
                     <span class="module-hours">2 hours</span>
                 </div>
@@ -681,7 +646,7 @@ code {
 
             <div class="module">
                 <div class="module-head">
-                    <span class="module-num">10</span>
+                    <span class="module-num">9</span>
                     <span class="module-title">JDBC</span>
                     <span class="module-hours">4 hours</span>
                 </div>
@@ -730,7 +695,6 @@ code {
         <section>
             <h2><i class="fa-solid fa-laptop-code"></i> Software Requirements</h2>
             <ul class="software-list">
-                <li>Docker Desktop</li>
                 <li>MySQL Community Server</li>
                 <li>MySQL Workbench</li>
                 <li>SQL Server Express</li>


### PR DESCRIPTION
Closes #270.

The three Docker lessons — Introduction to Containers, Introduction to Docker, Docker Commands Core (4h) — are covered by the dedicated **Docker Container Isolation** course (24h), and they **do not exist in this course**: no `modules/01-*` folder, no `content.md`, no deployed PDF, no SCORM. The outline described material that was never built, and the CDA pacing guide was scheduling ~4h against it with nothing to link to.

| File | Change |
|---|---|
| `outlines/databases-in-java.json` | totalHours 40 → **36**, modules 10 → 9, lessons 23 → 22 |
| `courses.json` | hours 40 → **36** |
| `syllabi/databases-in-java.html` | Module 1 section removed, description reworded, modules renumbered |
| `courses.js`, `outlines/outlines.js` | regenerated via `build.js` |

Lesson hours now sum to 36, matching `totalHours`. The `topics` arrays were edited textually so they stay inline — a JSON re-dump would have reformatted the whole file.

Also dropped **Docker Desktop** from Software Requirements; it was there for the removed module. The secure edition's container work lives in its own course with its own requirements.

## Notes

- The workspace source `syllabus-databases-in-java.md` carries the same edits (the workspace is not a git repo).
- `convert-syllabi.js` regenerates *every* syllabus. The 4 unrelated files it rewrote and the 13 it created were reverted — only `databases-in-java.html` is in this commit.
- **Content in the LMS is unaffected** and needs no change.
- **Module 4: Database Instance Installs** has the same problem (in the outline, no folder, no content) but is *not* covered elsewhere, so it is deliberately left alone — see #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)