### PR TITLE
ITIL Foundations: 19 → 20 lessons after adding IT Asset and Service Configuration Management (#272)

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -746,7 +746,7 @@ const courseData = [
     },
     "syllabus": "itil-foundations",
     "outline": true,
-    "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep.",
+    "note": "20 hours, 7 modules, 20 lessons. ITIL 4 Foundation certification prep. IT Asset and Service Configuration Management added to Module 5 (2026-08-24) to close the two practices examined by the sample papers but taught nowhere in the course — IT asset management (syllabus 6.1.d) and service configuration management (6.1.g). Published length held at 20h with no existing lesson trimmed, so scheduled content runs ~21h and the instructor absorbs the difference; guidance is in the lesson instructor guide. Live in Absorb 2026-08-24.",
     "driveFolder": "https://drive.google.com/drive/folders/1aljEOFGVRecJDz1QsGRCNTjBs-i81esw",
     "deployRepo": "https://github.com/apprenti-org/itil-foundations-content",
     "sourceRepo": "https://github.com/apprenti-org/design-documentation",

--- a/courses.json
+++ b/courses.json
@@ -744,7 +744,7 @@
       },
       "syllabus": "itil-foundations",
       "outline": true,
-      "note": "20 hours, 7 modules, 19 lessons. ITIL 4 Foundation certification prep.",
+      "note": "20 hours, 7 modules, 20 lessons. ITIL 4 Foundation certification prep. IT Asset and Service Configuration Management added to Module 5 (2026-08-24) to close the two practices examined by the sample papers but taught nowhere in the course — IT asset management (syllabus 6.1.d) and service configuration management (6.1.g). Published length held at 20h with no existing lesson trimmed, so scheduled content runs ~21h and the instructor absorbs the difference; guidance is in the lesson instructor guide. Live in Absorb 2026-08-24.",
       "driveFolder": "https://drive.google.com/drive/folders/1aljEOFGVRecJDz1QsGRCNTjBs-i81esw",
       "deployRepo": "https://github.com/apprenti-org/itil-foundations-content",
       "sourceRepo": "https://github.com/apprenti-org/design-documentation",

--- a/outlines/itil-foundations.json
+++ b/outlines/itil-foundations.json
@@ -1,7 +1,7 @@
 {
   "course": "ITIL Foundations",
   "totalHours": 20,
-  "totalLessons": 19,
+  "totalLessons": 20,
   "totalModules": 7,
   "modules": [
     {
@@ -23,10 +23,10 @@
           ],
           "objects": [
             "Object: Lesson: What is IT Service Management (ITSM)?",
-            "SCORM: Interactive \u2014 What is IT Service Management (ITSM)?",
-            "Assessment: Quiz \u2014 What is IT Service Management (ITSM)?",
-            "Object: Activity \u2014 Exercise: Identify Services in Your Daily Life",
-            "Object: Activity \u2014 Exercise: Map the Service Relationship"
+            "SCORM: Interactive — What is IT Service Management (ITSM)?",
+            "Assessment: Quiz — What is IT Service Management (ITSM)?",
+            "Object: Activity — Exercise: Identify Services in Your Daily Life",
+            "Object: Activity — Exercise: Map the Service Relationship"
           ]
         },
         {
@@ -36,15 +36,15 @@
             "History and evolution of ITIL to ITIL 4",
             "ITIL 4 structure and certification pathway",
             "Key terminology: outcome, output, cost, risk",
-            "Utility (\"fit for purpose\") vs warranty (\"fit for use\") \u2014 exam-critical distinction",
+            "Utility (\"fit for purpose\") vs warranty (\"fit for use\") — exam-critical distinction",
             "Service offerings: goods, access to resources, service actions",
             "How external factors (PESTLE) affect the four dimensions"
           ],
           "objects": [
             "Object: Lesson: Overview of the ITIL Framework",
-            "SCORM: Interactive \u2014 Overview of the ITIL Framework",
-            "Assessment: Quiz \u2014 Overview of the ITIL Framework",
-            "Object: Activity \u2014 Exercise: Utility vs Warranty Challenge"
+            "SCORM: Interactive — Overview of the ITIL Framework",
+            "Assessment: Quiz — Overview of the ITIL Framework",
+            "Object: Activity — Exercise: Utility vs Warranty Challenge"
           ]
         }
       ]
@@ -58,15 +58,15 @@
           "hours": 1.5,
           "topics": [
             "What is the Service Value System?",
-            "Inputs (opportunity and demand) \u2192 Outputs \u2192 Value",
+            "Inputs (opportunity and demand) → Outputs → Value",
             "Components of the SVS: guiding principles, governance, service value chain, practices, continual improvement",
             "How the components interact"
           ],
           "objects": [
             "Object: Lesson: The Service Value System (SVS)",
-            "SCORM: Interactive \u2014 The Service Value System (SVS)",
-            "Assessment: Quiz \u2014 The Service Value System (SVS)",
-            "Object: Activity \u2014 Exercise: Label and Connect the SVS Diagram"
+            "SCORM: Interactive — The Service Value System (SVS)",
+            "Assessment: Quiz — The Service Value System (SVS)",
+            "Object: Activity — Exercise: Label and Connect the SVS Diagram"
           ]
         },
         {
@@ -80,9 +80,9 @@
           ],
           "objects": [
             "Object: Lesson: Governance and the SVS in Action",
-            "SCORM: Interactive \u2014 Governance and the SVS in Action",
-            "Assessment: Quiz \u2014 Governance and the SVS in Action",
-            "Object: Activity \u2014 Exercise: Diagram a Real-World Service Using the SVS"
+            "SCORM: Interactive — Governance and the SVS in Action",
+            "Assessment: Quiz — Governance and the SVS in Action",
+            "Object: Activity — Exercise: Diagram a Real-World Service Using the SVS"
           ]
         }
       ]
@@ -92,7 +92,7 @@
       "hours": 3,
       "lessons": [
         {
-          "title": "Guiding Principles 1\u20134",
+          "title": "Guiding Principles 1–4",
           "hours": 1.5,
           "topics": [
             "Focus on value",
@@ -101,29 +101,29 @@
             "Collaborate and promote visibility"
           ],
           "objects": [
-            "Object: Lesson: Guiding Principles 1\u20134",
-            "SCORM: Interactive \u2014 Guiding Principles 1\u20134",
-            "Assessment: Quiz \u2014 Guiding Principles 1\u20134",
-            "Object: Activity \u2014 Exercise: Principle Application Scenarios"
+            "Object: Lesson: Guiding Principles 1–4",
+            "SCORM: Interactive — Guiding Principles 1–4",
+            "Assessment: Quiz — Guiding Principles 1–4",
+            "Object: Activity — Exercise: Principle Application Scenarios"
           ]
         },
         {
-          "title": "Guiding Principles 5\u20137 and Application",
+          "title": "Guiding Principles 5–7 and Application",
           "hours": 1.5,
           "topics": [
             "Think and work holistically",
             "Keep it simple and practical",
             "Optimize and automate",
             "How principles interact and support each other",
-            "Case study: broken IT system \u2192 apply guiding principles",
+            "Case study: broken IT system → apply guiding principles",
             "Group discussion: which principles are violated?"
           ],
           "objects": [
-            "Object: Lesson: Guiding Principles 5\u20137 and Application",
-            "SCORM: Interactive \u2014 Guiding Principles 5\u20137 and Application",
-            "Assessment: Quiz \u2014 Guiding Principles 5\u20137 and Application",
-            "Object: Activity \u2014 Exercise: Case Study \u2014 Broken IT System",
-            "Object: Activity \u2014 Exercise: Principle Identification \u2014 Quick Scenarios"
+            "Object: Lesson: Guiding Principles 5–7 and Application",
+            "SCORM: Interactive — Guiding Principles 5–7 and Application",
+            "Assessment: Quiz — Guiding Principles 5–7 and Application",
+            "Object: Activity — Exercise: Case Study — Broken IT System",
+            "Object: Activity — Exercise: Principle Identification — Quick Scenarios"
           ]
         }
       ]
@@ -146,9 +146,9 @@
           ],
           "objects": [
             "Object: Lesson: The 6 Value Chain Activities",
-            "SCORM: Interactive \u2014 The 6 Value Chain Activities",
-            "Assessment: Quiz \u2014 The 6 Value Chain Activities",
-            "Object: Activity \u2014 Exercise: Match Inputs and Outputs"
+            "SCORM: Interactive — The 6 Value Chain Activities",
+            "Assessment: Quiz — The 6 Value Chain Activities",
+            "Object: Activity — Exercise: Match Inputs and Outputs"
           ]
         },
         {
@@ -160,24 +160,24 @@
             "Example value streams: incident resolution, service request fulfillment, new service deployment",
             "Mapping workflows through the value chain",
             "Identifying bottlenecks and optimization opportunities",
-            "Map a help desk ticket through the value chain \u2014 trace inputs/outputs between activities",
+            "Map a help desk ticket through the value chain — trace inputs/outputs between activities",
             "Map a service request through the value chain",
             "Identify bottlenecks and propose improvements"
           ],
           "objects": [
             "Object: Lesson: Value Streams and Workflow",
-            "SCORM: Interactive \u2014 Value Streams and Workflow",
-            "Assessment: Quiz \u2014 Value Streams and Workflow",
-            "Object: Activity \u2014 Exercise: Identify Bottlenecks and Propose Improvements",
-            "Object: Activity \u2014 Exercise: Map a Help Desk Ticket Through the Value Chain",
-            "Object: Activity \u2014 Exercise: Map a Service Request Through the Value Chain"
+            "SCORM: Interactive — Value Streams and Workflow",
+            "Assessment: Quiz — Value Streams and Workflow",
+            "Object: Activity — Exercise: Identify Bottlenecks and Propose Improvements",
+            "Object: Activity — Exercise: Map a Help Desk Ticket Through the Value Chain",
+            "Object: Activity — Exercise: Map a Service Request Through the Value Chain"
           ]
         }
       ]
     },
     {
       "name": "ITIL Practices",
-      "hours": 5,
+      "hours": 6,
       "lessons": [
         {
           "title": "Incident Management",
@@ -191,16 +191,16 @@
           ],
           "objects": [
             "Object: Lesson: Incident Management",
-            "SCORM: Interactive \u2014 Incident Management",
-            "Assessment: Quiz \u2014 Incident Management",
-            "Object: Activity \u2014 Exercise: Incident Prioritization"
+            "SCORM: Interactive — Incident Management",
+            "Assessment: Quiz — Incident Management",
+            "Object: Activity — Exercise: Incident Prioritization"
           ]
         },
         {
           "title": "Problem Management",
           "hours": 1.0,
           "topics": [
-            "Key terms: problem vs incident vs known error \u2014 exam-critical distinctions",
+            "Key terms: problem vs incident vs known error — exam-critical distinctions",
             "Problem identification and logging",
             "Root cause analysis (RCA) techniques",
             "Known errors and workarounds",
@@ -208,9 +208,9 @@
           ],
           "objects": [
             "Object: Lesson: Problem Management",
-            "SCORM: Interactive \u2014 Problem Management",
-            "Assessment: Quiz \u2014 Problem Management",
-            "Object: Activity \u2014 Exercise: Incident vs. Problem vs. Known Error Classification"
+            "SCORM: Interactive — Problem Management",
+            "Assessment: Quiz — Problem Management",
+            "Object: Activity — Exercise: Incident vs. Problem vs. Known Error Classification"
           ]
         },
         {
@@ -225,9 +225,9 @@
           ],
           "objects": [
             "Object: Lesson: Change Enablement and Release Management",
-            "SCORM: Interactive \u2014 Change Enablement and Release Management",
-            "Assessment: Quiz \u2014 Change Enablement and Release Management",
-            "Object: Activity \u2014 Exercise: Change Classification"
+            "SCORM: Interactive — Change Enablement and Release Management",
+            "Assessment: Quiz — Change Enablement and Release Management",
+            "Object: Activity — Exercise: Change Classification"
           ]
         },
         {
@@ -235,16 +235,16 @@
           "hours": 1.0,
           "topics": [
             "Key terms: SLA, SLO, OLA, service review",
-            "Service level agreements (SLAs) \u2014 structure and content",
+            "Service level agreements (SLAs) — structure and content",
             "Service level objectives (SLOs) and operational level agreements (OLAs)",
             "Measuring and reporting service performance against uptime targets",
             "Service reviews and customer feedback"
           ],
           "objects": [
             "Object: Lesson: Service Level Management",
-            "SCORM: Interactive \u2014 Service Level Management",
-            "Assessment: Quiz \u2014 Service Level Management",
-            "Object: Activity \u2014 Exercise: Design an SLA"
+            "SCORM: Interactive — Service Level Management",
+            "Assessment: Quiz — Service Level Management",
+            "Object: Activity — Exercise: Design an SLA"
           ]
         },
         {
@@ -257,10 +257,27 @@
           ],
           "objects": [
             "Object: Lesson: Service Desk, Service Request Management, and Supporting Practices",
-            "SCORM: Interactive \u2014 Service Desk, Service Request Management, and Supporting Practices",
-            "Assessment: Quiz \u2014 Service Desk, Service Request Management, and Supporting Practices",
-            "Object: Activity \u2014 Exercise: Build a Service Request Workflow",
-            "Object: Activity \u2014 Exercise: Simulate a Help Desk Scenario"
+            "SCORM: Interactive — Service Desk, Service Request Management, and Supporting Practices",
+            "Assessment: Quiz — Service Desk, Service Request Management, and Supporting Practices",
+            "Object: Activity — Exercise: Build a Service Request Workflow",
+            "Object: Activity — Exercise: Simulate a Help Desk Scenario"
+          ]
+        },
+        {
+          "title": "IT Asset and Service Configuration Management",
+          "hours": 1.0,
+          "topics": [
+            "Purpose of IT asset management — planning and managing the full lifecycle of all IT assets",
+            "Purpose of service configuration management — accurate, reliable configuration information available when and where needed",
+            "Key terms: IT asset, asset lifecycle, asset register",
+            "Key terms: configuration item (CI), configuration management database (CMDB), configuration record",
+            "Distinguishing an IT asset from a configuration item, including components that are both"
+          ],
+          "objects": [
+            "Object: Lesson: IT Asset and Service Configuration Management",
+            "SCORM: Interactive — IT Asset and Service Configuration Management",
+            "Assessment: Quiz — IT Asset and Service Configuration Management",
+            "Object: Activity — Exercise: Asset, Configuration Item, or Both?"
           ]
         }
       ]
@@ -280,10 +297,10 @@
           ],
           "objects": [
             "Object: Lesson: The Continual Improvement Model",
-            "SCORM: Interactive \u2014 The Continual Improvement Model",
-            "Assessment: Quiz \u2014 The Continual Improvement Model",
-            "Object: Activity \u2014 Exercise: Memorization Drill \u2014 Order the Steps",
-            "Object: Activity \u2014 Exercise: Quick-Fire Recall Checkpoint"
+            "SCORM: Interactive — The Continual Improvement Model",
+            "Assessment: Quiz — The Continual Improvement Model",
+            "Object: Activity — Exercise: Memorization Drill — Order the Steps",
+            "Object: Activity — Exercise: Quick-Fire Recall Checkpoint"
           ]
         },
         {
@@ -298,9 +315,9 @@
           ],
           "objects": [
             "Object: Lesson: Applying Continual Improvement",
-            "SCORM: Interactive \u2014 Applying Continual Improvement",
-            "Assessment: Quiz \u2014 Applying Continual Improvement",
-            "Object: Activity \u2014 Exercise: Evaluate and Improve a Broken Process"
+            "SCORM: Interactive — Applying Continual Improvement",
+            "Assessment: Quiz — Applying Continual Improvement",
+            "Object: Activity — Exercise: Evaluate and Improve a Broken Process"
           ]
         }
       ]
@@ -314,15 +331,15 @@
           "hours": 0.5,
           "topics": [
             "ITIL in help desk and support roles",
-            "ITIL in DevOps and Agile environments \u2014 how they work together",
+            "ITIL in DevOps and Agile environments — how they work together",
             "Tools: ServiceNow, Jira Service Management",
             "Mapping ITIL concepts to real job postings"
           ],
           "objects": [
             "Object: Lesson: ITIL in Practice",
-            "SCORM: Interactive \u2014 ITIL in Practice",
-            "Assessment: Quiz \u2014 ITIL in Practice",
-            "Object: Activity \u2014 Exercise: Map ITIL to Real Job Postings"
+            "SCORM: Interactive — ITIL in Practice",
+            "Assessment: Quiz — ITIL in Practice",
+            "Object: Activity — Exercise: Map ITIL to Real Job Postings"
           ]
         },
         {
@@ -335,8 +352,8 @@
           ],
           "objects": [
             "Object: Lesson: Comprehensive Review",
-            "SCORM: Interactive \u2014 Comprehensive Review",
-            "Assessment: Quiz \u2014 Comprehensive Review"
+            "SCORM: Interactive — Comprehensive Review",
+            "Assessment: Quiz — Comprehensive Review"
           ]
         },
         {
@@ -349,9 +366,9 @@
           ],
           "objects": [
             "Object: Lesson: Practice Exam",
-            "SCORM: Interactive \u2014 Practice Exam",
-            "Assessment: Quiz \u2014 Practice Exam",
-            "Object: Activity \u2014 Exercise: Timed Practice Exam"
+            "SCORM: Interactive — Practice Exam",
+            "Assessment: Quiz — Practice Exam",
+            "Object: Activity — Exercise: Timed Practice Exam"
           ]
         },
         {
@@ -371,10 +388,10 @@
           ],
           "objects": [
             "Object: Lesson: Case Study and Final Review",
-            "SCORM: Interactive \u2014 Case Study and Final Review",
-            "Assessment: Quiz \u2014 Case Study and Final Review",
-            "Object: Activity \u2014 Exercise: Role-Play \u2014 Service Desk vs Developer vs Manager",
-            "Object: Activity \u2014 Exercise: TechServe Case Study Analysis"
+            "SCORM: Interactive — Case Study and Final Review",
+            "Assessment: Quiz — Case Study and Final Review",
+            "Object: Activity — Exercise: Role-Play — Service Desk vs Developer vs Manager",
+            "Object: Activity — Exercise: TechServe Case Study Analysis"
           ]
         }
       ]

--- a/outlines/outlines.js
+++ b/outlines/outlines.js
@@ -8355,7 +8355,7 @@ const courseOutlines = {
   "ITIL Foundations": {
     "course": "ITIL Foundations",
     "totalHours": 20,
-    "totalLessons": 19,
+    "totalLessons": 20,
     "totalModules": 7,
     "modules": [
       {
@@ -8531,7 +8531,7 @@ const courseOutlines = {
       },
       {
         "name": "ITIL Practices",
-        "hours": 5,
+        "hours": 6,
         "lessons": [
           {
             "title": "Incident Management",
@@ -8615,6 +8615,23 @@ const courseOutlines = {
               "Assessment: Quiz — Service Desk, Service Request Management, and Supporting Practices",
               "Object: Activity — Exercise: Build a Service Request Workflow",
               "Object: Activity — Exercise: Simulate a Help Desk Scenario"
+            ]
+          },
+          {
+            "title": "IT Asset and Service Configuration Management",
+            "hours": 1,
+            "topics": [
+              "Purpose of IT asset management — planning and managing the full lifecycle of all IT assets",
+              "Purpose of service configuration management — accurate, reliable configuration information available when and where needed",
+              "Key terms: IT asset, asset lifecycle, asset register",
+              "Key terms: configuration item (CI), configuration management database (CMDB), configuration record",
+              "Distinguishing an IT asset from a configuration item, including components that are both"
+            ],
+            "objects": [
+              "Object: Lesson: IT Asset and Service Configuration Management",
+              "SCORM: Interactive — IT Asset and Service Configuration Management",
+              "Assessment: Quiz — IT Asset and Service Configuration Management",
+              "Object: Activity — Exercise: Asset, Configuration Item, or Both?"
             ]
           }
         ]


### PR DESCRIPTION
Closes #272. Brings the dashboard in line with the course, which is live in Absorb with 20 lessons while tracking still read 19.

## Why

*IT Asset and Service Configuration Management* was added to Module 5 to close the two practices the ITIL 4 sample papers examine but the course taught nowhere: **IT asset management** (syllabus 6.1.d) and **service configuration management** (6.1.g). Each is the correct answer to a sample-paper question, they appear in six questions between them, and both had **0 mentions across all 19 lessons** — verified against the official answers and rationales.

Build: `apprenti-org/design-documentation#1599` · LMS: `#1601`, closed and verified in Absorb 2026-08-24.

## Changes

| File | Change |
|---|---|
| `outlines/itil-foundations.json` | New lesson in Module 5 (5 topics, 4 objects); Module 5 hours 5 → 6; `totalLessons` 19 → 20 |
| `courses.json` | `note` refreshed to 20 lessons with the reason for the change |
| `courses.js` · `outlines/outlines.js` · `course-overview.js` | Regenerated via `node build.js` |

`node build.js` → **Validations passed**. The warnings it prints are pre-existing Cyber Developer Associate legacy name-refs, untouched here.

## Two values held deliberately

**`totalHours` stays 20.** No existing lesson was trimmed, so module hours now sum to 21 against a published length of 20. The published figure is what learners and schedulers see and it does not change; the instructor absorbs the extra hour, with guidance in the lesson's instructor guide. The divergence is recorded in the `note` rather than hidden — if you would rather the published total move to 21, that is a one-line change here plus the syllabus.

**`statusConfirmed` stays `true`.** Every audited field — hours, both status values, syllabus, outline, note, driveFolder, sourceRepo — is still accurate after this change. Flipping it to `false` would badge a correct, freshly verified record as unaudited. Say so and I will flip it.

## Verification

- Module 5 now carries 6 lessons at 1h each, matching `hours: 6`
- `totalLessons` 20 matches the course tree, the deploy tree, and `course-outline.txt` (7 modules / 20 lessons)
- Both regenerated bundles contain the new lesson
